### PR TITLE
Re-enable 3D preview on web for character customization

### DIFF
--- a/scripts/2d/character_create.gd
+++ b/scripts/2d/character_create.gd
@@ -389,20 +389,17 @@ func _teardown_preview() -> void:
 func _show_appearance() -> void:
 	_step = Step.APPEARANCE
 
-	# Build the 3D preview in the info panel (skip on web — SubViewport 3D causes WebGL issues)
+	hint_label.text = "[↑/↓] Row  [←/→] Change  [SPACE+←/→] Rotate  [ENTER] Next  [ESC] Back"
+
+	# Build the 3D preview in the info panel
 	for child in info_panel.get_children():
 		child.queue_free()
-	if OS.has_feature("web"):
-		hint_label.text = "[↑/↓] Row  [←/→] Change  [ENTER] Next  [ESC] Back"
-		_update_class_info()
-	else:
-		hint_label.text = "[↑/↓] Row  [←/→] Change  [SPACE+←/→] Rotate  [ENTER] Next  [ESC] Back"
-		var viewport_container := _build_preview_viewport()
-		info_panel.add_child(viewport_container)
-		_preview_active = true
-		_update_preview_model()
+	var viewport_container := _build_preview_viewport()
+	info_panel.add_child(viewport_container)
+	_preview_active = true
 
 	_update_appearance()
+	_update_preview_model()
 
 
 func _update_appearance() -> void:


### PR DESCRIPTION
## Summary
- Re-enable the 3D model preview during character appearance customization on web
- The empty screen was caused by the `.tres.remap` registry loading bug (fixed in PR #9), not SubViewport rendering
- The character create preview doesn't use `own_world_3d` so it works fine on WebGL

## Test plan
- [ ] 3D character preview renders during appearance customization on web
- [ ] Appearance changes (head type, colors) update the preview model in real time
- [ ] Desktop build still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)