### PR TITLE
Complete Q4 Static in the Snow

### DIFF
--- a/data/quests/manifest.json
+++ b/data/quests/manifest.json
@@ -1,1 +1,1 @@
-["search_and_rescue", "apothecary_supply", "static_in_the_snow", "deep_ore_extraction", "messages_from_the_past", "the_paru_pact", "native_research", "seek_my_mentor"]
+["search_and_rescue", "the_paru_pact", "apothecary_supply", "static_in_the_snow", "deep_ore_extraction", "messages_from_the_past", "native_research", "seek_my_mentor"]

--- a/data/quests/static_in_the_snow.json
+++ b/data/quests/static_in_the_snow.json
@@ -68,8 +68,31 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 0
+          "path_order": 0,
+          "objects": [
+            {
+              "type": "dialog_trigger",
+              "position": [
+                0,
+                0,
+                5.4
+              ],
+              "trigger_size": [
+                25.5,
+                3,
+                4
+              ],
+              "dialog": [
+                {
+                  "speaker": "Kai",
+                  "text": "Let's head out, I hope we're not too late."
+                }
+              ]
+            }
+          ]
         },
         {
           "pos": "1,2",
@@ -159,10 +182,50 @@
           "is_branch": true,
           "has_key": false,
           "key_for_cell": "",
-          "is_key_gate": false,
-          "key_gate_direction": "",
+          "is_key_gate": true,
+          "key_gate_direction": "south",
+          "key_drop": "",
+          "required_keys": 1,
           "warp_edge": "",
-          "path_order": 1
+          "path_order": 1,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -9.7,
+                0,
+                -10.2
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -11.9,
+                0,
+                2
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -5.9,
+                0,
+                7.1
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -1.3,
+                0,
+                11.5
+              ],
+              "enemy_id": "reyhound"
+            }
+          ]
         },
         {
           "pos": "1,3",
@@ -204,12 +267,72 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "1,2",
+          "required_keys": 0,
           "warp_edge": "",
           "path_order": 2,
           "key_position": [
             -5.2,
             1,
             -1.6
+          ],
+          "key_drop_position": [
+            -17.1,
+            1,
+            -16.3
+          ],
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -5.3,
+                0,
+                -6.2
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                0.6,
+                0,
+                -5.4
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                2.6,
+                0,
+                0.9
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "box",
+              "position": [
+                11.4,
+                0,
+                -17.6
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                15.4,
+                0,
+                -17.2
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                16.6,
+                0,
+                -12.3
+              ]
+            }
           ]
         },
         {
@@ -302,8 +425,84 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 3
+          "path_order": 3,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -10.1,
+                0,
+                -9.3
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -9.2,
+                0,
+                -2.3
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -7.4,
+                0,
+                5.1
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "box",
+              "position": [
+                4.2,
+                0,
+                12.1
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                3.1,
+                0,
+                15.8
+              ]
+            },
+            {
+              "type": "enemy",
+              "position": [
+                11.1,
+                0,
+                -4.9
+              ],
+              "enemy_id": "usanny",
+              "wave": 2
+            },
+            {
+              "type": "enemy",
+              "position": [
+                11.8,
+                0,
+                -13.1
+              ],
+              "enemy_id": "usanny",
+              "wave": 2
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -19.3,
+                0,
+                -11
+              ],
+              "enemy_id": "lizard"
+            }
+          ]
         },
         {
           "pos": "2,3",
@@ -370,8 +569,66 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 4
+          "path_order": 4,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                6.3,
+                0,
+                -11.7
+              ],
+              "enemy_id": "lizard"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                1.7,
+                0,
+                -12.6
+              ],
+              "enemy_id": "lizard"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -3.7,
+                0,
+                -12
+              ],
+              "enemy_id": "lizard"
+            },
+            {
+              "type": "fence",
+              "position": [
+                1.7,
+                0,
+                -6.3
+              ],
+              "link_id": "a"
+            },
+            {
+              "type": "step_switch",
+              "position": [
+                -20.1,
+                0,
+                3.2
+              ],
+              "link_id": "a"
+            },
+            {
+              "type": "message",
+              "position": [
+                -3.8,
+                0,
+                11.4
+              ],
+              "text": "Expedition Log: We're finding it hard to avoid encounters. Previsions are starting to run low. "
+            }
+          ]
         },
         {
           "pos": "2,1",
@@ -413,8 +670,64 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 5
+          "path_order": 5,
+          "objects": [
+            {
+              "type": "message",
+              "position": [
+                12,
+                0,
+                -18
+              ],
+              "text": "Expedition Log, Visibility dropping fast. Going to push deeper despite the conditions."
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -11.3,
+                0,
+                -4
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -5.2,
+                0,
+                -4.9
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -2.8,
+                0,
+                2.1
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "box",
+              "position": [
+                16.3,
+                0,
+                -16.4
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                17.1,
+                0,
+                -13
+              ]
+            }
+          ]
         },
         {
           "pos": "2,4",
@@ -481,8 +794,63 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 6
+          "path_order": 6,
+          "objects": [
+            {
+              "type": "box",
+              "position": [
+                -15.3,
+                0,
+                15.3
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                14.7,
+                0,
+                -17
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                8.5,
+                0,
+                -17.3
+              ]
+            },
+            {
+              "type": "enemy",
+              "position": [
+                1.5,
+                0,
+                0.1
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -2.8,
+                0,
+                3.7
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -7.7,
+                0,
+                5.6
+              ],
+              "enemy_id": "reyhound"
+            }
+          ]
         },
         {
           "pos": "3,4",
@@ -548,8 +916,84 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "south",
-          "path_order": 7
+          "path_order": 7,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -10.4,
+                0,
+                -8.1
+              ],
+              "enemy_id": "stagg",
+              "wave": 2
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -2.6,
+                0,
+                -10.5
+              ],
+              "enemy_id": "stagg",
+              "wave": 2
+            },
+            {
+              "type": "enemy",
+              "position": [
+                6.3,
+                0,
+                -11.4
+              ],
+              "enemy_id": "stagg",
+              "wave": 2
+            },
+            {
+              "type": "box",
+              "position": [
+                -17.6,
+                0,
+                0.7
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                -17.9,
+                0,
+                -4.5
+              ]
+            },
+            {
+              "type": "rare_box",
+              "position": [
+                -18.7,
+                0,
+                -11.2
+              ]
+            },
+            {
+              "type": "enemy",
+              "position": [
+                12.6,
+                0,
+                8.9
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                5.7,
+                0,
+                10
+              ],
+              "enemy_id": "reyhound"
+            }
+          ]
         }
       ]
     },
