### PR TITLE
Fix resource loading in exported builds (.remap handling)

### DIFF
--- a/scripts/autoloads/armor_registry.gd
+++ b/scripts/autoloads/armor_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all ArmorData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const ARMORS_PATH = "res://data/armors/"
 
 var _armors: Dictionary = {}
@@ -14,25 +15,10 @@ func _ready() -> void:
 
 func _load_all_armors() -> void:
 	_armors.clear()
-
-	var dir = DirAccess.open(ARMORS_PATH)
-	if dir == null:
-		push_warning("[ArmorRegistry] Could not open armors directory: ", ARMORS_PATH)
-		armors_loaded.emit()
-		return
-
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var full_path = ARMORS_PATH + file_name
-			var armor = load(full_path)
-			if armor and not armor.id.is_empty():
-				_armors[armor.id] = armor
-		file_name = dir.get_next()
-
-	dir.list_dir_end()
+	for path in _RU.list_resources(ARMORS_PATH):
+		var armor = load(path)
+		if armor and not armor.id.is_empty():
+			_armors[armor.id] = armor
 	print("[ArmorRegistry] Loaded ", _armors.size(), " armors")
 	armors_loaded.emit()
 

--- a/scripts/autoloads/class_registry.gd
+++ b/scripts/autoloads/class_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all ClassData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const CLASSES_PATH = "res://data/classes/"
 
 var _classes: Dictionary = {}
@@ -14,22 +15,12 @@ func _ready() -> void:
 
 func _load_all_classes() -> void:
 	_classes.clear()
-	var dir = DirAccess.open(CLASSES_PATH)
-	if dir == null:
-		push_warning("[ClassRegistry] Could not open classes directory: ", CLASSES_PATH)
-		classes_loaded.emit()
-		return
-
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var full_path = CLASSES_PATH + file_name
-			var class_res = load(full_path)
-			if class_res and not class_res.id.is_empty():
-				_classes[class_res.id] = class_res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(CLASSES_PATH):
+		var class_res = load(path)
+		if class_res and not class_res.id.is_empty():
+			_classes[class_res.id] = class_res
+	if _classes.is_empty():
+		push_warning("[ClassRegistry] Could not load any classes from: ", CLASSES_PATH)
 	print("[ClassRegistry] Loaded ", _classes.size(), " classes")
 	classes_loaded.emit()
 

--- a/scripts/autoloads/consumable_registry.gd
+++ b/scripts/autoloads/consumable_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all ConsumableData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const CONSUMABLES_PATH = "res://data/consumables/"
 
 var _consumables: Dictionary = {}
