### PR TITLE
Fix web build character creation flow

### DIFF
--- a/scripts/2d/character_create.gd
+++ b/scripts/2d/character_create.gd
@@ -280,7 +280,6 @@ func _build_preview_viewport() -> SubViewportContainer:
 	_preview_viewport.size = Vector2i(400, 500)
 	_preview_viewport.transparent_bg = true
 	_preview_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
-	_preview_viewport.msaa_3d = Viewport.MSAA_2X
 	container.add_child(_preview_viewport)
 
 	# Camera looking at model
@@ -389,17 +388,21 @@ func _teardown_preview() -> void:
 
 func _show_appearance() -> void:
 	_step = Step.APPEARANCE
-	hint_label.text = "[↑/↓] Row  [←/→] Change  [SPACE+←/→] Rotate  [ENTER] Next  [ESC] Back"
 
-	# Build the 3D preview in the info panel
+	# Build the 3D preview in the info panel (skip on web — SubViewport 3D causes WebGL issues)
 	for child in info_panel.get_children():
 		child.queue_free()
-	var viewport_container := _build_preview_viewport()
-	info_panel.add_child(viewport_container)
-	_preview_active = true
+	if OS.has_feature("web"):
+		hint_label.text = "[↑/↓] Row  [←/→] Change  [ENTER] Next  [ESC] Back"
+		_update_class_info()
+	else:
+		hint_label.text = "[↑/↓] Row  [←/→] Change  [SPACE+←/→] Rotate  [ENTER] Next  [ESC] Back"
+		var viewport_container := _build_preview_viewport()
+		info_panel.add_child(viewport_container)
+		_preview_active = true
+		_update_preview_model()
 
 	_update_appearance()
-	_update_preview_model()
 
 
 func _update_appearance() -> void:

--- a/scripts/2d/character_select.gd
+++ b/scripts/2d/character_select.gd
@@ -71,9 +71,9 @@ func _refresh_slots() -> void:
 		var hbox := HBoxContainer.new()
 		hbox.add_theme_constant_override("separation", 12)
 
-		# 3D preview on the left
+		# 3D preview on the left (skip on web — SubViewport 3D causes WebGL issues)
 		var character = CharacterManager.get_character(i)
-		if character != null:
+		if character != null and not OS.has_feature("web"):
 			var preview := _build_slot_preview(character)
 			hbox.add_child(preview)
 


### PR DESCRIPTION
## Summary
- Skip 3D SubViewport previews on web builds (character select + character create screens)
- SubViewport with `own_world_3d` and 3D model rendering causes WebGL context issues on GL Compatibility web builds, preventing the character creation screen from displaying
- Fall back to text-only display on web while keeping 3D previews on desktop
- Remove MSAA 2X from character create preview viewport (unsupported on some WebGL implementations)

## Test plan
- [ ] Web build loads and character select screen displays correctly
- [ ] Can navigate to character create screen on web
- [ ] Can complete full character creation flow on web (class → appearance → name → confirm)
- [ ] Desktop build still shows 3D previews in character select and create screens
- [ ] All 326 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)