@@ -621,8 +1065,48 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "south",
-          "path_order": 0
+          "path_order": 0,
+          "objects": [
+            {
+              "type": "message",
+              "position": [
+                5.3,
+                0,
+                -10.8
+              ],
+              "text": "...surrounded... camp is holding ... won't last much longer ..."
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -2.6,
+                0,
+                2.6
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                3.2,
+                0,
+                -0.8
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                7.5,
+                0,
+                1.8
+              ],
+              "enemy_id": "usanny"
+            }
+          ]
         }
       ],
       "entry_direction": "south",
@@ -698,6 +1182,8 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
           "path_order": 0
         },
@@ -791,8 +1277,39 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 1
+          "path_order": 1,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -5.5,
+                0,
+                -10.7
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                0.4,
+                0,
+                -4.6
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -5.6,
+                0,
+                -1.8
+              ],
+              "enemy_id": "usanny"
+            }
+          ]
         },
         {
           "pos": "1,3",
@@ -834,8 +1351,48 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 2
+          "path_order": 2,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -0.8,
+                0,
+                4.5
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                4,
+                0,
+                0.7
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                7.8,
+                0,
+                6.2
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "message",
+              "position": [
+                -2,
+                0,
+                -3.4
+              ],
+              "text": "Expedition Lo: We more supplies to another creature ambush. The wildlife here is more aggressive than anything in the survey data"
+            }
+          ]
         },
         {
           "pos": "2,2",
@@ -902,8 +1459,59 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 3
+          "path_order": 3,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -11.7,
+                0,
+                15.1
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -12.3,
+                0,
+                6.1
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -3.1,
+                0,
+                6.6
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                6.7,
+                0,
+                -10.6
+              ],
+              "enemy_id": "reyhound",
+              "wave": 2
+            },
+            {
+              "type": "enemy",
+              "position": [
+                12.3,
+                0,
+                -16.1
+              ],
+              "enemy_id": "reyhound",
+              "wave": 2
+            }
+          ]
         },
         {
           "pos": "2,3",
@@ -995,8 +1603,63 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 4
+          "path_order": 4,
+          "objects": [
+            {
+              "type": "box",
+              "position": [
+                0.5,
+                0,
+                -16.5
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                6,
+                0,
+                -14.7
+              ]
+            },
+            {
+              "type": "box",
+              "position": [
+                9.5,
+                0,
+                -11.6
+              ]
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -11.4,
+                0,
+                -6.5
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -2.1,
+                0,
+                -3.8
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                5,
+                0,
+                -0.3
+              ],
+              "enemy_id": "usanny"
+            }
+          ]
         },
         {
           "pos": "3,3",
@@ -1063,33 +1726,84 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
-          "path_order": 5
+          "path_order": 5,
+          "objects": [
+            {
+              "type": "enemy",
+              "position": [
+                -11.2,
+                0,
+                2.9
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -1,
+                0,
+                5.8
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                8.7,
+                0,
+                0.7
+              ],
+              "enemy_id": "usanny"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -6.7,
+                0,
+                10.6
+              ],
+              "enemy_id": "usanny",
+              "wave": 2
+            },
+            {
+              "type": "enemy",
+              "position": [
+                6.8,
+                0,
+                11
+              ],
+              "enemy_id": "stagg",
+              "wave": 2
+            }
+          ]
         },
         {
           "pos": "2,4",
-          "stage_id": "s03b_ga1",
+          "stage_id": "s03b_nb2",
           "rotation": 90,
           "connections": {
             "west": "2,3"
           },
           "portals": {
             "west": {
-              "portal_id": "portal_1770725676213_mbx0o9fxx",
+              "portal_id": "portal_1770726458075_bz9f98pru",
               "gate": [
-                -3.05,
+                13.06,
                 0,
-                20.18
+                21.73
               ],
               "spawn": [
-                -3.05,
+                13.06,
                 1,
-                23.18
+                24.73
               ],
               "trigger": [
-                -3.05,
+                13.06,
                 0,
-                27.18
+                28.73
               ],
               "gate_rot": [
                 0,
@@ -1106,12 +1820,47 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
           "path_order": 6,
-          "key_position": [
-            2.5,
-            1,
-            4.1
+          "objects": [
+            {
+              "type": "message",
+              "position": [
+                14.8,
+                0,
+                -16.4
+              ],
+              "text": "I don't know how much longer we can hold out. Almost everything is gone now. "
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -13.2,
+                0,
+                -3.4
+              ],
+              "enemy_id": "reyhound"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                -8.9,
+                0,
+                -13.2
+              ],
+              "enemy_id": "stagg"
+            },
+            {
+              "type": "enemy",
+              "position": [
+                2,
+                0,
+                -15.9
+              ],
+              "enemy_id": "hildeghana"
+            }
           ]
         },
         {
@@ -1154,6 +1903,8 @@
           "key_for_cell": "",
           "is_key_gate": false,
           "key_gate_direction": "",
+          "key_drop": "",
+          "required_keys": 0,
           "warp_edge": "",
           "path_order": 7,
           "objects": [
@@ -1252,7 +2003,9 @@
       ]
     }
   ],
-  "companions": ["kai"],
+  "companions": [
+    "kai"
+  ],
   "office_npcs": [
     {
       "npc_id": "dr_carlo",
@@ -1266,11 +2019,25 @@
     }
   ],
   "briefing_dialog": [
-    { "speaker": "Principal", "text": "We've lost contact with a research team in the snowfield. Their last transmission was mostly static." },
-    { "speaker": "Dr. Carlo", "text": "I'm Dr. Carlo, the expedition lead. My team was conducting survey work in the deep snow region when our comms cut out." },
-    { "speaker": "Dr. Carlo", "text": "I made it back, but the rest of the team is still out there. The creatures in that area have been unusually aggressive." },
-    { "speaker": "Principal", "text": "We're sending Kai with you. Find the expedition camp and bring the team home safely." },
-    { "speaker": "Kai", "text": "The snowfield's no joke. Stay close and we'll get them out." }
-  ],
-  "report_to": "guild_counter"
+    {
+      "speaker": "Principal",
+      "text": "We've lost contact with a research team in the snowfield. Their last transmission was mostly static."
+    },
+    {
+      "speaker": "Dr. Carlo",
+      "text": "I'm Dr. Carlo, the expedition lead. My team was conducting survey work in the deep snow region when our comms cut out."
+    },
+    {
+      "speaker": "Dr. Carlo",
+      "text": "I made it back, but the rest of the team is still out there. The creatures in that area have been unusually aggressive."
+    },
+    {
+      "speaker": "Principal",
+      "text": "We're sending Kai with you. Find the expedition camp and bring the team home safely."
+    },
+    {
+      "speaker": "Kai",
+      "text": "The snowfield's no joke. Stay close and we'll get them out."
+    }
+  ]
 }

