### PR TITLE
Add Eternal Tower (s08) field generation

### DIFF
--- a/scenes/3d/player/player.tscn
+++ b/scenes/3d/player/player.tscn
@@ -11,6 +11,7 @@ height = 1.4
 [node name="Player" type="CharacterBody3D" groups=["player"]]
 collision_layer = 2
 collision_mask = 1
+floor_snap_length = 0.5
 script = ExtResource("1_player")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]

--- a/scripts/2d/warp_teleporter.gd
+++ b/scripts/2d/warp_teleporter.gd
@@ -9,6 +9,7 @@ const AREAS := [
 	{"id": "makara", "name": "Makara Ruins", "rec_level": [40, 55, 90]},
 	{"id": "arca", "name": "Arca Plant", "rec_level": [50, 60, 95]},
 	{"id": "dark", "name": "Dark Shrine", "rec_level": [60, 70, 100]},
+	{"id": "tower", "name": "Eternal Tower", "rec_level": [70, 80, 100]},
 ]
 
 ## Story mission that must be completed to unlock each warp area.
@@ -20,6 +21,7 @@ const AREA_UNLOCK_MISSIONS := {
 	"makara": "fallen_flowers",
 	"arca": "ana_s_request",
 	"dark": "mother_s_memory",
+	"tower": "mother_s_memory",
 }
 
 const DIFFICULTIES := ["Normal", "Hard", "Super-Hard"]
@@ -97,7 +99,11 @@ func _warp_to_field() -> void:
 	var GridGen := preload("res://scripts/3d/field/grid_generator.gd")
 	if GridGen.AREA_CONFIG.has(area_id):
 		var gen := GridGen.new()
-		var field: Dictionary = gen.generate_field(difficulty, area_id)
+		var field: Dictionary
+		if area_id == "tower":
+			field = gen.generate_tower_field(difficulty)
+		else:
+			field = gen.generate_field(difficulty, area_id)
 		var sections: Array = field["sections"]
 		SessionManager.set_field_sections(sections)
 		var first_section: Dictionary = sections[0]

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -60,6 +60,7 @@ func _ready() -> void:
 
 	# Load GLB — resolve area folder from session
 	var stage_id: String = str(_current_cell["stage_id"])
+	TimeManager.stage_label = stage_id
 	var area_id: String = str(SessionManager.get_session().get("area_id", "gurhacia"))
 	var area_cfg: Dictionary = GridGenerator.AREA_CONFIG.get(area_id, GridGenerator.AREA_CONFIG["gurhacia"])
 	var map_path := "res://assets/environments/%s/%s.glb" % [area_cfg["folder"], stage_id]

--- a/scripts/autoloads/session_manager.gd
+++ b/scripts/autoloads/session_manager.gd
@@ -65,7 +65,7 @@ func _area_name_to_id(area_name: String) -> String:
 		"Makura Ruins": "makara", "Makara Ruins": "makara",
 		"Arca Plant": "arca",
 		"Dark Shrine": "dark",
-		"Eternal Tower": "dark",
+		"Eternal Tower": "tower",
 	}
 	return mapping.get(area_name, "gurhacia")
 

--- a/scripts/autoloads/time_manager.gd
+++ b/scripts/autoloads/time_manager.gd
@@ -13,6 +13,7 @@ var paused: bool = false
 ## HUD
 var _hud_layer: CanvasLayer
 var _hud_label: Label
+var stage_label: String = ""  # Set by field controller for debug display
 
 ## Screen tint overlay (multiply blend for day/night atmosphere on unshaded geometry)
 var _tint_layer: CanvasLayer
@@ -82,8 +83,8 @@ func _ready() -> void:
 	_hud_label.anchor_right = 0.5
 	_hud_label.anchor_top = 0.0
 	_hud_label.anchor_bottom = 0.0
-	_hud_label.offset_left = -80
-	_hud_label.offset_right = 80
+	_hud_label.offset_left = -140
+	_hud_label.offset_right = 140
 	_hud_label.offset_top = 8
 	_hud_label.offset_bottom = 32
 	_hud_label.add_theme_font_size_override("font_size", 16)
@@ -196,7 +197,10 @@ func _update_hud() -> void:
 	var h: int = int(current_hour) % 24
 	var m: int = int(fmod(current_hour, 1.0) * 60.0)
 	var phase: String = get_phase().capitalize()
-	_hud_label.text = "%02d:%02d - %s" % [h, m, phase]
+	if stage_label.is_empty():
+		_hud_label.text = "%02d:%02d - %s" % [h, m, phase]
+	else:
+		_hud_label.text = "%02d:%02d - %s  [%s]" % [h, m, phase, stage_label]
 
 
 func _unhandled_input(event: InputEvent) -> void:


### PR DESCRIPTION
## Summary
- Implement `generate_tower_field()` in GridGenerator for the tower's linear floor-by-floor climb (entrance → floor rooms → mid-tower transition → floor rooms → boss), with configurable `tower_floors` and `tower_rooms_per_floor` per difficulty
- Add Eternal Tower to warp teleporter (rec Lv.70/80/100, unlocked after mother_s_memory) and fix session manager area mapping from "dark" to "tower"
- Increase player `floor_snap_length` to 0.5 to prevent getting stuck in tower floor indentations
- Show current stage_id (e.g. `[s081_ga1]`) in the time-of-day HUD for debugging

## Test plan
- [x] 24 new tower field tests added (524 total, 0 failures)
- [x] Section counts verified: Normal=9, Hard=19, Super-Hard=27
- [x] All 27 tower GLBs validated
- [x] No regressions on existing valley/wetlands field generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)