@@ -14,20 +15,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_consumables.clear()
-	var dir = DirAccess.open(CONSUMABLES_PATH)
-	if dir == null:
-		push_warning("[ConsumableRegistry] Could not open directory: ", CONSUMABLES_PATH)
-		consumables_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(CONSUMABLES_PATH + file_name)
-			if res and not res.id.is_empty():
-				_consumables[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(CONSUMABLES_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_consumables[res.id] = res
 	print("[ConsumableRegistry] Loaded ", _consumables.size(), " consumables")
 	consumables_loaded.emit()
 

--- a/scripts/autoloads/drop_registry.gd
+++ b/scripts/autoloads/drop_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to DropTableData resources.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const DROPS_PATH = "res://data/drop_tables/"
 var _drops: Dictionary = {}
 signal drops_loaded()
@@ -10,19 +11,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_drops.clear()
-	var dir = DirAccess.open(DROPS_PATH)
-	if dir == null:
-		drops_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(DROPS_PATH + file_name)
-			if res and not res.id.is_empty():
-				_drops[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(DROPS_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_drops[res.id] = res
 	print("[DropRegistry] Loaded ", _drops.size(), " drop tables")
 	drops_loaded.emit()
 

--- a/scripts/autoloads/enemy_registry.gd
+++ b/scripts/autoloads/enemy_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all EnemyData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const ENEMIES_PATH = "res://data/enemies/"
 
 var _enemies: Dictionary = {}
@@ -14,25 +15,10 @@ func _ready() -> void:
 
 func _load_all_enemies() -> void:
 	_enemies.clear()
-
-	var dir = DirAccess.open(ENEMIES_PATH)
-	if dir == null:
-		push_warning("[EnemyRegistry] Could not open enemies directory: ", ENEMIES_PATH)
-		enemies_loaded.emit()
-		return
-
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var full_path = ENEMIES_PATH + file_name
-			var enemy = load(full_path)
-			if enemy and not enemy.id.is_empty():
-				_enemies[enemy.id] = enemy
-		file_name = dir.get_next()
-
-	dir.list_dir_end()
+	for path in _RU.list_resources(ENEMIES_PATH):
+		var enemy = load(path)
+		if enemy and not enemy.id.is_empty():
+			_enemies[enemy.id] = enemy
 	print("[EnemyRegistry] Loaded ", _enemies.size(), " enemies")
 	enemies_loaded.emit()
 

--- a/scripts/autoloads/item_registry.gd
+++ b/scripts/autoloads/item_registry.gd
@@ -3,6 +3,7 @@ extends Node
 ## Loads all .tres files from data/items/ on startup.
 
 const ItemDataScript = preload("res://scripts/resources/item_data.gd")
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const ITEMS_PATH = "res://data/items/"
 
 ## Dictionary of item_id -> ItemData
@@ -19,28 +20,13 @@ func _ready() -> void:
 ## Load all ItemData resources from the items directory
 func _load_all_items() -> void:
 	_items.clear()
-
-	var dir = DirAccess.open(ITEMS_PATH)
-	if dir == null:
-		push_warning("[ItemRegistry] Could not open items directory: ", ITEMS_PATH)
-		items_loaded.emit()
-		return
-
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var full_path = ITEMS_PATH + file_name
-			var item = load(full_path)
-			if item and not item.id.is_empty():
-				_items[item.id] = item
-				print("[ItemRegistry] Loaded: ", item.id, " (", item.name, ")")
-			else:
-				push_warning("[ItemRegistry] Invalid item at: ", full_path)
-		file_name = dir.get_next()
-
-	dir.list_dir_end()
+	for path in _RU.list_resources(ITEMS_PATH):
+		var item = load(path)
+		if item and not item.id.is_empty():
+			_items[item.id] = item
+			print("[ItemRegistry] Loaded: ", item.id, " (", item.name, ")")
+		else:
+			push_warning("[ItemRegistry] Invalid item at: ", path)
 	print("[ItemRegistry] Loaded ", _items.size(), " items")
 	items_loaded.emit()
 

--- a/scripts/autoloads/mag_manager.gd
+++ b/scripts/autoloads/mag_manager.gd
@@ -2,6 +2,8 @@ extends Node
 ## MagManager — handles mag feeding, leveling, and evolution.
 ## Ported from psz-sketch/src/systems/mag-feeder + mag-evolutions
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
+
 signal mag_fed(item_id: String, stat_changes: Dictionary)
 signal mag_leveled_up(new_level: int)
 signal mag_evolved(old_form: String, new_form: String)
@@ -34,20 +36,10 @@ func _ready() -> void:
 
 
 func _load_mag_forms() -> void:
-	var dir := DirAccess.open("res://data/mags/")
-	if dir == null:
-		push_warning("[MagManager] Could not open data/mags/")
-		return
-	dir.list_dir_begin()
-	var file_name := dir.get_next()
-	while not file_name.is_empty():
-		if file_name.ends_with(".tres"):
-			var path := "res://data/mags/%s" % file_name
-			var mag_data = load(path)
-			if mag_data:
-				_mag_forms[mag_data.id] = mag_data
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources("res://data/mags/"):
+		var mag_data = load(path)
+		if mag_data:
+			_mag_forms[mag_data.id] = mag_data
 	print("[MagManager] Loaded %d mag forms" % _mag_forms.size())
 
 

--- a/scripts/autoloads/material_registry.gd
+++ b/scripts/autoloads/material_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all MaterialData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const MATERIALS_PATH = "res://data/materials/"
 
 var _materials: Dictionary = {}
@@ -14,20 +15,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_materials.clear()
-	var dir = DirAccess.open(MATERIALS_PATH)
-	if dir == null:
-		push_warning("[MaterialRegistry] Could not open directory: ", MATERIALS_PATH)
-		materials_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(MATERIALS_PATH + file_name)
-			if res and not res.id.is_empty():
-				_materials[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(MATERIALS_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_materials[res.id] = res
 	print("[MaterialRegistry] Loaded ", _materials.size(), " materials")
 	materials_loaded.emit()
 

--- a/scripts/autoloads/mission_registry.gd
+++ b/scripts/autoloads/mission_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to MissionData, QuestAreaData, and QuestDefinitionData.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const MISSIONS_PATH = "res://data/missions/"
 const QUEST_AREAS_PATH = "res://data/quest_areas/"
 const QUEST_DEFS_PATH = "res://data/quest_definitions/"
@@ -18,18 +19,10 @@ func _ready() -> void:
 	data_loaded.emit()
 
 func _load_dir(path: String, dict: Dictionary, label: String) -> void:
-	var dir = DirAccess.open(path)
-	if dir == null:
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(path + file_name)
-			if res and not res.id.is_empty():
-				dict[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for res_path in _RU.list_resources(path):
+		var res = load(res_path)
+		if res and not res.id.is_empty():
+			dict[res.id] = res
 	print("[%s] Loaded %d" % [label, dict.size()])
 
 func get_mission(id: String):

--- a/scripts/autoloads/modifier_registry.gd
+++ b/scripts/autoloads/modifier_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all ModifierData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const MODIFIERS_PATH = "res://data/modifiers/"
 
 var _modifiers: Dictionary = {}
@@ -14,20 +15,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_modifiers.clear()
-	var dir = DirAccess.open(MODIFIERS_PATH)
-	if dir == null:
-		push_warning("[ModifierRegistry] Could not open directory: ", MODIFIERS_PATH)
-		modifiers_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(MODIFIERS_PATH + file_name)
-			if res and not res.id.is_empty():
-				_modifiers[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(MODIFIERS_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_modifiers[res.id] = res
 	print("[ModifierRegistry] Loaded ", _modifiers.size(), " modifiers")
 	modifiers_loaded.emit()
 

--- a/scripts/autoloads/photon_art_registry.gd
+++ b/scripts/autoloads/photon_art_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all PhotonArtData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const ARTS_PATH = "res://data/photon_arts/"
 var _arts: Dictionary = {}
 signal arts_loaded()
@@ -10,19 +11,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_arts.clear()
-	var dir = DirAccess.open(ARTS_PATH)
-	if dir == null:
-		arts_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(ARTS_PATH + file_name)
-			if res and not res.id.is_empty():
-				_arts[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(ARTS_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_arts[res.id] = res
 	print("[PhotonArtRegistry] Loaded ", _arts.size(), " photon arts")
 	arts_loaded.emit()
 

--- a/scripts/autoloads/set_bonus_registry.gd
+++ b/scripts/autoloads/set_bonus_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all SetBonusData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const SET_BONUSES_PATH = "res://data/set_bonuses/"
 
 var _set_bonuses: Dictionary = {}
@@ -14,20 +15,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_set_bonuses.clear()
-	var dir = DirAccess.open(SET_BONUSES_PATH)
-	if dir == null:
-		push_warning("[SetBonusRegistry] Could not open directory: ", SET_BONUSES_PATH)
-		set_bonuses_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(SET_BONUSES_PATH + file_name)
-			if res and not res.id.is_empty():
-				_set_bonuses[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(SET_BONUSES_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_set_bonuses[res.id] = res
 	print("[SetBonusRegistry] Loaded ", _set_bonuses.size(), " set bonuses")
 	set_bonuses_loaded.emit()
 

--- a/scripts/autoloads/shop_registry.gd
+++ b/scripts/autoloads/shop_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all ShopData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const SHOPS_PATH = "res://data/shops/"
 
 var _shops: Dictionary = {}
@@ -14,20 +15,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_shops.clear()
-	var dir = DirAccess.open(SHOPS_PATH)
-	if dir == null:
-		push_warning("[ShopRegistry] Could not open directory: ", SHOPS_PATH)
-		shops_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(SHOPS_PATH + file_name)
-			if res and not res.id.is_empty():
-				_shops[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(SHOPS_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_shops[res.id] = res
 	print("[ShopRegistry] Loaded ", _shops.size(), " shops")
 	shops_loaded.emit()
 

--- a/scripts/autoloads/unit_registry.gd
+++ b/scripts/autoloads/unit_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all UnitData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const UNITS_PATH = "res://data/units/"
 var _units: Dictionary = {}
 signal units_loaded()
@@ -10,19 +11,10 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_units.clear()
-	var dir = DirAccess.open(UNITS_PATH)
-	if dir == null:
-		units_loaded.emit()
-		return
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var res = load(UNITS_PATH + file_name)
-			if res and not res.id.is_empty():
-				_units[res.id] = res
-		file_name = dir.get_next()
-	dir.list_dir_end()
+	for path in _RU.list_resources(UNITS_PATH):
+		var res = load(path)
+		if res and not res.id.is_empty():
+			_units[res.id] = res
 	print("[UnitRegistry] Loaded ", _units.size(), " units")
 	units_loaded.emit()
 

--- a/scripts/autoloads/weapon_registry.gd
+++ b/scripts/autoloads/weapon_registry.gd
@@ -1,6 +1,7 @@
 extends Node
 ## Autoload that provides access to all WeaponData resources by ID.
 
+const _RU = preload("res://scripts/utils/resource_utils.gd")
 const WEAPONS_PATH = "res://data/weapons/"
 
 var _weapons: Dictionary = {}
@@ -14,25 +15,10 @@ func _ready() -> void:
 
 func _load_all_weapons() -> void:
 	_weapons.clear()
-
-	var dir = DirAccess.open(WEAPONS_PATH)
-	if dir == null:
-		push_warning("[WeaponRegistry] Could not open weapons directory: ", WEAPONS_PATH)
-		weapons_loaded.emit()
-		return
-
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-
-	while file_name != "":
-		if not dir.current_is_dir() and file_name.ends_with(".tres"):
-			var full_path = WEAPONS_PATH + file_name
-			var weapon = load(full_path)
-			if weapon and not weapon.id.is_empty():
-				_weapons[weapon.id] = weapon
-		file_name = dir.get_next()
-
-	dir.list_dir_end()
+	for path in _RU.list_resources(WEAPONS_PATH):
+		var weapon = load(path)
+		if weapon and not weapon.id.is_empty():
+			_weapons[weapon.id] = weapon
 	print("[WeaponRegistry] Loaded ", _weapons.size(), " weapons")
 	weapons_loaded.emit()
 

--- a/scripts/utils/resource_utils.gd
+++ b/scripts/utils/resource_utils.gd
@@ -1,0 +1,23 @@
+class_name ResourceUtils
+## Utility for resource loading that works in both editor and exported builds.
+## In exported builds, .tres files become .tres.remap — DirAccess lists the
+## remapped names, so we must check for both suffixes.
+
+
+## List resource file paths in a directory, handling .remap suffix in exports.
+static func list_resources(dir_path: String, extension: String = ".tres") -> Array[String]:
+	var paths: Array[String] = []
+	var dir = DirAccess.open(dir_path)
+	if dir == null:
+		return paths
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	while file_name != "":
+		if not dir.current_is_dir():
+			if file_name.ends_with(extension):
+				paths.append(dir_path + file_name)
+			elif file_name.ends_with(extension + ".remap"):
+				paths.append(dir_path + file_name.replace(".remap", ""))
+		file_name = dir.get_next()
+	dir.list_dir_end()
+	return paths


### PR DESCRIPTION
## Summary
- **Root cause found**: In exported builds, `.tres` files are stored as `.tres.remap` in the PCK. `DirAccess` lists the remapped filenames, so `.ends_with(".tres")` fails silently — all 14 registries load zero resources
- Add `ResourceUtils.list_resources()` helper that checks for both `.tres` and `.tres.remap` suffixes
- Update all 15 registry loading functions to use it
- Also includes previous fix: skip 3D SubViewport previews on web, remove MSAA 2X

## Test plan
- [ ] Web build loads all registries (weapons, classes, enemies, etc.)
- [ ] Character create screen shows class list on web
- [ ] Can complete full character creation flow on web
- [ ] All 328 tests pass on desktop
- [ ] Desktop build continues to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)