--- a/data/quests/static_in_the_snow.json
+++ b/data/quests/static_in_the_snow.json
@@ -500,7 +500,7 @@
                 0,
                 -11
               ],
-              "enemy_id": "lizard"
+              "enemy_id": "reyhound"
             }
           ]
         },
@@ -581,7 +581,7 @@
                 0,
                 -11.7
               ],
-              "enemy_id": "lizard"
+              "enemy_id": "reyhound"
             },
             {
               "type": "enemy",
@@ -590,7 +590,7 @@
                 0,
                 -12.6
               ],
-              "enemy_id": "lizard"
+              "enemy_id": "reyhound"
             },
             {
               "type": "enemy",
@@ -599,7 +599,7 @@
                 0,
                 -12
               ],
-              "enemy_id": "lizard"
+              "enemy_id": "reyhound"
             },
             {
               "type": "fence",
@@ -1067,7 +1067,7 @@
           "key_gate_direction": "",
           "key_drop": "",
           "required_keys": 0,
-          "warp_edge": "south",
+          "warp_edge": "north",
           "path_order": 0,
           "objects": [
             {

--- a/web/src/quest-editor/QuestHome.tsx
+++ b/web/src/quest-editor/QuestHome.tsx
@@ -234,7 +234,7 @@ export default function QuestHome() {
         )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '32px' }}>
-          {gameQuests.map(q => (
+          {gameQuests.map((q, i) => (
             <div
               key={q.filename}
               style={cardStyle}
@@ -249,8 +249,11 @@ export default function QuestHome() {
                   borderRadius: '4px',
                   fontSize: '10px',
                   color: '#88aaff',
+                  fontWeight: 700,
+                  minWidth: '18px',
+                  textAlign: 'center' as const,
                 }}>
-                  game
+                  Q{i + 1}
                 </span>
                 <span style={{ fontWeight: 600, fontSize: '14px' }}>{q.name}</span>
                 <span style={{ color: '#666', fontSize: '11px', marginLeft: 'auto' }}>


### PR DESCRIPTION
## Summary
- Fill all three sections of Static in the Snow with enemies, boxes, messages, and dialog
- Add expedition log message packs breadcrumbing toward the camp
- Reorder quest manifest to match issue numbering (Q1-Q8)
- Show quest numbers (Q1, Q2, ...) in quest editor home page
- Fix transition direction (enter south, exit north)
- Replace invalid "lizard" enemy_id with snowfield-native reyhound

🤖 Generated with [Claude Code](https://claude.com/claude-code)