### PR TITLE
Add PSO → PSZ animation retargeting viewer

### DIFF
--- a/web/scripts/dump-bones.mjs
+++ b/web/scripts/dump-bones.mjs
@@ -1,0 +1,142 @@
+// Dump rest-pose bone info for PSZ and PSO models side by side
+import { Blob } from 'buffer';
+globalThis.self = globalThis;
+globalThis.Blob = Blob;
+globalThis.document = { createElementNS: () => ({}) };
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import fs from 'fs';
+import path from 'path';
+
+const MAPPINGS = {
+  bone_000: '000_Root',
+  bone_002: '010_Hip',
+  bone_024: '020_Spine',
+  bone_028: '030_LArm01',
+  bone_029: '040_LArm02',
+  bone_041: '060_RArm01',
+  bone_042: '070_RArm02',
+  bone_056: '090_Head',
+  bone_004: '100_LLeg01',
+  bone_005: '110_LLeg02',
+  bone_013: '120_RLeg01',
+  bone_014: '130_RLeg02',
+};
+
+function loadGLB(filePath) {
+  return new Promise((resolve, reject) => {
+    const data = fs.readFileSync(filePath);
+    const loader = new GLTFLoader();
+    loader.parse(data.buffer, '', (gltf) => resolve(gltf), reject);
+  });
+}
+
+function fmt(v, decimals = 4) {
+  if (v instanceof THREE.Quaternion) {
+    return `(${v.x.toFixed(decimals)}, ${v.y.toFixed(decimals)}, ${v.z.toFixed(decimals)}, ${v.w.toFixed(decimals)})`;
+  }
+  if (v instanceof THREE.Vector3) {
+    return `(${v.x.toFixed(decimals)}, ${v.y.toFixed(decimals)}, ${v.z.toFixed(decimals)})`;
+  }
+  if (v instanceof THREE.Euler) {
+    const deg = (r) => (r * 180 / Math.PI).toFixed(1);
+    return `(${deg(v.x)}, ${deg(v.y)}, ${deg(v.z)})°`;
+  }
+  return String(v);
+}
+
+function collectBoneInfo(model) {
+  const info = {};
+  // Reset to bind pose
+  model.traverse((child) => {
+    if (child.isSkinnedMesh && child.skeleton) {
+      child.skeleton.pose();
+    }
+  });
+  model.updateMatrixWorld(true);
+
+  model.traverse((child) => {
+    if (child.isBone) {
+      const worldQuat = new THREE.Quaternion();
+      const worldPos = new THREE.Vector3();
+      child.getWorldQuaternion(worldQuat);
+      child.getWorldPosition(worldPos);
+
+      const euler = new THREE.Euler().setFromQuaternion(child.quaternion);
+      const worldEuler = new THREE.Euler().setFromQuaternion(worldQuat);
+
+      info[child.name] = {
+        localQuat: child.quaternion.clone(),
+        localEuler: euler,
+        localPos: child.position.clone(),
+        worldQuat,
+        worldEuler,
+        worldPos,
+        parent: child.parent?.isBone ? child.parent.name : null,
+      };
+    }
+  });
+  return info;
+}
+
+async function main() {
+  const pszPath = path.resolve('public/player/pc_000/pc_000/pc_000_000.glb');
+  const psoPath = path.resolve('../data/retarget/Humar_body.glb');
+
+  console.log('Loading PSZ model...');
+  const pszGltf = await loadGLB(pszPath);
+  const pszInfo = collectBoneInfo(pszGltf.scene);
+
+  console.log('Loading PSO model...');
+  const psoGltf = await loadGLB(psoPath);
+  const psoInfo = collectBoneInfo(psoGltf.scene);
+
+  console.log('\n=== ALL PSZ BONES ===');
+  for (const [name, b] of Object.entries(pszInfo)) {
+    console.log(`  ${name}`);
+    console.log(`    parent: ${b.parent || '(root)'}`);
+    console.log(`    localQuat: ${fmt(b.localQuat)}  euler: ${fmt(b.localEuler)}`);
+    console.log(`    localPos:  ${fmt(b.localPos)}`);
+    console.log(`    worldQuat: ${fmt(b.worldQuat)}  euler: ${fmt(b.worldEuler)}`);
+    console.log(`    worldPos:  ${fmt(b.worldPos)}`);
+  }
+
+  console.log('\n=== ALL PSO BONES (mapped only) ===');
+  for (const [psoName, b] of Object.entries(psoInfo)) {
+    if (!(psoName in MAPPINGS)) continue;
+    console.log(`  ${psoName}`);
+    console.log(`    parent: ${b.parent || '(root)'}`);
+    console.log(`    localQuat: ${fmt(b.localQuat)}  euler: ${fmt(b.localEuler)}`);
+    console.log(`    localPos:  ${fmt(b.localPos)}`);
+    console.log(`    worldQuat: ${fmt(b.worldQuat)}  euler: ${fmt(b.worldEuler)}`);
+    console.log(`    worldPos:  ${fmt(b.worldPos)}`);
+  }
+
+  console.log('\n=== SIDE-BY-SIDE COMPARISON ===');
+  for (const [psoName, pszName] of Object.entries(MAPPINGS)) {
+    const pso = psoInfo[psoName];
+    const psz = pszInfo[pszName];
+    if (!pso || !psz) {
+      console.log(`\n${psoName} -> ${pszName}: MISSING`);
+      continue;
+    }
+    console.log(`\n${psoName} -> ${pszName}:`);
+    console.log(`  PSO local euler: ${fmt(pso.localEuler)}   PSZ local euler: ${fmt(psz.localEuler)}`);
+    console.log(`  PSO local quat:  ${fmt(pso.localQuat)}   PSZ local quat:  ${fmt(psz.localQuat)}`);
+    console.log(`  PSO world euler: ${fmt(pso.worldEuler)}   PSZ world euler: ${fmt(psz.worldEuler)}`);
+    console.log(`  PSO local pos:   ${fmt(pso.localPos)}   PSZ local pos:   ${fmt(psz.localPos)}`);
+
+    // Compute the correction quaternion: what rotation transforms PSO's world frame to PSZ's world frame
+    const correction = psz.worldQuat.clone().multiply(pso.worldQuat.clone().invert());
+    const corrEuler = new THREE.Euler().setFromQuaternion(correction);
+    console.log(`  correction quat: ${fmt(correction)}  euler: ${fmt(corrEuler)}`);
+  }
+
+  // Also dump full PSO bone hierarchy
+  console.log('\n=== FULL PSO BONE HIERARCHY ===');
+  for (const [name, b] of Object.entries(psoInfo)) {
+    console.log(`  ${name} (parent: ${b.parent || 'root'})  euler: ${fmt(b.localEuler)}  pos: ${fmt(b.localPos)}`);
+  }
+}
+
+main().catch(console.error);

--- a/web/scripts/retarget-notes.md
+++ b/web/scripts/retarget-notes.md
@@ -1,0 +1,139 @@
+# PSO -> PSZ Animation Retargeting Notes
+
+## Model Overview
+
+### PSZ (Phantasy Star Zero)
+- **12 bones** total (simple skeleton)
+- **Scale**: ~1.5 units tall (game units)
+- **Bone naming**: `NNN_Name` format (e.g., `010_Hip`, `060_RArm01`)
+- **Rest pose approach**: Complex multi-axis local rotations. Hip has -90 Y, spine has (90, -80, 180), arms have ~135 degree compound rotations
+- **Bone orientation**: Local X-axis generally points along the bone (positions like `(0.27, 0, 0)` for arm segments, `(0.32, 0, 0)` for leg segments)
+- **Root bone** (`000_Root`): Identity quaternion at origin
+
+### PSO (Phantasy Star Online)
+- **64 bones** (bone_000 to bone_063, plus bone_000_1, bone_000_2)
+- **Scale**: ~16 units tall (roughly 10x PSZ)
+- **Bone naming**: `bone_NNN` format (numbered, no semantic names)
+- **Rest pose approach**: Primarily Z-axis rotations for pre-rotation. Hip is -91 Z, spine is +91 Z (cancels hip), arms are ~-83 Z, legs are ~-94 Z
+- **Bone orientation**: Local X-axis points along bones (positions like `(2.5, 0, 0)` for arm segments, `(3.95, 0, 0)` for leg segments)
+- **Root bone** (`bone_000`): Identity quaternion at origin
+- Has extra bones for fingers, toes, accessories, etc. that PSZ doesn't have
+
+## Bone Mappings (12 mapped bones)
+
+| PSO Bone | PSZ Bone | Body Part |
+|----------|----------|-----------|
+| bone_000 | 000_Root | Root |
+| bone_002 | 010_Hip | Hip/Pelvis |
+| bone_024 | 020_Spine | Spine/Chest |
+| bone_028 | 030_LArm01 | Left Upper Arm |
+| bone_029 | 040_LArm02 | Left Lower Arm |
+| bone_041 | 060_RArm01 | Right Upper Arm |
+| bone_042 | 070_RArm02 | Right Lower Arm |
+| bone_056 | 090_Head | Head |
+| bone_004 | 100_LLeg01 | Left Upper Leg |
+| bone_005 | 110_LLeg02 | Left Lower Leg |
+| bone_013 | 120_RLeg01 | Right Upper Leg |
+| bone_014 | 130_RLeg02 | Right Lower Leg |
+
+## PSO Bone Hierarchy (mapped bones in context)
+
+```
+bone_000 (root)
+  bone_001 (position offset to hip height)
+    bone_002 (hip) — Z rotation -91°
+      bone_003 → bone_004 (LLeg01) → bone_005 (LLeg02) → bone_006..011 (foot/toes)
+      bone_012 → bone_013 (RLeg01) → bone_014 (RLeg02) → bone_015..020 (foot/toes)
+      bone_024 (spine) — Z rotation +91° (cancels hip rotation)
+        bone_025 (chest/upper spine)
+          bone_026 → bone_027 → bone_028 (LArm01) → bone_029 (LArm02) → bone_030..037 (hand/fingers)
+          bone_039 → bone_040 → bone_041 (RArm01) → bone_042 (RArm02) → bone_043..051 (hand/fingers)
+          bone_055 → bone_056 (Head) → bone_057..059 (face)
+```
+
+Note: PSO has intermediate bones between mapped bones (e.g., bone_003 between hip and LLeg01, bone_027 between spine chain and arms). These intermediate bones have their own rotations that contribute to the world-space orientation.
+
+## PSZ Bone Hierarchy
+
+```
+000_Root
+  010_Hip — Y rotation -90°
+    120_RLeg01 → 130_RLeg02
+    020_Spine (complex compound rotation)
+      060_RArm01 → 070_RArm02
+      090_Head
+      030_LArm01 → 040_LArm02
+    100_LLeg01 → 110_LLeg02
+```
+
+## Key Differences
+
+### 1. Pre-rotation Axes
+- **PSO**: Almost exclusively uses Z-axis rotation for bone pre-rotations (the "old school" approach)
+- **PSZ**: Uses complex multi-axis compound rotations (more modern approach with arbitrary rest orientations)
+- This means PSO's local rotation space is very different from PSZ's local rotation space for corresponding bones
+
+### 2. Intermediate Bones
+PSO has bones between mapped positions that PSZ doesn't:
+- `bone_001` between root and hip (just a position offset)
+- `bone_003` / `bone_012` between hip and legs (with -90/+90 X rotations and 5-6° Z)
+- `bone_025` between spine and everything above (89.6° Z)
+- `bone_026`/`bone_027` and `bone_039`/`bone_040` between chest and arms (with 90° Y rotation)
+- `bone_055` between chest and head
+
+These intermediate bones accumulate rotations that affect the world-space orientation of mapped bones.
+
+### 3. World-Space Rest Orientations (the core problem)
+
+Comparing world-space euler angles at rest for each mapped pair:
+
+| Body Part | PSO World Euler | PSZ World Euler | Difference |
+|-----------|----------------|-----------------|------------|
+| Root | (0, 0, 0) | (0, 0, 0) | Same |
+| Hip | (0, 0, -91) | (0, -90, 0) | Different axes |
+| Spine | (0, 0, 0) | (170, 0, -90) | Very different |
+| LArm01 | (-83, 90, 0) | (3.5, -2.3, -44) | Very different |
+| RArm01 | (-83, 90, 0) | (3.5, 2.3, -136) | Very different |
+| Head | (0, 0, 91) | (-180, 0, -90) | Very different |
+| LLeg01 | (-90, 85, -4) | (-175, 0, 90) | Very different |
+| RLeg01 | (90, 86, 176) | (-175, 0, 90) | Very different |
+
+The world-space rest orientations are fundamentally different for every bone pair except root. This means:
+- A "swing forward" rotation in PSO world space is NOT the same axis as "swing forward" in PSZ world space
+- Simple local or world quaternion remapping won't work correctly
+
+### 4. Animation Structure
+- PSO animations contain **position, rotation (quaternion), and scale** tracks per bone per keyframe
+- Animations are **relative to rest pose** — zeroing out rest rotations breaks the model
+- Only **rotation tracks** should be transferred (position and scale are skeleton-specific)
+
+## Retargeting Approaches Tried
+
+### Approach 1: Direct Copy (failed)
+Just rename bone tracks. Result: completely twisted/mutilated model because local coordinate frames are totally different.
+
+### Approach 2: Local Rest-Pose Delta (partially worked)
+`pszLocal = pszRest * inv(psoRest) * psoAnim`
+Result: character stands up, arms/legs move, but swing directions are wrong (legs waddle sideways instead of forward/back). The local rest delta doesn't account for the different parent chain orientations.
+
+### Approach 3: World-Space Delta (current, partially works)
+1. Convert PSO local anim to world: `psoWorld = psoParentWorldRest * psoLocalAnim`
+2. Get world delta: `worldDelta = inv(psoWorldRest) * psoWorld`
+3. Apply to PSZ: `pszWorld = pszWorldRest * worldDelta`
+4. Convert back: `pszLocal = inv(pszParentWorldRest) * pszWorld`
+
+Result: character stands but movements are very subtle/dampened. The world delta extraction may be losing the rotation magnitude.
+
+## Potential Next Steps
+
+1. **Debug the world-space approach**: The math may have a quaternion multiplication order issue. Quaternion multiplication is non-commutative, and the difference between `A * B` and `B * A` matters.
+
+2. **Try a different delta formulation**: Instead of `worldDelta = inv(psoWorldRest) * psoWorld`, try `worldDelta = psoWorld * inv(psoWorldRest)` (right-multiply vs left-multiply changes whether the delta is in world frame or bone frame).
+
+3. **Axis remapping per bone**: Compute a static correction quaternion per mapped bone pair that transforms PSO's bone coordinate frame to PSZ's. Apply this correction to each animation frame.
+
+4. **Look at Mixamo/Unity retargeting**: These engines solve this problem. Unity's Humanoid system normalizes all skeletons to a canonical "muscle space" with per-bone twist/swing decomposition. This is more complex but robust.
+
+5. **Manual axis mapping**: For each mapped bone pair, manually specify which PSO axis maps to which PSZ axis (e.g., "PSO X-swing = PSZ Z-swing"). This is tedious but might be the most practical for 12 bones.
+
+6. **Consider that PSO has 3 skins**: The GLB has `bone_000`, `bone_000_1`, `bone_000_2` suggesting multiple skin/skeleton variants. Need to verify we're using the right one.

--- a/web/scripts/retarget-notes.md
+++ b/web/scripts/retarget-notes.md
@@ -116,24 +116,37 @@ Just rename bone tracks. Result: completely twisted/mutilated model because loca
 `pszLocal = pszRest * inv(psoRest) * psoAnim`
 Result: character stands up, arms/legs move, but swing directions are wrong (legs waddle sideways instead of forward/back). The local rest delta doesn't account for the different parent chain orientations.
 
-### Approach 3: World-Space Delta (current, partially works)
-1. Convert PSO local anim to world: `psoWorld = psoParentWorldRest * psoLocalAnim`
-2. Get world delta: `worldDelta = inv(psoWorldRest) * psoWorld`
-3. Apply to PSZ: `pszWorld = pszWorldRest * worldDelta`
-4. Convert back: `pszLocal = inv(pszParentWorldRest) * pszWorld`
+### Approach 3: World-Space Delta (had a bug, now fixed)
+Original (buggy) implementation extracted a LEFT (world-frame) delta but applied it on the RIGHT (bone-frame):
+```
+worldDelta = psoWorld * inv(psoWorldRest)     // LEFT extraction
+pszWorldAnimated = pszWorldRest * worldDelta  // RIGHT application (BUG!)
+```
+This mismatch caused dampened/subtle movements. For arm bones the error was up to 170°.
 
-Result: character stands but movements are very subtle/dampened. The world delta extraction may be losing the rotation magnitude.
+### Approach 4: Conjugation (current, correct)
+Re-express the local animation delta from PSO's bone coordinate frame to PSZ's:
 
-## Potential Next Steps
+```
+localDelta = inv(psoLocalRest) * psoLocalAnim     // delta in PSO bone frame
+F = inv(pszWorldRest) * psoWorldRest               // frame correction PSO -> PSZ
+pszDelta = F * localDelta * inv(F)                 // conjugate to PSZ's frame
+pszLocal = pszLocalRest * pszDelta
+```
 
-1. **Debug the world-space approach**: The math may have a quaternion multiplication order issue. Quaternion multiplication is non-commutative, and the difference between `A * B` and `B * A` matters.
+Optimized form (precompute per bone, 2 quat multiplies per keyframe):
+```
+prefix = pszLocalRest * F * inv(psoLocalRest)
+suffix = inv(F)
+pszLocal = prefix * psoLocalAnim * suffix
+```
 
-2. **Try a different delta formulation**: Instead of `worldDelta = inv(psoWorldRest) * psoWorld`, try `worldDelta = psoWorld * inv(psoWorldRest)` (right-multiply vs left-multiply changes whether the delta is in world frame or bone frame).
+Verified via `retarget-test.mjs`: this produces identical results to the corrected world-frame approach (left-left), with 0.0° difference across all bones and keyframes.
 
-3. **Axis remapping per bone**: Compute a static correction quaternion per mapped bone pair that transforms PSO's bone coordinate frame to PSZ's. Apply this correction to each animation frame.
+## Remaining Issues
 
-4. **Look at Mixamo/Unity retargeting**: These engines solve this problem. Unity's Humanoid system normalizes all skeletons to a canonical "muscle space" with per-bone twist/swing decomposition. This is more complex but robust.
+1. **Visual verification needed**: The math is correct but the retargeted animations need visual inspection in the RetargetViewer to confirm they look right on the PSZ model.
 
-5. **Manual axis mapping**: For each mapped bone pair, manually specify which PSO axis maps to which PSZ axis (e.g., "PSO X-swing = PSZ Z-swing"). This is tedious but might be the most practical for 12 bones.
+2. **PSO has 3 skins**: The GLB has `bone_000`, `bone_000_1`, `bone_000_2` suggesting multiple skin/skeleton variants. Currently using the first one.
 
-6. **Consider that PSO has 3 skins**: The GLB has `bone_000`, `bone_000_1`, `bone_000_2` suggesting multiple skin/skeleton variants. Need to verify we're using the right one.
+3. **Animation naming**: PSO animations are numbered (`plymotiondata_000` through `plymotiondata_571`). Need to map these to semantic names using the PLYMOTION array from the psov2 codebase.

--- a/web/scripts/retarget-test.mjs
+++ b/web/scripts/retarget-test.mjs
@@ -1,0 +1,218 @@
+// Test different retargeting approaches on actual animation data
+// to identify the correct quaternion multiplication order.
+import { Blob } from 'buffer';
+globalThis.self = globalThis;
+globalThis.Blob = Blob;
+globalThis.document = { createElementNS: () => ({}) };
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import fs from 'fs';
+import path from 'path';
+
+const MAPPINGS = {
+  bone_000: '000_Root',
+  bone_002: '010_Hip',
+  bone_024: '020_Spine',
+  bone_028: '030_LArm01',
+  bone_029: '040_LArm02',
+  bone_041: '060_RArm01',
+  bone_042: '070_RArm02',
+  bone_056: '090_Head',
+  bone_004: '100_LLeg01',
+  bone_005: '110_LLeg02',
+  bone_013: '120_RLeg01',
+  bone_014: '130_RLeg02',
+};
+
+function loadGLB(filePath) {
+  return new Promise((resolve, reject) => {
+    const data = fs.readFileSync(filePath);
+    const loader = new GLTFLoader();
+    loader.parse(data.buffer, '', (gltf) => resolve(gltf), reject);
+  });
+}
+
+function fmt(q, d = 4) {
+  if (q instanceof THREE.Quaternion)
+    return `(${q.x.toFixed(d)}, ${q.y.toFixed(d)}, ${q.z.toFixed(d)}, ${q.w.toFixed(d)})`;
+  if (q instanceof THREE.Euler) {
+    const deg = (r) => (r * 180 / Math.PI).toFixed(1);
+    return `(${deg(q.x)}, ${deg(q.y)}, ${deg(q.z)})°`;
+  }
+  return String(q);
+}
+
+function captureRestPose(model) {
+  const localQuats = {};
+  const worldQuats = {};
+  const parentMap = {};
+
+  model.traverse((child) => {
+    if (child.isSkinnedMesh && child.skeleton) child.skeleton.pose();
+  });
+  model.updateMatrixWorld(true);
+
+  model.traverse((child) => {
+    if (child.isBone) {
+      localQuats[child.name] = child.quaternion.clone();
+      const wq = new THREE.Quaternion();
+      child.getWorldQuaternion(wq);
+      worldQuats[child.name] = wq;
+      parentMap[child.name] = child.parent?.isBone ? child.parent.name : null;
+    }
+  });
+  return { localQuats, worldQuats, parentMap };
+}
+
+// Compute world rest quat by walking the parent chain (same as RetargetViewer)
+function getWorldRestQuat(boneName, restData) {
+  const result = new THREE.Quaternion();
+  const chain = [];
+  let cur = boneName;
+  while (cur) {
+    chain.unshift(cur);
+    cur = restData.parentMap[cur] || null;
+  }
+  for (const name of chain) {
+    const local = restData.localQuats[name];
+    if (local) result.multiply(local);
+  }
+  return result;
+}
+
+async function main() {
+  const pszPath = path.resolve('public/player/pc_000/pc_000/pc_000_000.glb');
+  const psoPath = path.resolve('../data/retarget/Humar_body.glb');
+
+  console.log('Loading models...');
+  const [pszGltf, psoGltf] = await Promise.all([loadGLB(pszPath), loadGLB(psoPath)]);
+
+  const psoRest = captureRestPose(psoGltf.scene);
+  const pszRest = captureRestPose(pszGltf.scene);
+
+  // Verify getWorldRestQuat matches actual world quats
+  console.log('\n=== VERIFY getWorldRestQuat vs actual world quats ===');
+  for (const boneName of Object.keys(MAPPINGS)) {
+    const computed = getWorldRestQuat(boneName, psoRest);
+    const actual = psoRest.worldQuats[boneName];
+    if (!actual) { console.log(`  ${boneName}: MISSING`); continue; }
+    const diff = computed.angleTo(actual) * 180 / Math.PI;
+    if (diff > 0.1) {
+      console.log(`  ${boneName}: MISMATCH! diff=${diff.toFixed(2)}° computed=${fmt(computed)} actual=${fmt(actual)}`);
+    }
+  }
+  console.log('  (only mismatches shown)');
+
+  // Pick an animation with visible movement (try walk or attack)
+  const anims = psoGltf.animations;
+  // Use animation index 0 (first idle), and also try a few others
+  const testAnims = [0, 7, 25]; // idle, some others
+
+  for (const animIdx of testAnims) {
+    if (animIdx >= anims.length) continue;
+    const clip = anims[animIdx];
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`ANIMATION: ${clip.name} (${clip.duration.toFixed(2)}s, ${clip.tracks.length} tracks)`);
+    console.log(`${'='.repeat(60)}`);
+
+    // For each mapped bone, get the quaternion track and test retargeting at frame 0 and mid-frame
+    for (const [psoBone, pszBone] of Object.entries(MAPPINGS)) {
+      const trackName = `${psoBone}.quaternion`;
+      const track = clip.tracks.find((t) => t.name === trackName);
+      if (!track) continue;
+
+      // Get rest quaternions
+      const psoLocalRest = psoRest.localQuats[psoBone] || new THREE.Quaternion();
+      const pszLocalRest = pszRest.localQuats[pszBone] || new THREE.Quaternion();
+
+      const psoParent = psoRest.parentMap[psoBone];
+      const pszParent = pszRest.parentMap[pszBone];
+      const psoParentWorldRest = psoParent ? getWorldRestQuat(psoParent, psoRest) : new THREE.Quaternion();
+      const pszParentWorldRest = pszParent ? getWorldRestQuat(pszParent, pszRest) : new THREE.Quaternion();
+
+      const psoWorldRest = psoParentWorldRest.clone().multiply(psoLocalRest);
+      const pszWorldRest = pszParentWorldRest.clone().multiply(pszLocalRest);
+
+      // Test at a few keyframes
+      const numKf = track.times.length;
+      const testFrames = [0, Math.floor(numKf / 4), Math.floor(numKf / 2)];
+
+      console.log(`\n  ${psoBone} -> ${pszBone} (${numKf} keyframes):`);
+      console.log(`    PSO local rest: ${fmt(psoLocalRest)}  euler: ${fmt(new THREE.Euler().setFromQuaternion(psoLocalRest))}`);
+      console.log(`    PSZ local rest: ${fmt(pszLocalRest)}  euler: ${fmt(new THREE.Euler().setFromQuaternion(pszLocalRest))}`);
+
+      for (const fi of testFrames) {
+        if (fi >= numKf) continue;
+        const i = fi * 4;
+        const psoLocalAnim = new THREE.Quaternion(
+          track.values[i], track.values[i + 1], track.values[i + 2], track.values[i + 3]
+        );
+
+        // How much does this frame differ from rest?
+        const localDeltaAngle = psoLocalRest.angleTo(psoLocalAnim) * 180 / Math.PI;
+
+        // ---- APPROACH 1: Current buggy (left extract, right apply) ----
+        const psoWorld1 = psoParentWorldRest.clone().multiply(psoLocalAnim);
+        const worldDelta1 = psoWorldRest.clone().invert().clone().premultiply(psoWorld1);
+        // worldDelta1 = psoWorld1 * inv(psoWorldRest) — LEFT delta
+        const pszWorldAnim1 = pszWorldRest.clone().multiply(worldDelta1);
+        // pszWorldAnim1 = pszWorldRest * worldDelta1 — RIGHT apply (BUG)
+        const pszLocal1 = pszParentWorldRest.clone().invert().multiply(pszWorldAnim1);
+
+        // ---- APPROACH 2: Fixed left-left (world frame delta) ----
+        const psoWorld2 = psoParentWorldRest.clone().multiply(psoLocalAnim);
+        const worldDelta2L = psoWorld2.clone().multiply(psoWorldRest.clone().invert());
+        // worldDelta2L = psoWorld2 * inv(psoWorldRest) — LEFT delta
+        const pszWorldAnim2 = worldDelta2L.clone().multiply(pszWorldRest);
+        // pszWorldAnim2 = worldDelta2L * pszWorldRest — LEFT apply (FIXED)
+        const pszLocal2 = pszParentWorldRest.clone().invert().multiply(pszWorldAnim2);
+
+        // ---- APPROACH 3: Right-right (bone frame delta) ----
+        const psoWorld3 = psoParentWorldRest.clone().multiply(psoLocalAnim);
+        const worldDelta3R = psoWorldRest.clone().invert().multiply(psoWorld3);
+        // worldDelta3R = inv(psoWorldRest) * psoWorld3 — RIGHT delta
+        const pszWorldAnim3 = pszWorldRest.clone().multiply(worldDelta3R);
+        // pszWorldAnim3 = pszWorldRest * worldDelta3R — RIGHT apply
+        const pszLocal3 = pszParentWorldRest.clone().invert().multiply(pszWorldAnim3);
+
+        // ---- APPROACH 4: Conjugation (frame-corrected local delta) ----
+        const localDelta = psoLocalRest.clone().invert().multiply(psoLocalAnim);
+        const F = pszWorldRest.clone().invert().multiply(psoWorldRest);
+        const Finv = F.clone().invert();
+        const pszDelta = F.clone().multiply(localDelta).multiply(Finv);
+        const pszLocal4 = pszLocalRest.clone().multiply(pszDelta);
+
+        // Compare approaches
+        const diff12 = pszLocal1.angleTo(pszLocal2) * 180 / Math.PI;
+        const diff23 = pszLocal2.angleTo(pszLocal3) * 180 / Math.PI;
+        const diff24 = pszLocal2.angleTo(pszLocal4) * 180 / Math.PI;
+        const diff34 = pszLocal3.angleTo(pszLocal4) * 180 / Math.PI;
+
+        // How far is each result from PSZ rest? (should be non-zero for animated frames)
+        const restDelta1 = pszLocalRest.angleTo(pszLocal1) * 180 / Math.PI;
+        const restDelta2 = pszLocalRest.angleTo(pszLocal2) * 180 / Math.PI;
+        const restDelta3 = pszLocalRest.angleTo(pszLocal3) * 180 / Math.PI;
+        const restDelta4 = pszLocalRest.angleTo(pszLocal4) * 180 / Math.PI;
+
+        if (localDeltaAngle < 0.5) continue; // skip near-rest frames
+
+        console.log(`    kf[${fi}] t=${track.times[fi].toFixed(3)}s  PSO anim delta from rest: ${localDeltaAngle.toFixed(1)}°`);
+        console.log(`      Approach 1 (LEFT-RIGHT bug):  deviation from PSZ rest: ${restDelta1.toFixed(1)}°  euler: ${fmt(new THREE.Euler().setFromQuaternion(pszLocal1))}`);
+        console.log(`      Approach 2 (LEFT-LEFT fix):   deviation from PSZ rest: ${restDelta2.toFixed(1)}°  euler: ${fmt(new THREE.Euler().setFromQuaternion(pszLocal2))}`);
+        console.log(`      Approach 3 (RIGHT-RIGHT):     deviation from PSZ rest: ${restDelta3.toFixed(1)}°  euler: ${fmt(new THREE.Euler().setFromQuaternion(pszLocal3))}`);
+        console.log(`      Approach 4 (CONJUGATION):     deviation from PSZ rest: ${restDelta4.toFixed(1)}°  euler: ${fmt(new THREE.Euler().setFromQuaternion(pszLocal4))}`);
+        console.log(`      Diff 1vs2: ${diff12.toFixed(1)}°  2vs3: ${diff23.toFixed(1)}°  2vs4: ${diff24.toFixed(1)}°  3vs4: ${diff34.toFixed(1)}°`);
+      }
+    }
+  }
+
+  // Summary: which approaches agree?
+  console.log('\n=== APPROACH EQUIVALENCE SUMMARY ===');
+  console.log('Approach 2 (left-left) and Approach 4 (conjugation) should be mathematically equivalent.');
+  console.log('Approach 3 (right-right) is different — it applies the delta in PSO bone frame without correction.');
+  console.log('Approach 1 (current bug) mixes left extraction with right application.');
+  console.log('\nApproach 2 = Approach 4 means the world-frame delta is correctly preserved.');
+  console.log('If 2 != 3, the frame correction matters (different bone orientations).');
+}
+
+main().catch(console.error);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ const PlayerAnimationStorybook = lazy(() => import('./storybook/PlayerAnimationS
 const StageEditor = lazy(() => import('./stage-editor/UnifiedStageEditor'));
 const SvgCheck = lazy(() => import('./svg-check/SvgCheck'));
 const OfficeEditor = lazy(() => import('./office-editor/OfficeEditor'));
+const RetargetViewer = lazy(() => import('./retarget/RetargetViewer'));
 
 function NavBar() {
   const location = useLocation();
@@ -82,6 +83,12 @@ function NavBar() {
       }}>
         Office
       </Link>
+      <Link to="/retarget" style={{
+        color: isActive('/retarget') ? '#fff' : '#888',
+        textDecoration: 'none',
+      }}>
+        Retarget
+      </Link>
     </nav>
   );
 }
@@ -103,6 +110,7 @@ export default function App() {
             <Route path="/stage-editor" element={<StageEditor />} />
             <Route path="/svg-check" element={<SvgCheck />} />
             <Route path="/office-editor" element={<OfficeEditor />} />
+            <Route path="/retarget" element={<RetargetViewer />} />
           </Routes>
         </Suspense>
       </div>

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -1,0 +1,514 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { assetUrl } from '../utils/assets';
+
+// PSZ model — using humar (pc_000) as reference
+const PSZ_MODEL_PATH = assetUrl('/player/pc_000/pc_000/pc_000_000.glb');
+const PSZ_TEXTURE_PATH = assetUrl('/player/pc_000/textures/pc_000_000.png');
+
+// PSO model — Humar with all animations
+const PSO_MODEL_PATH = '/data/retarget/Humar_body.glb';
+
+interface BoneInfo {
+  name: string;
+  depth: number;
+  worldPos: THREE.Vector3;
+  bone: THREE.Bone;
+}
+
+function collectBones(root: THREE.Object3D): BoneInfo[] {
+  const bones: BoneInfo[] = [];
+  const traverse = (obj: THREE.Object3D, depth: number) => {
+    if ((obj as THREE.Bone).isBone) {
+      const worldPos = new THREE.Vector3();
+      obj.getWorldPosition(worldPos);
+      bones.push({ name: obj.name, depth, worldPos, bone: obj as THREE.Bone });
+    }
+    for (const child of obj.children) {
+      traverse(child, depth + 1);
+    }
+  };
+  traverse(root, 0);
+  return bones;
+}
+
+function createBoneLabels(
+  bones: BoneInfo[],
+  color: string,
+  scene: THREE.Scene,
+  selectedBone: string | null,
+): THREE.Sprite[] {
+  const sprites: THREE.Sprite[] = [];
+  for (const bone of bones) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d')!;
+    const isSelected = bone.name === selectedBone;
+    ctx.font = isSelected ? 'bold 18px monospace' : '14px monospace';
+    ctx.fillStyle = isSelected ? '#ffff00' : color;
+    ctx.fillText(bone.name, 4, 20);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    const material = new THREE.SpriteMaterial({ map: texture, depthTest: false });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(1.2, 0.3, 1);
+    sprite.position.copy(bone.worldPos);
+    sprite.position.y += 0.08;
+    sprite.renderOrder = 999;
+    scene.add(sprite);
+    sprites.push(sprite);
+  }
+  return sprites;
+}
+
+function createSkeletonHelper(model: THREE.Object3D, color: number): THREE.SkeletonHelper | null {
+  let skeleton: THREE.Skeleton | null = null;
+  model.traverse((child) => {
+    if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
+      skeleton = (child as THREE.SkinnedMesh).skeleton;
+    }
+  });
+  if (!skeleton) return null;
+  const helper = new THREE.SkeletonHelper(model);
+  (helper.material as THREE.LineBasicMaterial).color.set(color);
+  (helper.material as THREE.LineBasicMaterial).linewidth = 2;
+  helper.renderOrder = 998;
+  return helper;
+}
+
+interface SceneState {
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  renderer: THREE.WebGLRenderer;
+  controls: OrbitControls;
+  pszModel: THREE.Object3D | null;
+  psoModel: THREE.Object3D | null;
+  pszHelper: THREE.SkeletonHelper | null;
+  psoHelper: THREE.SkeletonHelper | null;
+  psoMixer: THREE.AnimationMixer | null;
+  psoAnimations: THREE.AnimationClip[];
+  currentAction: THREE.AnimationAction | null;
+  labelSprites: THREE.Sprite[];
+}
+
+export default function RetargetViewer() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sceneRef = useRef<SceneState | null>(null);
+
+  const [pszBones, setPszBones] = useState<BoneInfo[]>([]);
+  const [psoBones, setPsoBones] = useState<BoneInfo[]>([]);
+  const [selectedPszBone, setSelectedPszBone] = useState<string | null>(null);
+  const [selectedPsoBone, setSelectedPsoBone] = useState<string | null>(null);
+  const [psoAnimations, setPsoAnimations] = useState<string[]>([]);
+  const [selectedAnimation, setSelectedAnimation] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [showMeshes, setShowMeshes] = useState(true);
+  const [showLabels, setShowLabels] = useState(true);
+  const [mappings, setMappings] = useState<Record<string, string>>({});
+
+  // Initialize Three.js scene
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const container = containerRef.current;
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(50, width / height, 0.01, 100);
+    camera.position.set(0, 1.5, 4);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    renderer.setClearColor(0x0a0a1a);
+    container.appendChild(renderer.domElement);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+    const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+    dirLight.position.set(5, 5, 5);
+    scene.add(dirLight);
+    scene.add(new THREE.GridHelper(10, 10, 0x333333, 0x222222));
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.target.set(0, 0.8, 0);
+
+    sceneRef.current = {
+      scene, camera, renderer, controls,
+      pszModel: null, psoModel: null,
+      pszHelper: null, psoHelper: null,
+      psoMixer: null, psoAnimations: [],
+      currentAction: null, labelSprites: [],
+    };
+
+    const clock = new THREE.Clock();
+    const animate = () => {
+      requestAnimationFrame(animate);
+      const delta = clock.getDelta();
+      if (sceneRef.current?.psoMixer) sceneRef.current.psoMixer.update(delta);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    const handleResize = () => {
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    };
+    window.addEventListener('resize', handleResize);
+
+    // Load both models
+    const loader = new GLTFLoader();
+    const textureLoader = new THREE.TextureLoader();
+
+    // PSZ model on the left
+    loader.load(PSZ_MODEL_PATH, (gltf) => {
+      const model = gltf.scene;
+      model.position.x = -1.2;
+      scene.add(model);
+      sceneRef.current!.pszModel = model;
+
+      textureLoader.load(PSZ_TEXTURE_PATH, (texture) => {
+        texture.magFilter = THREE.NearestFilter;
+        texture.minFilter = THREE.NearestFilter;
+        texture.flipY = false;
+        texture.colorSpace = THREE.SRGBColorSpace;
+        model.traverse((child: THREE.Object3D) => {
+          if ((child as THREE.Mesh).isMesh) {
+            const mat = new THREE.MeshBasicMaterial({ map: texture });
+            (child as THREE.Mesh).material = mat;
+          }
+        });
+      });
+
+      const helper = createSkeletonHelper(model, 0x44ff44);
+      if (helper) {
+        scene.add(helper);
+        sceneRef.current!.pszHelper = helper;
+      }
+      // Need to update world matrices before collecting bone positions
+      model.updateMatrixWorld(true);
+      setPszBones(collectBones(model));
+    });
+
+    // PSO model on the right
+    loader.load(PSO_MODEL_PATH, (gltf) => {
+      const model = gltf.scene;
+      model.position.x = 1.2;
+      scene.add(model);
+      sceneRef.current!.psoModel = model;
+
+      const helper = createSkeletonHelper(model, 0xff4444);
+      if (helper) {
+        scene.add(helper);
+        sceneRef.current!.psoHelper = helper;
+      }
+
+      const mixer = new THREE.AnimationMixer(model);
+      sceneRef.current!.psoMixer = mixer;
+      sceneRef.current!.psoAnimations = gltf.animations;
+      const animNames = gltf.animations.map((a) => a.name);
+      setPsoAnimations(animNames);
+
+      model.updateMatrixWorld(true);
+      setPsoBones(collectBones(model));
+    });
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      renderer.dispose();
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  // Update labels when selection changes
+  useEffect(() => {
+    if (!sceneRef.current || !showLabels) return;
+    const { scene, labelSprites } = sceneRef.current;
+
+    // Remove old labels
+    for (const sprite of labelSprites) scene.remove(sprite);
+    sceneRef.current.labelSprites = [];
+
+    // Add new labels
+    const pszLabels = createBoneLabels(pszBones, '#44ff44', scene, selectedPszBone);
+    const psoLabels = createBoneLabels(psoBones, '#ff4444', scene, selectedPsoBone);
+    sceneRef.current.labelSprites = [...pszLabels, ...psoLabels];
+  }, [pszBones, psoBones, selectedPszBone, selectedPsoBone, showLabels]);
+
+  // Toggle labels visibility
+  useEffect(() => {
+    if (!sceneRef.current) return;
+    const { scene, labelSprites } = sceneRef.current;
+    if (!showLabels) {
+      for (const sprite of labelSprites) scene.remove(sprite);
+      sceneRef.current.labelSprites = [];
+    }
+  }, [showLabels]);
+
+  // Toggle meshes visibility
+  useEffect(() => {
+    if (!sceneRef.current) return;
+    const { pszModel, psoModel } = sceneRef.current;
+    const toggleMeshes = (model: THREE.Object3D | null) => {
+      if (!model) return;
+      model.traverse((child) => {
+        if ((child as THREE.Mesh).isMesh) {
+          (child as THREE.Mesh).visible = showMeshes;
+        }
+      });
+    };
+    toggleMeshes(pszModel);
+    toggleMeshes(psoModel);
+  }, [showMeshes]);
+
+  // Play animation on PSO model
+  useEffect(() => {
+    if (!sceneRef.current?.psoMixer || !selectedAnimation) return;
+    const { psoMixer, psoAnimations, currentAction } = sceneRef.current;
+    if (currentAction) currentAction.fadeOut(0.2);
+    const clip = psoAnimations.find((a) => a.name === selectedAnimation);
+    if (clip) {
+      const action = psoMixer.clipAction(clip);
+      action.reset().fadeIn(0.2).play();
+      action.setLoop(THREE.LoopRepeat, Infinity);
+      action.paused = !isPlaying;
+      sceneRef.current.currentAction = action;
+    }
+  }, [selectedAnimation]);
+
+  useEffect(() => {
+    if (sceneRef.current?.currentAction) sceneRef.current.currentAction.paused = !isPlaying;
+  }, [isPlaying]);
+
+  const addMapping = useCallback(() => {
+    if (selectedPszBone && selectedPsoBone) {
+      setMappings((prev) => ({ ...prev, [selectedPsoBone]: selectedPszBone }));
+    }
+  }, [selectedPszBone, selectedPsoBone]);
+
+  const removeMapping = useCallback((psoKey: string) => {
+    setMappings((prev) => {
+      const next = { ...prev };
+      delete next[psoKey];
+      return next;
+    });
+  }, []);
+
+  const exportMappings = useCallback(() => {
+    const json = JSON.stringify(mappings, null, 2);
+    navigator.clipboard.writeText(json);
+  }, [mappings]);
+
+  return (
+    <div style={{ background: '#1a1a2e', height: '100%', color: '#fff', padding: '16px', boxSizing: 'border-box' }}>
+      <div style={{ display: 'flex', gap: '16px', height: '100%' }}>
+        {/* Left panel - PSZ bones */}
+        <div style={{ width: '220px', background: '#2d2d44', borderRadius: '8px', padding: '12px', overflowY: 'auto' }}>
+          <h3 style={{ fontSize: '12px', color: '#44ff44', margin: '0 0 10px 0', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+            PSZ Bones ({pszBones.length})
+          </h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+            {pszBones.map((bone) => (
+              <button
+                key={bone.name}
+                onClick={() => setSelectedPszBone(bone.name)}
+                style={{
+                  padding: '4px 8px',
+                  paddingLeft: `${8 + bone.depth * 12}px`,
+                  background: selectedPszBone === bone.name ? '#2a4a2a' : 'transparent',
+                  border: selectedPszBone === bone.name ? '1px solid #44ff44' : '1px solid transparent',
+                  borderRadius: '3px',
+                  color: selectedPszBone === bone.name ? '#44ff44' : '#aaa',
+                  cursor: 'pointer',
+                  fontSize: '11px',
+                  textAlign: 'left',
+                  fontFamily: 'monospace',
+                }}
+              >
+                {bone.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Center - 3D Canvas + Controls */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <div style={{
+            background: '#2d2d44', borderRadius: '8px', padding: '10px 16px',
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          }}>
+            <span style={{ fontSize: '14px', fontWeight: 'bold' }}>
+              <span style={{ color: '#44ff44' }}>PSZ</span>
+              {' vs '}
+              <span style={{ color: '#ff4444' }}>PSO</span>
+              {' Skeleton Comparison'}
+            </span>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <label style={{ fontSize: '11px', color: '#888', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <input type="checkbox" checked={showMeshes} onChange={(e) => setShowMeshes(e.target.checked)} />
+                Meshes
+              </label>
+              <label style={{ fontSize: '11px', color: '#888', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <input type="checkbox" checked={showLabels} onChange={(e) => setShowLabels(e.target.checked)} />
+                Labels
+              </label>
+            </div>
+          </div>
+          <div style={{ flex: 1, background: '#0a0a1a', borderRadius: '8px', overflow: 'hidden' }} ref={containerRef} />
+
+          {/* Mapping controls */}
+          <div style={{
+            background: '#2d2d44', borderRadius: '8px', padding: '10px 16px',
+            display: 'flex', alignItems: 'center', gap: '12px',
+          }}>
+            <span style={{ fontSize: '11px', color: '#44ff44', fontFamily: 'monospace' }}>
+              {selectedPszBone || '(select PSZ)'}
+            </span>
+            <span style={{ fontSize: '11px', color: '#666' }}>&larr;</span>
+            <span style={{ fontSize: '11px', color: '#ff4444', fontFamily: 'monospace' }}>
+              {selectedPsoBone || '(select PSO)'}
+            </span>
+            <button
+              onClick={addMapping}
+              disabled={!selectedPszBone || !selectedPsoBone}
+              style={{
+                padding: '4px 12px', background: '#4a4a6a', border: '1px solid #6b8afd',
+                borderRadius: '4px', color: '#fff', cursor: 'pointer', fontSize: '11px',
+                opacity: selectedPszBone && selectedPsoBone ? 1 : 0.4,
+              }}
+            >
+              Map
+            </button>
+            <button
+              onClick={exportMappings}
+              style={{
+                padding: '4px 12px', background: '#2d5a2d', border: '1px solid #4a4',
+                borderRadius: '4px', color: '#6f6', cursor: 'pointer', fontSize: '11px',
+                marginLeft: 'auto',
+              }}
+            >
+              Copy JSON ({Object.keys(mappings).length})
+            </button>
+          </div>
+        </div>
+
+        {/* Right panel - PSO bones + animations + mappings */}
+        <div style={{ width: '280px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {/* PSO Bones */}
+          <div style={{ flex: 1, background: '#2d2d44', borderRadius: '8px', padding: '12px', overflowY: 'auto' }}>
+            <h3 style={{ fontSize: '12px', color: '#ff4444', margin: '0 0 10px 0', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+              PSO Bones ({psoBones.length})
+            </h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+              {psoBones.map((bone) => {
+                const isMapped = bone.name in mappings;
+                return (
+                  <button
+                    key={bone.name}
+                    onClick={() => setSelectedPsoBone(bone.name)}
+                    style={{
+                      padding: '4px 8px',
+                      paddingLeft: `${8 + bone.depth * 12}px`,
+                      background: selectedPsoBone === bone.name ? '#4a2a2a' : isMapped ? '#2a2a3a' : 'transparent',
+                      border: selectedPsoBone === bone.name ? '1px solid #ff4444' : '1px solid transparent',
+                      borderRadius: '3px',
+                      color: selectedPsoBone === bone.name ? '#ff4444' : isMapped ? '#8888ff' : '#aaa',
+                      cursor: 'pointer',
+                      fontSize: '11px',
+                      textAlign: 'left',
+                      fontFamily: 'monospace',
+                    }}
+                  >
+                    {bone.name}
+                    {isMapped && (
+                      <span style={{ color: '#44ff44', fontSize: '9px', marginLeft: '6px' }}>
+                        &rarr; {mappings[bone.name]}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Animations */}
+          <div style={{ maxHeight: '200px', background: '#2d2d44', borderRadius: '8px', padding: '12px', overflowY: 'auto' }}>
+            <h3 style={{ fontSize: '12px', color: '#6b8afd', margin: '0 0 8px 0', textTransform: 'uppercase' }}>
+              PSO Animations ({psoAnimations.length})
+            </h3>
+            <button
+              onClick={() => setIsPlaying(!isPlaying)}
+              style={{
+                padding: '4px 8px', width: '100%', marginBottom: '8px',
+                background: isPlaying ? '#2d5a2d' : '#1a1a2e',
+                border: isPlaying ? '1px solid #4a4' : '1px solid #444',
+                borderRadius: '4px', color: isPlaying ? '#6f6' : '#aaa',
+                cursor: 'pointer', fontSize: '11px',
+              }}
+            >
+              {isPlaying ? 'Pause' : 'Play'}
+            </button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+              {psoAnimations.map((name) => (
+                <button
+                  key={name}
+                  onClick={() => { setSelectedAnimation(name); setIsPlaying(true); }}
+                  style={{
+                    padding: '3px 6px',
+                    background: selectedAnimation === name ? '#4a4a6a' : 'transparent',
+                    border: selectedAnimation === name ? '1px solid #6b8afd' : '1px solid transparent',
+                    borderRadius: '3px',
+                    color: selectedAnimation === name ? '#fff' : '#aaa',
+                    cursor: 'pointer',
+                    fontSize: '10px',
+                    textAlign: 'left',
+                    fontFamily: 'monospace',
+                  }}
+                >
+                  {name}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Mappings list */}
+          {Object.keys(mappings).length > 0 && (
+            <div style={{ maxHeight: '200px', background: '#2d2d44', borderRadius: '8px', padding: '12px', overflowY: 'auto' }}>
+              <h3 style={{ fontSize: '12px', color: '#8888ff', margin: '0 0 8px 0', textTransform: 'uppercase' }}>
+                Mappings ({Object.keys(mappings).length})
+              </h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+                {Object.entries(mappings).map(([pso, psz]) => (
+                  <div key={pso} style={{
+                    display: 'flex', alignItems: 'center', gap: '6px',
+                    padding: '3px 6px', background: '#1a1a2e', borderRadius: '3px', fontSize: '10px',
+                  }}>
+                    <span style={{ color: '#ff4444', fontFamily: 'monospace', flex: 1 }}>{pso}</span>
+                    <span style={{ color: '#666' }}>&rarr;</span>
+                    <span style={{ color: '#44ff44', fontFamily: 'monospace', flex: 1 }}>{psz}</span>
+                    <button
+                      onClick={() => removeMapping(pso)}
+                      style={{
+                        padding: '1px 5px', background: '#4a2a2a', border: '1px solid #644',
+                        borderRadius: '3px', color: '#f66', cursor: 'pointer', fontSize: '9px',
+                      }}
+                    >
+                      x
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -89,8 +89,10 @@ interface SceneState {
   pszHelper: THREE.SkeletonHelper | null;
   psoHelper: THREE.SkeletonHelper | null;
   psoMixer: THREE.AnimationMixer | null;
+  pszMixer: THREE.AnimationMixer | null;
   psoAnimations: THREE.AnimationClip[];
   currentAction: THREE.AnimationAction | null;
+  currentPszAction: THREE.AnimationAction | null;
   labelSprites: THREE.Sprite[];
 }
 
@@ -110,6 +112,9 @@ export default function RetargetViewer() {
   const [mappings, setMappings] = useState<Record<string, string>>({});
   const [pszLoaded, setPszLoaded] = useState(false);
   const [psoLoaded, setPsoLoaded] = useState(false);
+  const [psoLoadError, setPsoLoadError] = useState<string | null>(null);
+  const [psoLoadProgress, setPsoLoadProgress] = useState(0);
+  const [playOnBoth, setPlayOnBoth] = useState(false);
 
   // Initialize Three.js scene
   useEffect(() => {
@@ -140,8 +145,8 @@ export default function RetargetViewer() {
       scene, camera, renderer, controls,
       pszModel: null, psoModel: null,
       pszHelper: null, psoHelper: null,
-      psoMixer: null, psoAnimations: [],
-      currentAction: null, labelSprites: [],
+      psoMixer: null, pszMixer: null, psoAnimations: [],
+      currentAction: null, currentPszAction: null, labelSprites: [],
     };
 
     const clock = new THREE.Clock();
@@ -149,6 +154,7 @@ export default function RetargetViewer() {
       requestAnimationFrame(animate);
       const delta = clock.getDelta();
       if (sceneRef.current?.psoMixer) sceneRef.current.psoMixer.update(delta);
+      if (sceneRef.current?.pszMixer) sceneRef.current.pszMixer.update(delta);
       controls.update();
       renderer.render(scene, camera);
     };
@@ -192,6 +198,9 @@ export default function RetargetViewer() {
         scene.add(helper);
         sceneRef.current!.pszHelper = helper;
       }
+      const pszMixer = new THREE.AnimationMixer(model);
+      sceneRef.current!.pszMixer = pszMixer;
+
       // Need to update world matrices before collecting bone positions
       model.updateMatrixWorld(true);
       setPszBones(collectBones(model));
@@ -199,28 +208,40 @@ export default function RetargetViewer() {
     });
 
     // PSO model on the right
-    loader.load(PSO_MODEL_PATH, (gltf) => {
-      const model = gltf.scene;
-      model.position.x = 1.2;
-      scene.add(model);
-      sceneRef.current!.psoModel = model;
+    loader.load(
+      PSO_MODEL_PATH,
+      (gltf) => {
+        const model = gltf.scene;
+        model.position.x = 1.2;
+        scene.add(model);
+        sceneRef.current!.psoModel = model;
 
-      const helper = createSkeletonHelper(model, 0xff4444);
-      if (helper) {
-        scene.add(helper);
-        sceneRef.current!.psoHelper = helper;
-      }
+        const helper = createSkeletonHelper(model, 0xff4444);
+        if (helper) {
+          scene.add(helper);
+          sceneRef.current!.psoHelper = helper;
+        }
 
-      const mixer = new THREE.AnimationMixer(model);
-      sceneRef.current!.psoMixer = mixer;
-      sceneRef.current!.psoAnimations = gltf.animations;
-      const animNames = gltf.animations.map((a) => a.name);
-      setPsoAnimations(animNames);
+        const mixer = new THREE.AnimationMixer(model);
+        sceneRef.current!.psoMixer = mixer;
+        sceneRef.current!.psoAnimations = gltf.animations;
+        const animNames = gltf.animations.map((a) => a.name);
+        setPsoAnimations(animNames);
 
-      model.updateMatrixWorld(true);
-      setPsoBones(collectBones(model));
-      setPsoLoaded(true);
-    });
+        model.updateMatrixWorld(true);
+        setPsoBones(collectBones(model));
+        setPsoLoaded(true);
+      },
+      (progress) => {
+        if (progress.total > 0) {
+          setPsoLoadProgress(Math.round((progress.loaded / progress.total) * 100));
+        }
+      },
+      (error) => {
+        console.error('Failed to load PSO model:', error);
+        setPsoLoadError(`Failed to load PSO model: ${error}`);
+      },
+    );
 
     return () => {
       window.removeEventListener('resize', handleResize);
@@ -272,11 +293,34 @@ export default function RetargetViewer() {
     toggleMeshes(psoModel);
   }, [showMeshes]);
 
-  // Play animation on PSO model
+  // Build a retargeted clip that maps PSO bone tracks → PSZ bone names
+  const buildRetargetedClip = useCallback((clip: THREE.AnimationClip, boneMap: Record<string, string>): THREE.AnimationClip | null => {
+    if (Object.keys(boneMap).length === 0) return null;
+    const tracks: THREE.KeyframeTrack[] = [];
+    for (const track of clip.tracks) {
+      // Track names are like "bone_000.quaternion" or "bone_000.position"
+      const dotIdx = track.name.indexOf('.');
+      if (dotIdx < 0) continue;
+      const boneName = track.name.substring(0, dotIdx);
+      const prop = track.name.substring(dotIdx);
+      const pszBoneName = boneMap[boneName];
+      if (pszBoneName) {
+        const newTrack = track.clone();
+        newTrack.name = pszBoneName + prop;
+        tracks.push(newTrack);
+      }
+    }
+    if (tracks.length === 0) return null;
+    return new THREE.AnimationClip(clip.name + '_retargeted', clip.duration, tracks);
+  }, []);
+
+  // Play animation on PSO model (and optionally retarget to PSZ)
   useEffect(() => {
     if (!sceneRef.current?.psoMixer || !selectedAnimation) return;
-    const { psoMixer, psoAnimations, currentAction } = sceneRef.current;
+    const { psoMixer, pszMixer, psoAnimations, currentAction, currentPszAction } = sceneRef.current;
     if (currentAction) currentAction.fadeOut(0.2);
+    if (currentPszAction) currentPszAction.fadeOut(0.2);
+
     const clip = psoAnimations.find((a) => a.name === selectedAnimation);
     if (clip) {
       const action = psoMixer.clipAction(clip);
@@ -284,11 +328,24 @@ export default function RetargetViewer() {
       action.setLoop(THREE.LoopRepeat, Infinity);
       action.paused = !isPlaying;
       sceneRef.current.currentAction = action;
+
+      // Retarget to PSZ if enabled and mappings exist
+      if (playOnBoth && pszMixer) {
+        const retargeted = buildRetargetedClip(clip, mappings);
+        if (retargeted) {
+          const pszAction = pszMixer.clipAction(retargeted);
+          pszAction.reset().fadeIn(0.2).play();
+          pszAction.setLoop(THREE.LoopRepeat, Infinity);
+          pszAction.paused = !isPlaying;
+          sceneRef.current.currentPszAction = pszAction;
+        }
+      }
     }
-  }, [selectedAnimation]);
+  }, [selectedAnimation, playOnBoth, mappings, buildRetargetedClip]);
 
   useEffect(() => {
     if (sceneRef.current?.currentAction) sceneRef.current.currentAction.paused = !isPlaying;
+    if (sceneRef.current?.currentPszAction) sceneRef.current.currentPszAction.paused = !isPlaying;
   }, [isPlaying]);
 
   const addMapping = useCallback(() => {
@@ -351,7 +408,9 @@ export default function RetargetViewer() {
             <span style={{ fontSize: '14px', fontWeight: 'bold' }}>
               <span style={{ color: pszLoaded ? '#44ff44' : '#666' }}>PSZ {!pszLoaded && '(loading...)'}</span>
               {' vs '}
-              <span style={{ color: psoLoaded ? '#ff4444' : '#666' }}>PSO {!psoLoaded && '(loading ~55MB...)'}</span>
+              <span style={{ color: psoLoaded ? '#ff4444' : psoLoadError ? '#ff6666' : '#666' }}>
+                PSO {psoLoadError ? '(FAILED)' : !psoLoaded ? `(loading ${psoLoadProgress}%...)` : ''}
+              </span>
               {' Skeleton Comparison'}
             </span>
             <div style={{ display: 'flex', gap: '8px' }}>
@@ -363,9 +422,19 @@ export default function RetargetViewer() {
                 <input type="checkbox" checked={showLabels} onChange={(e) => setShowLabels(e.target.checked)} />
                 Labels
               </label>
+              <label style={{ fontSize: '11px', color: Object.keys(mappings).length > 0 ? '#8888ff' : '#555', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <input type="checkbox" checked={playOnBoth} onChange={(e) => setPlayOnBoth(e.target.checked)} disabled={Object.keys(mappings).length === 0} />
+                Retarget
+              </label>
             </div>
           </div>
-          <div style={{ flex: 1, background: '#0a0a1a', borderRadius: '8px', overflow: 'hidden' }} ref={containerRef} />
+          <div style={{ flex: 1, background: '#0a0a1a', borderRadius: '8px', overflow: 'hidden', position: 'relative' }} ref={containerRef}>
+            {psoLoadError && (
+              <div style={{ position: 'absolute', bottom: 12, left: 12, right: 12, padding: '8px 12px', background: 'rgba(100,20,20,0.9)', borderRadius: '6px', fontSize: '11px', color: '#f88' }}>
+                {psoLoadError}
+              </div>
+            )}
+          </div>
 
           {/* Mapping controls */}
           <div style={{

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -9,7 +9,7 @@ const PSZ_MODEL_PATH = assetUrl('/player/pc_000/pc_000/pc_000_000.glb');
 const PSZ_TEXTURE_PATH = assetUrl('/player/pc_000/textures/pc_000_000.png');
 
 // PSO model — Humar with all animations
-const PSO_MODEL_PATH = '/data/retarget/Humar_body.glb';
+const PSO_MODEL_PATH = assetUrl('/data/retarget/Humar_body.glb');
 
 interface BoneInfo {
   name: string;
@@ -108,6 +108,8 @@ export default function RetargetViewer() {
   const [showMeshes, setShowMeshes] = useState(true);
   const [showLabels, setShowLabels] = useState(true);
   const [mappings, setMappings] = useState<Record<string, string>>({});
+  const [pszLoaded, setPszLoaded] = useState(false);
+  const [psoLoaded, setPsoLoaded] = useState(false);
 
   // Initialize Three.js scene
   useEffect(() => {
@@ -193,6 +195,7 @@ export default function RetargetViewer() {
       // Need to update world matrices before collecting bone positions
       model.updateMatrixWorld(true);
       setPszBones(collectBones(model));
+      setPszLoaded(true);
     });
 
     // PSO model on the right
@@ -216,6 +219,7 @@ export default function RetargetViewer() {
 
       model.updateMatrixWorld(true);
       setPsoBones(collectBones(model));
+      setPsoLoaded(true);
     });
 
     return () => {
@@ -345,9 +349,9 @@ export default function RetargetViewer() {
             display: 'flex', justifyContent: 'space-between', alignItems: 'center',
           }}>
             <span style={{ fontSize: '14px', fontWeight: 'bold' }}>
-              <span style={{ color: '#44ff44' }}>PSZ</span>
+              <span style={{ color: pszLoaded ? '#44ff44' : '#666' }}>PSZ {!pszLoaded && '(loading...)'}</span>
               {' vs '}
-              <span style={{ color: '#ff4444' }}>PSO</span>
+              <span style={{ color: psoLoaded ? '#ff4444' : '#666' }}>PSO {!psoLoaded && '(loading ~55MB...)'}</span>
               {' Skeleton Comparison'}
             </span>
             <div style={{ display: 'flex', gap: '8px' }}>

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -676,24 +676,17 @@ export default function RetargetViewer() {
       const pszBoneName = boneMap[boneName];
       if (!pszBoneName) continue;
 
-      // Conjugation approach: re-express the local animation delta in PSZ's bone frame
-      // localDelta = inv(psoLocalRest) * psoLocalAnim  (delta in PSO bone frame)
-      // F = inv(pszWorldRest) * psoWorldRest            (frame correction PSO -> PSZ)
-      // pszLocal = pszLocalRest * F * localDelta * inv(F)
-      //
-      // Precompute per-bone constants:
-      //   prefix = pszLocalRest * F * inv(psoLocalRest)
-      //   suffix = inv(F)
-      // Then per keyframe: pszLocal = prefix * psoLocalAnim * suffix
-      const psoLocalRest = psoRest.localQuats[boneName] || identity;
-      const pszLocalRest = pszRest.localQuats[pszBoneName] || identity;
-      const psoWorldRest = getWorldRestQuat(boneName, psoRest);
-      const pszWorldRest = getWorldRestQuat(pszBoneName, pszRest);
-
-      const F = pszWorldRest.clone().invert().multiply(psoWorldRest);
-      const Finv = F.clone().invert();
-      const prefix = pszLocalRest.clone().multiply(F).multiply(psoLocalRest.clone().invert());
-      const suffix = Finv;
+      // Absolute world-space approach: match PSO's bone world orientation on PSZ.
+      // psoWorldAnim = psoParentWorldRest * psoLocalAnim
+      // pszLocal = inv(pszParentWorldRest) * psoWorldAnim
+      //          = inv(pszParentWorldRest) * psoParentWorldRest * psoLocalAnim
+      //          = P * psoLocalAnim
+      // P is constant per bone — just 1 quat mul per keyframe.
+      const psoParent = psoRest.parentMap[boneName];
+      const pszParent = pszRest.parentMap[pszBoneName];
+      const psoParentWorldRest = psoParent ? getWorldRestQuat(psoParent, psoRest) : identity.clone();
+      const pszParentWorldRest = pszParent ? getWorldRestQuat(pszParent, pszRest) : identity.clone();
+      const P = pszParentWorldRest.clone().invert().multiply(psoParentWorldRest);
 
       const srcValues = track.values;
       const dstValues = new Float32Array(srcValues.length);
@@ -702,8 +695,8 @@ export default function RetargetViewer() {
       for (let i = 0; i < srcValues.length; i += 4) {
         psoLocalAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
 
-        // pszLocal = prefix * psoLocalAnim * suffix
-        const pszLocalResult = prefix.clone().multiply(psoLocalAnim).multiply(suffix);
+        // pszLocal = P * psoLocalAnim  (matches PSO's world orientation)
+        const pszLocalResult = P.clone().multiply(psoLocalAnim);
 
         dstValues[i] = pszLocalResult.x;
         dstValues[i + 1] = pszLocalResult.y;

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -493,7 +493,11 @@ export default function RetargetViewer() {
       model.updateMatrixWorld(true);
       setPszBones(collectBones(model));
       setPszLoaded(true);
-      if (sceneRef.current!.psoModel) matchPsoScaleToPsz(model, sceneRef.current!.psoModel);
+      if (sceneRef.current!.psoModel) {
+        matchPsoScaleToPsz(model, sceneRef.current!.psoModel);
+        sceneRef.current!.psoModel.updateMatrixWorld(true);
+        console.log('PSO scaled (from PSZ callback), scale:', sceneRef.current!.psoModel.scale.toArray());
+      }
     });
 
     // PSO model on the right
@@ -504,17 +508,28 @@ export default function RetargetViewer() {
         model.position.x = 1.2;
         scene.add(model);
         sceneRef.current!.psoModel = model;
+
+        // Scale BEFORE resetting to bind pose — animated pose gives reliable bounding box
+        model.updateMatrixWorld(true);
+        if (sceneRef.current!.pszModel) {
+          matchPsoScaleToPsz(sceneRef.current!.pszModel, model);
+          model.updateMatrixWorld(true);
+        }
+
+        // Now reset to T-pose
         resetToBindPose(model);
+
         const helper = createSkeletonHelper(model, 0xff4444);
         if (helper) { scene.add(helper); sceneRef.current!.psoHelper = helper; }
         const mixer = new THREE.AnimationMixer(model);
         sceneRef.current!.psoMixer = mixer;
         sceneRef.current!.psoAnimations = gltf.animations;
         setPsoAnimations(gltf.animations.map((a) => a.name));
-        if (sceneRef.current!.pszModel) matchPsoScaleToPsz(sceneRef.current!.pszModel, model);
+
         model.updateMatrixWorld(true);
         setPsoBones(collectBones(model));
         setPsoLoaded(true);
+        console.log('PSO loaded, scale:', model.scale.toArray(), 'position:', model.position.toArray());
       },
       (progress) => {
         if (progress.total > 0) setPsoLoadProgress(Math.round((progress.loaded / progress.total) * 100));

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -676,19 +676,24 @@ export default function RetargetViewer() {
       const pszBoneName = boneMap[boneName];
       if (!pszBoneName) continue;
 
-      // World-space approach:
-      // 1. Get PSO parent's world rest quat to convert PSO local anim -> world
-      // 2. Get PSZ parent's world rest quat to convert world -> PSZ local
-      const psoParent = psoRest.parentMap[boneName];
-      const pszParent = pszRest.parentMap[pszBoneName];
-      const psoParentWorldRest = psoParent ? getWorldRestQuat(psoParent, psoRest) : identity.clone();
-      const pszParentWorldRest = pszParent ? getWorldRestQuat(pszParent, pszRest) : identity.clone();
-      const pszParentWorldRestInv = pszParentWorldRest.clone().invert();
-
-      // PSO local rest and PSZ local rest for this bone
+      // Conjugation approach: re-express the local animation delta in PSZ's bone frame
+      // localDelta = inv(psoLocalRest) * psoLocalAnim  (delta in PSO bone frame)
+      // F = inv(pszWorldRest) * psoWorldRest            (frame correction PSO -> PSZ)
+      // pszLocal = pszLocalRest * F * localDelta * inv(F)
+      //
+      // Precompute per-bone constants:
+      //   prefix = pszLocalRest * F * inv(psoLocalRest)
+      //   suffix = inv(F)
+      // Then per keyframe: pszLocal = prefix * psoLocalAnim * suffix
       const psoLocalRest = psoRest.localQuats[boneName] || identity;
-      const psoLocalRestInv = psoLocalRest.clone().invert();
       const pszLocalRest = pszRest.localQuats[pszBoneName] || identity;
+      const psoWorldRest = getWorldRestQuat(boneName, psoRest);
+      const pszWorldRest = getWorldRestQuat(pszBoneName, pszRest);
+
+      const F = pszWorldRest.clone().invert().multiply(psoWorldRest);
+      const Finv = F.clone().invert();
+      const prefix = pszLocalRest.clone().multiply(F).multiply(psoLocalRest.clone().invert());
+      const suffix = Finv;
 
       const srcValues = track.values;
       const dstValues = new Float32Array(srcValues.length);
@@ -697,20 +702,8 @@ export default function RetargetViewer() {
       for (let i = 0; i < srcValues.length; i += 4) {
         psoLocalAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
 
-        // PSO local anim -> world: psoParentWorld * psoLocalAnim
-        const psoWorld = psoParentWorldRest.clone().multiply(psoLocalAnim);
-
-        // Extract delta in world space: how does this differ from PSO rest world?
-        const psoWorldRest = psoParentWorldRest.clone().multiply(psoLocalRest);
-        const psoWorldRestInv = psoWorldRest.clone().invert();
-        const worldDelta = psoWorldRestInv.clone().premultiply(psoWorld);
-        // worldDelta = psoWorld * inv(psoWorldRest) — rotation change in world space
-
-        // Apply world delta to PSZ world rest, then convert to PSZ local
-        const pszWorldRest = pszParentWorldRest.clone().multiply(pszLocalRest);
-        const pszWorldAnimated = pszWorldRest.clone().multiply(worldDelta);
-        // Convert back to local: pszLocal = inv(pszParentWorld) * pszWorld
-        const pszLocalResult = pszParentWorldRestInv.clone().multiply(pszWorldAnimated);
+        // pszLocal = prefix * psoLocalAnim * suffix
+        const pszLocalResult = prefix.clone().multiply(psoLocalAnim).multiply(suffix);
 
         dstValues[i] = pszLocalResult.x;
         dstValues[i + 1] = pszLocalResult.y;

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -659,7 +659,28 @@ export default function RetargetViewer() {
 
   const buildRetargetedClip = useCallback((clip: THREE.AnimationClip, boneMap: Record<string, string>): THREE.AnimationClip | null => {
     if (!sceneRef.current || Object.keys(boneMap).length === 0) return null;
-    const { psoRest, pszRest } = sceneRef.current;
+    const { psoRest, pszRest: pszRestOriginal } = sceneRef.current;
+
+    // Create a modified copy of PSZ rest data with arm bones adjusted to match
+    // PSO's rest orientation. PSO has arms at sides, PSZ has arms at 45° —
+    // without this correction the conjugation overshoots arm animations.
+    const pszRest: RestPoseData = {
+      localQuats: { ...pszRestOriginal.localQuats },
+      worldQuats: { ...pszRestOriginal.worldQuats },
+      parentMap: pszRestOriginal.parentMap,
+    };
+    const armBones: [string, string][] = [
+      ['bone_028', '030_LArm01'],
+      ['bone_041', '060_RArm01'],
+    ];
+    for (const [psoBone, pszBone] of armBones) {
+      if (!(psoBone in boneMap) || boneMap[psoBone] !== pszBone) continue;
+      const pszParent = pszRest.parentMap[pszBone];
+      const pszParentWorld = pszParent ? getWorldRestQuat(pszParent, pszRest) : new THREE.Quaternion();
+      const psoArmWorld = getWorldRestQuat(psoBone, psoRest);
+      // Set PSZ arm local rest so its world orientation matches PSO's
+      pszRest.localQuats[pszBone] = pszParentWorld.clone().invert().multiply(psoArmWorld);
+    }
 
     const tracks: THREE.KeyframeTrack[] = [];
     const identity = new THREE.Quaternion();

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -4,11 +4,8 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { assetUrl } from '../utils/assets';
 
-// PSZ model — using humar (pc_000) as reference
 const PSZ_MODEL_PATH = assetUrl('/player/pc_000/pc_000/pc_000_000.glb');
 const PSZ_TEXTURE_PATH = assetUrl('/player/pc_000/textures/pc_000_000.png');
-
-// PSO model — Humar with all animations
 const PSO_MODEL_PATH = assetUrl('/data/retarget/Humar_body.glb');
 
 const BONE_MARKER_RADIUS = 0.012;
@@ -20,10 +17,44 @@ interface BoneInfo {
   bone: THREE.Bone;
 }
 
+interface BoneTreeNode {
+  info: BoneInfo;
+  children: BoneTreeNode[];
+}
+
 interface BoneMarker {
   mesh: THREE.Mesh;
   boneName: string;
   side: 'psz' | 'pso';
+}
+
+// Build a tree from the flat depth-ordered bone list
+function buildBoneTree(bones: BoneInfo[]): BoneTreeNode[] {
+  const roots: BoneTreeNode[] = [];
+  const stack: BoneTreeNode[] = [];
+  for (const bone of bones) {
+    const node: BoneTreeNode = { info: bone, children: [] };
+    while (stack.length > 0 && stack[stack.length - 1].info.depth >= bone.depth) {
+      stack.pop();
+    }
+    if (stack.length === 0) {
+      roots.push(node);
+    } else {
+      stack[stack.length - 1].children.push(node);
+    }
+    stack.push(node);
+  }
+  return roots;
+}
+
+// Collect all descendant bone names (for hiding subtrees)
+function collectDescendantNames(node: BoneTreeNode): string[] {
+  const names: string[] = [];
+  for (const child of node.children) {
+    names.push(child.info.name);
+    names.push(...collectDescendantNames(child));
+  }
+  return names;
 }
 
 function collectBones(root: THREE.Object3D): BoneInfo[] {
@@ -58,8 +89,7 @@ function matchPsoScaleToPsz(pszModel: THREE.Object3D, psoModel: THREE.Object3D):
   const pszHeight = pszBox.max.y - pszBox.min.y;
   const psoHeight = psoBox.max.y - psoBox.min.y;
   if (psoHeight > 0 && pszHeight > 0) {
-    const scale = pszHeight / psoHeight;
-    psoModel.scale.multiplyScalar(scale);
+    psoModel.scale.multiplyScalar(pszHeight / psoHeight);
   }
 }
 
@@ -84,10 +114,12 @@ function createBoneMarkers(
   selectedBone: string | null,
   scene: THREE.Scene,
   side: 'psz' | 'pso',
+  disabledBones?: Set<string>,
 ): BoneMarker[] {
   const markers: BoneMarker[] = [];
   const geo = new THREE.SphereGeometry(BONE_MARKER_RADIUS, 8, 6);
   for (const bone of bones) {
+    if (disabledBones?.has(bone.name)) continue;
     const isSelected = bone.name === selectedBone;
     const mat = new THREE.MeshBasicMaterial({
       color: isSelected ? 0xffff00 : color,
@@ -101,6 +133,25 @@ function createBoneMarkers(
     markers.push({ mesh, boneName: bone.name, side });
   }
   return markers;
+}
+
+function createSelectedLabel(bone: BoneInfo, color: string, scene: THREE.Scene): THREE.Sprite {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 64;
+  const ctx = canvas.getContext('2d')!;
+  ctx.font = 'bold 24px monospace';
+  ctx.fillStyle = color;
+  ctx.fillText(bone.name, 4, 28);
+  const texture = new THREE.CanvasTexture(canvas);
+  const material = new THREE.SpriteMaterial({ map: texture, depthTest: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(1.6, 0.2, 1);
+  sprite.position.copy(bone.worldPos);
+  sprite.position.y += 0.06;
+  sprite.renderOrder = 1000;
+  scene.add(sprite);
+  return sprite;
 }
 
 interface SceneState {
@@ -118,6 +169,127 @@ interface SceneState {
   currentAction: THREE.AnimationAction | null;
   currentPszAction: THREE.AnimationAction | null;
   boneMarkers: BoneMarker[];
+  selectedLabels: THREE.Sprite[];
+}
+
+// Collapsible bone tree row component
+function BoneTreeRow({
+  node,
+  selectedBone,
+  onSelect,
+  collapsed,
+  onToggleCollapse,
+  color,
+  selectedColor,
+  mappings,
+  disabledBones,
+  onToggleDisable,
+  side,
+}: {
+  node: BoneTreeNode;
+  selectedBone: string | null;
+  onSelect: (name: string) => void;
+  collapsed: Set<string>;
+  onToggleCollapse: (name: string) => void;
+  color: string;
+  selectedColor: string;
+  mappings?: Record<string, string>;
+  disabledBones?: Set<string>;
+  onToggleDisable?: (name: string) => void;
+  side: 'psz' | 'pso';
+}) {
+  const isSelected = selectedBone === node.info.name;
+  const isCollapsed = collapsed.has(node.info.name);
+  const hasChildren = node.children.length > 0;
+  const isDisabled = disabledBones?.has(node.info.name);
+  const isMapped = mappings && node.info.name in mappings;
+
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
+        {/* Collapse toggle */}
+        {hasChildren ? (
+          <button
+            onClick={(e) => { e.stopPropagation(); onToggleCollapse(node.info.name); }}
+            style={{
+              width: '14px', height: '14px', padding: 0,
+              background: 'transparent', border: 'none',
+              color: '#666', cursor: 'pointer', fontSize: '9px',
+              flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}
+          >
+            {isCollapsed ? '\u25b6' : '\u25bc'}
+          </button>
+        ) : (
+          <span style={{ width: '14px', flexShrink: 0 }} />
+        )}
+
+        {/* Disable toggle (PSO only) */}
+        {onToggleDisable && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onToggleDisable(node.info.name); }}
+            title={isDisabled ? 'Show bone' : 'Hide bone'}
+            style={{
+              width: '14px', height: '14px', padding: 0,
+              background: 'transparent', border: 'none',
+              color: isDisabled ? '#555' : '#888', cursor: 'pointer', fontSize: '10px',
+              flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              opacity: isDisabled ? 0.5 : 1,
+            }}
+          >
+            {isDisabled ? '\u25cb' : '\u25cf'}
+          </button>
+        )}
+
+        {/* Bone name button */}
+        <button
+          onClick={() => onSelect(node.info.name)}
+          style={{
+            flex: 1,
+            padding: '3px 6px',
+            paddingLeft: `${4 + node.info.depth * 10}px`,
+            background: isSelected ? (side === 'psz' ? '#2a4a2a' : '#4a2a2a') : isMapped ? '#2a2a3a' : 'transparent',
+            border: isSelected ? `1px solid ${selectedColor}` : '1px solid transparent',
+            borderRadius: '3px',
+            color: isDisabled ? '#444' : isSelected ? selectedColor : isMapped ? '#8888ff' : '#aaa',
+            cursor: 'pointer',
+            fontSize: '11px',
+            textAlign: 'left',
+            fontFamily: 'monospace',
+            textDecoration: isDisabled ? 'line-through' : 'none',
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {node.info.name}
+          {isMapped && (
+            <span style={{ color: '#44ff44', fontSize: '9px', marginLeft: '4px' }}>
+              &rarr; {mappings![node.info.name]}
+            </span>
+          )}
+        </button>
+      </div>
+      {/* Children */}
+      {hasChildren && !isCollapsed && node.children.map((child) => (
+        <BoneTreeRow
+          key={child.info.name}
+          node={child}
+          selectedBone={selectedBone}
+          onSelect={onSelect}
+          collapsed={collapsed}
+          onToggleCollapse={onToggleCollapse}
+          color={color}
+          selectedColor={selectedColor}
+          mappings={mappings}
+          disabledBones={disabledBones}
+          onToggleDisable={onToggleDisable}
+          side={side}
+        />
+      ))}
+    </>
+  );
 }
 
 export default function RetargetViewer() {
@@ -141,6 +313,46 @@ export default function RetargetViewer() {
   const [psoLoadProgress, setPsoLoadProgress] = useState(0);
   const [playOnBoth, setPlayOnBoth] = useState(false);
   const [hoveredBone, setHoveredBone] = useState<{ name: string; side: 'psz' | 'pso' } | null>(null);
+  const [pszCollapsed, setPszCollapsed] = useState<Set<string>>(new Set());
+  const [psoCollapsed, setPsoCollapsed] = useState<Set<string>>(new Set());
+  const [disabledPsoBones, setDisabledPsoBones] = useState<Set<string>>(new Set());
+
+  const pszTree = buildBoneTree(pszBones);
+  const psoTree = buildBoneTree(psoBones);
+
+  const toggleCollapse = useCallback((setFn: React.Dispatch<React.SetStateAction<Set<string>>>) => (name: string) => {
+    setFn((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
+
+  const toggleDisablePsoBone = useCallback((name: string) => {
+    setDisabledPsoBones((prev) => {
+      const next = new Set(prev);
+      // Find the node to also toggle descendants
+      const findNode = (nodes: BoneTreeNode[]): BoneTreeNode | null => {
+        for (const n of nodes) {
+          if (n.info.name === name) return n;
+          const found = findNode(n.children);
+          if (found) return found;
+        }
+        return null;
+      };
+      const node = findNode(psoTree);
+      const names = [name];
+      if (node) names.push(...collectDescendantNames(node));
+
+      const willDisable = !prev.has(name);
+      for (const n of names) {
+        if (willDisable) next.add(n);
+        else next.delete(n);
+      }
+      return next;
+    });
+  }, [psoTree]);
 
   // Initialize Three.js scene
   useEffect(() => {
@@ -172,7 +384,7 @@ export default function RetargetViewer() {
       pszModel: null, psoModel: null,
       pszHelper: null, psoHelper: null,
       psoMixer: null, pszMixer: null, psoAnimations: [],
-      currentAction: null, currentPszAction: null, boneMarkers: [],
+      currentAction: null, currentPszAction: null, boneMarkers: [], selectedLabels: [],
     };
 
     const clock = new THREE.Clock();
@@ -186,7 +398,6 @@ export default function RetargetViewer() {
     };
     animate();
 
-    // Raycasting for hover/click on bone markers
     const raycaster = new THREE.Raycaster();
     const mouse = new THREE.Vector2();
 
@@ -194,12 +405,10 @@ export default function RetargetViewer() {
       const rect = renderer.domElement.getBoundingClientRect();
       mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
       mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-
       if (!sceneRef.current) return;
       raycaster.setFromCamera(mouse, camera);
       const markerMeshes = sceneRef.current.boneMarkers.map((m) => m.mesh);
       const intersects = raycaster.intersectObjects(markerMeshes);
-
       if (tooltipRef.current) {
         if (intersects.length > 0) {
           const hit = intersects[0].object;
@@ -221,12 +430,10 @@ export default function RetargetViewer() {
       const rect = renderer.domElement.getBoundingClientRect();
       mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
       mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-
       if (!sceneRef.current) return;
       raycaster.setFromCamera(mouse, camera);
       const markerMeshes = sceneRef.current.boneMarkers.map((m) => m.mesh);
       const intersects = raycaster.intersectObjects(markerMeshes);
-
       if (intersects.length > 0) {
         const hit = intersects[0].object;
         const { boneName, side } = hit.userData;
@@ -247,7 +454,6 @@ export default function RetargetViewer() {
     };
     window.addEventListener('resize', handleResize);
 
-    // Load both models
     const loader = new GLTFLoader();
     const textureLoader = new THREE.TextureLoader();
 
@@ -257,7 +463,6 @@ export default function RetargetViewer() {
       model.position.x = -1.2;
       scene.add(model);
       sceneRef.current!.pszModel = model;
-
       textureLoader.load(PSZ_TEXTURE_PATH, (texture) => {
         texture.magFilter = THREE.NearestFilter;
         texture.minFilter = THREE.NearestFilter;
@@ -265,27 +470,17 @@ export default function RetargetViewer() {
         texture.colorSpace = THREE.SRGBColorSpace;
         model.traverse((child: THREE.Object3D) => {
           if ((child as THREE.Mesh).isMesh) {
-            const mat = new THREE.MeshBasicMaterial({ map: texture });
-            (child as THREE.Mesh).material = mat;
+            (child as THREE.Mesh).material = new THREE.MeshBasicMaterial({ map: texture });
           }
         });
       });
-
       const helper = createSkeletonHelper(model, 0x44ff44);
-      if (helper) {
-        scene.add(helper);
-        sceneRef.current!.pszHelper = helper;
-      }
-      const pszMixer = new THREE.AnimationMixer(model);
-      sceneRef.current!.pszMixer = pszMixer;
-
+      if (helper) { scene.add(helper); sceneRef.current!.pszHelper = helper; }
+      sceneRef.current!.pszMixer = new THREE.AnimationMixer(model);
       model.updateMatrixWorld(true);
       setPszBones(collectBones(model));
       setPszLoaded(true);
-
-      if (sceneRef.current!.psoModel) {
-        matchPsoScaleToPsz(model, sceneRef.current!.psoModel);
-      }
+      if (sceneRef.current!.psoModel) matchPsoScaleToPsz(model, sceneRef.current!.psoModel);
     });
 
     // PSO model on the right
@@ -296,35 +491,20 @@ export default function RetargetViewer() {
         model.position.x = 1.2;
         scene.add(model);
         sceneRef.current!.psoModel = model;
-
-        // Reset to T-pose (bind pose)
         resetToBindPose(model);
-
         const helper = createSkeletonHelper(model, 0xff4444);
-        if (helper) {
-          scene.add(helper);
-          sceneRef.current!.psoHelper = helper;
-        }
-
+        if (helper) { scene.add(helper); sceneRef.current!.psoHelper = helper; }
         const mixer = new THREE.AnimationMixer(model);
         sceneRef.current!.psoMixer = mixer;
         sceneRef.current!.psoAnimations = gltf.animations;
-        const animNames = gltf.animations.map((a) => a.name);
-        setPsoAnimations(animNames);
-
-        // Scale PSO to match PSZ height
-        if (sceneRef.current!.pszModel) {
-          matchPsoScaleToPsz(sceneRef.current!.pszModel, model);
-        }
-
+        setPsoAnimations(gltf.animations.map((a) => a.name));
+        if (sceneRef.current!.pszModel) matchPsoScaleToPsz(sceneRef.current!.pszModel, model);
         model.updateMatrixWorld(true);
         setPsoBones(collectBones(model));
         setPsoLoaded(true);
       },
       (progress) => {
-        if (progress.total > 0) {
-          setPsoLoadProgress(Math.round((progress.loaded / progress.total) * 100));
-        }
+        if (progress.total > 0) setPsoLoadProgress(Math.round((progress.loaded / progress.total) * 100));
       },
       (error) => {
         console.error('Failed to load PSO model:', error);
@@ -337,47 +517,54 @@ export default function RetargetViewer() {
       renderer.domElement.removeEventListener('mousemove', onMouseMove);
       renderer.domElement.removeEventListener('click', onClick);
       renderer.dispose();
-      if (container.contains(renderer.domElement)) {
-        container.removeChild(renderer.domElement);
-      }
+      if (container.contains(renderer.domElement)) container.removeChild(renderer.domElement);
     };
   }, []);
 
-  // Update bone markers when selection or bones change
+  // Update bone markers + selected labels
   useEffect(() => {
     if (!sceneRef.current) return;
-    const { scene, boneMarkers } = sceneRef.current;
+    const { scene, boneMarkers, selectedLabels } = sceneRef.current;
 
-    // Remove old markers
     for (const marker of boneMarkers) scene.remove(marker.mesh);
+    for (const label of selectedLabels) { scene.remove(label); label.material.map?.dispose(); (label.material as THREE.SpriteMaterial).dispose(); }
 
     if (!showMarkers) {
       sceneRef.current.boneMarkers = [];
+      sceneRef.current.selectedLabels = [];
       return;
     }
 
     const pszMarkers = createBoneMarkers(pszBones, 0x44ff44, selectedPszBone, scene, 'psz');
-    const psoMarkers = createBoneMarkers(psoBones, 0xff4444, selectedPsoBone, scene, 'pso');
+    const psoMarkers = createBoneMarkers(psoBones, 0xff4444, selectedPsoBone, scene, 'pso', disabledPsoBones);
     sceneRef.current.boneMarkers = [...pszMarkers, ...psoMarkers];
-  }, [pszBones, psoBones, selectedPszBone, selectedPsoBone, showMarkers]);
+
+    // Add 3D labels for selected bones
+    const newLabels: THREE.Sprite[] = [];
+    if (selectedPszBone) {
+      const bone = pszBones.find((b) => b.name === selectedPszBone);
+      if (bone) newLabels.push(createSelectedLabel(bone, '#44ff44', scene));
+    }
+    if (selectedPsoBone) {
+      const bone = psoBones.find((b) => b.name === selectedPsoBone);
+      if (bone && !disabledPsoBones.has(bone.name)) newLabels.push(createSelectedLabel(bone, '#ff4444', scene));
+    }
+    sceneRef.current.selectedLabels = newLabels;
+  }, [pszBones, psoBones, selectedPszBone, selectedPsoBone, showMarkers, disabledPsoBones]);
 
   // Toggle meshes visibility
   useEffect(() => {
     if (!sceneRef.current) return;
-    const { pszModel, psoModel } = sceneRef.current;
-    const toggleMeshes = (model: THREE.Object3D | null) => {
+    const toggle = (model: THREE.Object3D | null) => {
       if (!model) return;
       model.traverse((child) => {
-        if ((child as THREE.Mesh).isMesh) {
-          (child as THREE.Mesh).visible = showMeshes;
-        }
+        if ((child as THREE.Mesh).isMesh) (child as THREE.Mesh).visible = showMeshes;
       });
     };
-    toggleMeshes(pszModel);
-    toggleMeshes(psoModel);
+    toggle(sceneRef.current.pszModel);
+    toggle(sceneRef.current.psoModel);
   }, [showMeshes]);
 
-  // Build a retargeted clip that maps PSO bone tracks -> PSZ bone names
   const buildRetargetedClip = useCallback((clip: THREE.AnimationClip, boneMap: Record<string, string>): THREE.AnimationClip | null => {
     if (Object.keys(boneMap).length === 0) return null;
     const tracks: THREE.KeyframeTrack[] = [];
@@ -397,13 +584,11 @@ export default function RetargetViewer() {
     return new THREE.AnimationClip(clip.name + '_retargeted', clip.duration, tracks);
   }, []);
 
-  // Play animation on PSO model (and optionally retarget to PSZ)
   useEffect(() => {
     if (!sceneRef.current?.psoMixer || !selectedAnimation) return;
     const { psoMixer, pszMixer, psoAnimations, currentAction, currentPszAction } = sceneRef.current;
     if (currentAction) currentAction.fadeOut(0.2);
     if (currentPszAction) currentPszAction.fadeOut(0.2);
-
     const clip = psoAnimations.find((a) => a.name === selectedAnimation);
     if (clip) {
       const action = psoMixer.clipAction(clip);
@@ -411,7 +596,6 @@ export default function RetargetViewer() {
       action.setLoop(THREE.LoopRepeat, Infinity);
       action.paused = !isPlaying;
       sceneRef.current.currentAction = action;
-
       if (playOnBoth && pszMixer) {
         const retargeted = buildRetargetedClip(clip, mappings);
         if (retargeted) {
@@ -437,16 +621,11 @@ export default function RetargetViewer() {
   }, [selectedPszBone, selectedPsoBone]);
 
   const removeMapping = useCallback((psoKey: string) => {
-    setMappings((prev) => {
-      const next = { ...prev };
-      delete next[psoKey];
-      return next;
-    });
+    setMappings((prev) => { const next = { ...prev }; delete next[psoKey]; return next; });
   }, []);
 
   const exportMappings = useCallback(() => {
-    const json = JSON.stringify(mappings, null, 2);
-    navigator.clipboard.writeText(json);
+    navigator.clipboard.writeText(JSON.stringify(mappings, null, 2));
   }, [mappings]);
 
   return (
@@ -457,26 +636,19 @@ export default function RetargetViewer() {
           <h3 style={{ fontSize: '12px', color: '#44ff44', margin: '0 0 10px 0', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
             PSZ Bones ({pszBones.length})
           </h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-            {pszBones.map((bone) => (
-              <button
-                key={bone.name}
-                onClick={() => setSelectedPszBone(bone.name)}
-                style={{
-                  padding: '4px 8px',
-                  paddingLeft: `${8 + bone.depth * 12}px`,
-                  background: selectedPszBone === bone.name ? '#2a4a2a' : 'transparent',
-                  border: selectedPszBone === bone.name ? '1px solid #44ff44' : '1px solid transparent',
-                  borderRadius: '3px',
-                  color: selectedPszBone === bone.name ? '#44ff44' : '#aaa',
-                  cursor: 'pointer',
-                  fontSize: '11px',
-                  textAlign: 'left',
-                  fontFamily: 'monospace',
-                }}
-              >
-                {bone.name}
-              </button>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
+            {pszTree.map((node) => (
+              <BoneTreeRow
+                key={node.info.name}
+                node={node}
+                selectedBone={selectedPszBone}
+                onSelect={setSelectedPszBone}
+                collapsed={pszCollapsed}
+                onToggleCollapse={toggleCollapse(setPszCollapsed)}
+                color="#aaa"
+                selectedColor="#44ff44"
+                side="psz"
+              />
             ))}
           </div>
         </div>
@@ -511,22 +683,15 @@ export default function RetargetViewer() {
             </div>
           </div>
           <div style={{ flex: 1, background: '#0a0a1a', borderRadius: '8px', overflow: 'hidden', position: 'relative' }} ref={containerRef}>
-            {/* Hover tooltip */}
             <div
               ref={tooltipRef}
               style={{
-                display: 'none',
-                position: 'absolute',
-                pointerEvents: 'none',
-                padding: '4px 8px',
-                background: 'rgba(0,0,0,0.85)',
+                display: 'none', position: 'absolute', pointerEvents: 'none',
+                padding: '4px 8px', background: 'rgba(0,0,0,0.85)',
                 border: `1px solid ${hoveredBone?.side === 'psz' ? '#44ff44' : '#ff4444'}`,
-                borderRadius: '4px',
-                fontSize: '11px',
-                fontFamily: 'monospace',
+                borderRadius: '4px', fontSize: '11px', fontFamily: 'monospace',
                 color: hoveredBone?.side === 'psz' ? '#44ff44' : '#ff4444',
-                zIndex: 10,
-                whiteSpace: 'nowrap',
+                zIndex: 10, whiteSpace: 'nowrap',
               }}
             >
               {hoveredBone && (
@@ -583,38 +748,28 @@ export default function RetargetViewer() {
         <div style={{ width: '280px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
           {/* PSO Bones */}
           <div style={{ flex: 1, background: '#2d2d44', borderRadius: '8px', padding: '12px', overflowY: 'auto' }}>
-            <h3 style={{ fontSize: '12px', color: '#ff4444', margin: '0 0 10px 0', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-              PSO Bones ({psoBones.length})
-            </h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-              {psoBones.map((bone) => {
-                const isMapped = bone.name in mappings;
-                return (
-                  <button
-                    key={bone.name}
-                    onClick={() => setSelectedPsoBone(bone.name)}
-                    style={{
-                      padding: '4px 8px',
-                      paddingLeft: `${8 + bone.depth * 12}px`,
-                      background: selectedPsoBone === bone.name ? '#4a2a2a' : isMapped ? '#2a2a3a' : 'transparent',
-                      border: selectedPsoBone === bone.name ? '1px solid #ff4444' : '1px solid transparent',
-                      borderRadius: '3px',
-                      color: selectedPsoBone === bone.name ? '#ff4444' : isMapped ? '#8888ff' : '#aaa',
-                      cursor: 'pointer',
-                      fontSize: '11px',
-                      textAlign: 'left',
-                      fontFamily: 'monospace',
-                    }}
-                  >
-                    {bone.name}
-                    {isMapped && (
-                      <span style={{ color: '#44ff44', fontSize: '9px', marginLeft: '6px' }}>
-                        &rarr; {mappings[bone.name]}
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+              <h3 style={{ fontSize: '12px', color: '#ff4444', margin: 0, textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                PSO Bones ({psoBones.length - disabledPsoBones.size}/{psoBones.length})
+              </h3>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
+              {psoTree.map((node) => (
+                <BoneTreeRow
+                  key={node.info.name}
+                  node={node}
+                  selectedBone={selectedPsoBone}
+                  onSelect={setSelectedPsoBone}
+                  collapsed={psoCollapsed}
+                  onToggleCollapse={toggleCollapse(setPsoCollapsed)}
+                  color="#aaa"
+                  selectedColor="#ff4444"
+                  mappings={mappings}
+                  disabledBones={disabledPsoBones}
+                  onToggleDisable={toggleDisablePsoBone}
+                  side="pso"
+                />
+              ))}
             </div>
           </div>
 
@@ -646,10 +801,7 @@ export default function RetargetViewer() {
                     border: selectedAnimation === name ? '1px solid #6b8afd' : '1px solid transparent',
                     borderRadius: '3px',
                     color: selectedAnimation === name ? '#fff' : '#aaa',
-                    cursor: 'pointer',
-                    fontSize: '10px',
-                    textAlign: 'left',
-                    fontFamily: 'monospace',
+                    cursor: 'pointer', fontSize: '10px', textAlign: 'left', fontFamily: 'monospace',
                   }}
                 >
                   {name}

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -306,7 +306,20 @@ export default function RetargetViewer() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [showMeshes, setShowMeshes] = useState(true);
   const [showMarkers, setShowMarkers] = useState(true);
-  const [mappings, setMappings] = useState<Record<string, string>>({});
+  const [mappings, setMappings] = useState<Record<string, string>>({
+    bone_000: '000_Root',
+    bone_002: '010_Hip',
+    bone_024: '020_Spine',
+    bone_028: '030_LArm01',
+    bone_029: '040_LArm02',
+    bone_041: '060_RArm01',
+    bone_042: '070_RArm02',
+    bone_056: '090_Head',
+    bone_004: '100_LLeg01',
+    bone_005: '110_LLeg02',
+    bone_013: '120_RLeg01',
+    bone_014: '130_RLeg02',
+  });
   const [pszLoaded, setPszLoaded] = useState(false);
   const [psoLoaded, setPsoLoaded] = useState(false);
   const [psoLoadError, setPsoLoadError] = useState<string | null>(null);

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -676,17 +676,24 @@ export default function RetargetViewer() {
       const pszBoneName = boneMap[boneName];
       if (!pszBoneName) continue;
 
-      // Absolute world-space approach: match PSO's bone world orientation on PSZ.
-      // psoWorldAnim = psoParentWorldRest * psoLocalAnim
-      // pszLocal = inv(pszParentWorldRest) * psoWorldAnim
-      //          = inv(pszParentWorldRest) * psoParentWorldRest * psoLocalAnim
-      //          = P * psoLocalAnim
-      // P is constant per bone — just 1 quat mul per keyframe.
-      const psoParent = psoRest.parentMap[boneName];
-      const pszParent = pszRest.parentMap[pszBoneName];
-      const psoParentWorldRest = psoParent ? getWorldRestQuat(psoParent, psoRest) : identity.clone();
-      const pszParentWorldRest = pszParent ? getWorldRestQuat(pszParent, pszRest) : identity.clone();
-      const P = pszParentWorldRest.clone().invert().multiply(psoParentWorldRest);
+      // Conjugation approach: re-express the local animation delta in PSZ's bone frame
+      // localDelta = inv(psoLocalRest) * psoLocalAnim  (delta in PSO bone frame)
+      // F = inv(pszWorldRest) * psoWorldRest            (frame correction PSO -> PSZ)
+      // pszLocal = pszLocalRest * F * localDelta * inv(F)
+      //
+      // Precompute per-bone constants:
+      //   prefix = pszLocalRest * F * inv(psoLocalRest)
+      //   suffix = inv(F)
+      // Then per keyframe: pszLocal = prefix * psoLocalAnim * suffix
+      const psoLocalRest = psoRest.localQuats[boneName] || identity;
+      const pszLocalRest = pszRest.localQuats[pszBoneName] || identity;
+      const psoWorldRest = getWorldRestQuat(boneName, psoRest);
+      const pszWorldRest = getWorldRestQuat(pszBoneName, pszRest);
+
+      const F = pszWorldRest.clone().invert().multiply(psoWorldRest);
+      const Finv = F.clone().invert();
+      const prefix = pszLocalRest.clone().multiply(F).multiply(psoLocalRest.clone().invert());
+      const suffix = Finv;
 
       const srcValues = track.values;
       const dstValues = new Float32Array(srcValues.length);
@@ -695,8 +702,8 @@ export default function RetargetViewer() {
       for (let i = 0; i < srcValues.length; i += 4) {
         psoLocalAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
 
-        // pszLocal = P * psoLocalAnim  (matches PSO's world orientation)
-        const pszLocalResult = P.clone().multiply(psoLocalAnim);
+        // pszLocal = prefix * psoLocalAnim * suffix
+        const pszLocalResult = prefix.clone().multiply(psoLocalAnim).multiply(suffix);
 
         dstValues[i] = pszLocalResult.x;
         dstValues[i + 1] = pszLocalResult.y;

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -729,8 +729,9 @@ export default function RetargetViewer() {
           Array.from(track.times),
           Array.from(dstValues),
         ));
-      } else if (prop === '.position') {
-        // Scale position tracks to match PSZ model size
+      } else if (prop === '.position' && boneName === 'bone_000') {
+        // Only transfer root bone position (walking/falling). Other bones have
+        // different rest offsets and bone lengths that would distort the mesh.
         const srcValues = track.values;
         const dstValues = new Float32Array(srcValues.length);
 

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -685,58 +685,67 @@ export default function RetargetViewer() {
     const tracks: THREE.KeyframeTrack[] = [];
     const identity = new THREE.Quaternion();
 
+    // Scale ratio for position tracks: PSO model was scaled to match PSZ height
+    const posScale = sceneRef.current.psoModel?.scale.x || 1;
+
     for (const track of clip.tracks) {
       const dotIdx = track.name.indexOf('.');
       if (dotIdx < 0) continue;
       const boneName = track.name.substring(0, dotIdx);
       const prop = track.name.substring(dotIdx);
 
-      // Only transfer rotation tracks
-      if (prop !== '.quaternion') continue;
-
       const pszBoneName = boneMap[boneName];
       if (!pszBoneName) continue;
 
-      // Conjugation approach: re-express the local animation delta in PSZ's bone frame
-      // localDelta = inv(psoLocalRest) * psoLocalAnim  (delta in PSO bone frame)
-      // F = inv(pszWorldRest) * psoWorldRest            (frame correction PSO -> PSZ)
-      // pszLocal = pszLocalRest * F * localDelta * inv(F)
-      //
-      // Precompute per-bone constants:
-      //   prefix = pszLocalRest * F * inv(psoLocalRest)
-      //   suffix = inv(F)
-      // Then per keyframe: pszLocal = prefix * psoLocalAnim * suffix
-      const psoLocalRest = psoRest.localQuats[boneName] || identity;
-      const pszLocalRest = pszRest.localQuats[pszBoneName] || identity;
-      const psoWorldRest = getWorldRestQuat(boneName, psoRest);
-      const pszWorldRest = getWorldRestQuat(pszBoneName, pszRest);
+      if (prop === '.quaternion') {
+        // Conjugation approach: re-express the local animation delta in PSZ's bone frame
+        // Precompute per-bone: prefix = pszLocalRest * F * inv(psoLocalRest), suffix = inv(F)
+        // Per keyframe: pszLocal = prefix * psoLocalAnim * suffix
+        const psoLocalRest = psoRest.localQuats[boneName] || identity;
+        const pszLocalRest = pszRest.localQuats[pszBoneName] || identity;
+        const psoWorldRest = getWorldRestQuat(boneName, psoRest);
+        const pszWorldRest = getWorldRestQuat(pszBoneName, pszRest);
 
-      const F = pszWorldRest.clone().invert().multiply(psoWorldRest);
-      const Finv = F.clone().invert();
-      const prefix = pszLocalRest.clone().multiply(F).multiply(psoLocalRest.clone().invert());
-      const suffix = Finv;
+        const F = pszWorldRest.clone().invert().multiply(psoWorldRest);
+        const Finv = F.clone().invert();
+        const prefix = pszLocalRest.clone().multiply(F).multiply(psoLocalRest.clone().invert());
+        const suffix = Finv;
 
-      const srcValues = track.values;
-      const dstValues = new Float32Array(srcValues.length);
-      const psoLocalAnim = new THREE.Quaternion();
+        const srcValues = track.values;
+        const dstValues = new Float32Array(srcValues.length);
+        const psoLocalAnim = new THREE.Quaternion();
 
-      for (let i = 0; i < srcValues.length; i += 4) {
-        psoLocalAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
+        for (let i = 0; i < srcValues.length; i += 4) {
+          psoLocalAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
+          const pszLocalResult = prefix.clone().multiply(psoLocalAnim).multiply(suffix);
+          dstValues[i] = pszLocalResult.x;
+          dstValues[i + 1] = pszLocalResult.y;
+          dstValues[i + 2] = pszLocalResult.z;
+          dstValues[i + 3] = pszLocalResult.w;
+        }
 
-        // pszLocal = prefix * psoLocalAnim * suffix
-        const pszLocalResult = prefix.clone().multiply(psoLocalAnim).multiply(suffix);
+        tracks.push(new THREE.QuaternionKeyframeTrack(
+          pszBoneName + '.quaternion',
+          Array.from(track.times),
+          Array.from(dstValues),
+        ));
+      } else if (prop === '.position') {
+        // Scale position tracks to match PSZ model size
+        const srcValues = track.values;
+        const dstValues = new Float32Array(srcValues.length);
 
-        dstValues[i] = pszLocalResult.x;
-        dstValues[i + 1] = pszLocalResult.y;
-        dstValues[i + 2] = pszLocalResult.z;
-        dstValues[i + 3] = pszLocalResult.w;
+        for (let i = 0; i < srcValues.length; i += 3) {
+          dstValues[i] = srcValues[i] * posScale;
+          dstValues[i + 1] = srcValues[i + 1] * posScale;
+          dstValues[i + 2] = srcValues[i + 2] * posScale;
+        }
+
+        tracks.push(new THREE.VectorKeyframeTrack(
+          pszBoneName + '.position',
+          Array.from(track.times),
+          Array.from(dstValues),
+        ));
       }
-
-      tracks.push(new THREE.QuaternionKeyframeTrack(
-        pszBoneName + '.quaternion',
-        Array.from(track.times),
-        Array.from(dstValues),
-      ));
     }
     if (tracks.length === 0) return null;
     return new THREE.AnimationClip(clip.name + '_retargeted', clip.duration, tracks);

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -324,7 +324,7 @@ export default function RetargetViewer() {
   const [psoLoaded, setPsoLoaded] = useState(false);
   const [psoLoadError, setPsoLoadError] = useState<string | null>(null);
   const [psoLoadProgress, setPsoLoadProgress] = useState(0);
-  const [playOnBoth, setPlayOnBoth] = useState(false);
+  const [playOnBoth, setPlayOnBoth] = useState(true);
   const [hoveredBone, setHoveredBone] = useState<{ name: string; side: 'psz' | 'pso' } | null>(null);
   const [pszCollapsed, setPszCollapsed] = useState<Set<string>>(new Set());
   const [psoCollapsed, setPsoCollapsed] = useState<Set<string>>(new Set());

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -597,10 +597,15 @@ export default function RetargetViewer() {
     if (Object.keys(boneMap).length === 0) return null;
     const tracks: THREE.KeyframeTrack[] = [];
     for (const track of clip.tracks) {
+      // Track names are like "bone_000.quaternion", "bone_000.position", "bone_000.scale"
       const dotIdx = track.name.indexOf('.');
       if (dotIdx < 0) continue;
       const boneName = track.name.substring(0, dotIdx);
       const prop = track.name.substring(dotIdx);
+
+      // Only transfer rotation tracks — position and scale are skeleton-specific
+      if (prop !== '.quaternion') continue;
+
       const pszBoneName = boneMap[boneName];
       if (pszBoneName) {
         const newTrack = track.clone();

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -11,11 +11,19 @@ const PSZ_TEXTURE_PATH = assetUrl('/player/pc_000/textures/pc_000_000.png');
 // PSO model — Humar with all animations
 const PSO_MODEL_PATH = assetUrl('/data/retarget/Humar_body.glb');
 
+const BONE_MARKER_RADIUS = 0.012;
+
 interface BoneInfo {
   name: string;
   depth: number;
   worldPos: THREE.Vector3;
   bone: THREE.Bone;
+}
+
+interface BoneMarker {
+  mesh: THREE.Mesh;
+  boneName: string;
+  side: 'psz' | 'pso';
 }
 
 function collectBones(root: THREE.Object3D): BoneInfo[] {
@@ -34,34 +42,14 @@ function collectBones(root: THREE.Object3D): BoneInfo[] {
   return bones;
 }
 
-function createBoneLabels(
-  bones: BoneInfo[],
-  color: string,
-  scene: THREE.Scene,
-  selectedBone: string | null,
-): THREE.Sprite[] {
-  const sprites: THREE.Sprite[] = [];
-  for (const bone of bones) {
-    const canvas = document.createElement('canvas');
-    canvas.width = 256;
-    canvas.height = 64;
-    const ctx = canvas.getContext('2d')!;
-    const isSelected = bone.name === selectedBone;
-    ctx.font = isSelected ? 'bold 18px monospace' : '14px monospace';
-    ctx.fillStyle = isSelected ? '#ffff00' : color;
-    ctx.fillText(bone.name, 4, 20);
-
-    const texture = new THREE.CanvasTexture(canvas);
-    const material = new THREE.SpriteMaterial({ map: texture, depthTest: false });
-    const sprite = new THREE.Sprite(material);
-    sprite.scale.set(1.2, 0.3, 1);
-    sprite.position.copy(bone.worldPos);
-    sprite.position.y += 0.08;
-    sprite.renderOrder = 999;
-    scene.add(sprite);
-    sprites.push(sprite);
-  }
-  return sprites;
+function resetToBindPose(model: THREE.Object3D): void {
+  model.traverse((child) => {
+    if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
+      const skeleton = (child as THREE.SkinnedMesh).skeleton;
+      if (skeleton) skeleton.pose();
+    }
+  });
+  model.updateMatrixWorld(true);
 }
 
 function matchPsoScaleToPsz(pszModel: THREE.Object3D, psoModel: THREE.Object3D): void {
@@ -90,6 +78,31 @@ function createSkeletonHelper(model: THREE.Object3D, color: number): THREE.Skele
   return helper;
 }
 
+function createBoneMarkers(
+  bones: BoneInfo[],
+  color: number,
+  selectedBone: string | null,
+  scene: THREE.Scene,
+  side: 'psz' | 'pso',
+): BoneMarker[] {
+  const markers: BoneMarker[] = [];
+  const geo = new THREE.SphereGeometry(BONE_MARKER_RADIUS, 8, 6);
+  for (const bone of bones) {
+    const isSelected = bone.name === selectedBone;
+    const mat = new THREE.MeshBasicMaterial({
+      color: isSelected ? 0xffff00 : color,
+      depthTest: false,
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.position.copy(bone.worldPos);
+    mesh.renderOrder = 999;
+    mesh.userData = { boneName: bone.name, side };
+    scene.add(mesh);
+    markers.push({ mesh, boneName: bone.name, side });
+  }
+  return markers;
+}
+
 interface SceneState {
   scene: THREE.Scene;
   camera: THREE.PerspectiveCamera;
@@ -104,12 +117,13 @@ interface SceneState {
   psoAnimations: THREE.AnimationClip[];
   currentAction: THREE.AnimationAction | null;
   currentPszAction: THREE.AnimationAction | null;
-  labelSprites: THREE.Sprite[];
+  boneMarkers: BoneMarker[];
 }
 
 export default function RetargetViewer() {
   const containerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<SceneState | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
 
   const [pszBones, setPszBones] = useState<BoneInfo[]>([]);
   const [psoBones, setPsoBones] = useState<BoneInfo[]>([]);
@@ -119,13 +133,14 @@ export default function RetargetViewer() {
   const [selectedAnimation, setSelectedAnimation] = useState<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [showMeshes, setShowMeshes] = useState(true);
-  const [showLabels, setShowLabels] = useState(true);
+  const [showMarkers, setShowMarkers] = useState(true);
   const [mappings, setMappings] = useState<Record<string, string>>({});
   const [pszLoaded, setPszLoaded] = useState(false);
   const [psoLoaded, setPsoLoaded] = useState(false);
   const [psoLoadError, setPsoLoadError] = useState<string | null>(null);
   const [psoLoadProgress, setPsoLoadProgress] = useState(0);
   const [playOnBoth, setPlayOnBoth] = useState(false);
+  const [hoveredBone, setHoveredBone] = useState<{ name: string; side: 'psz' | 'pso' } | null>(null);
 
   // Initialize Three.js scene
   useEffect(() => {
@@ -157,7 +172,7 @@ export default function RetargetViewer() {
       pszModel: null, psoModel: null,
       pszHelper: null, psoHelper: null,
       psoMixer: null, pszMixer: null, psoAnimations: [],
-      currentAction: null, currentPszAction: null, labelSprites: [],
+      currentAction: null, currentPszAction: null, boneMarkers: [],
     };
 
     const clock = new THREE.Clock();
@@ -170,6 +185,58 @@ export default function RetargetViewer() {
       renderer.render(scene, camera);
     };
     animate();
+
+    // Raycasting for hover/click on bone markers
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
+    const onMouseMove = (e: MouseEvent) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+
+      if (!sceneRef.current) return;
+      raycaster.setFromCamera(mouse, camera);
+      const markerMeshes = sceneRef.current.boneMarkers.map((m) => m.mesh);
+      const intersects = raycaster.intersectObjects(markerMeshes);
+
+      if (tooltipRef.current) {
+        if (intersects.length > 0) {
+          const hit = intersects[0].object;
+          const { boneName, side } = hit.userData;
+          setHoveredBone({ name: boneName, side });
+          tooltipRef.current.style.left = `${e.clientX - rect.left + 12}px`;
+          tooltipRef.current.style.top = `${e.clientY - rect.top - 8}px`;
+          tooltipRef.current.style.display = 'block';
+          renderer.domElement.style.cursor = 'pointer';
+        } else {
+          setHoveredBone(null);
+          tooltipRef.current.style.display = 'none';
+          renderer.domElement.style.cursor = 'default';
+        }
+      }
+    };
+
+    const onClick = (e: MouseEvent) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+
+      if (!sceneRef.current) return;
+      raycaster.setFromCamera(mouse, camera);
+      const markerMeshes = sceneRef.current.boneMarkers.map((m) => m.mesh);
+      const intersects = raycaster.intersectObjects(markerMeshes);
+
+      if (intersects.length > 0) {
+        const hit = intersects[0].object;
+        const { boneName, side } = hit.userData;
+        if (side === 'psz') setSelectedPszBone(boneName);
+        else setSelectedPsoBone(boneName);
+      }
+    };
+
+    renderer.domElement.addEventListener('mousemove', onMouseMove);
+    renderer.domElement.addEventListener('click', onClick);
 
     const handleResize = () => {
       const w = container.clientWidth;
@@ -212,12 +279,10 @@ export default function RetargetViewer() {
       const pszMixer = new THREE.AnimationMixer(model);
       sceneRef.current!.pszMixer = pszMixer;
 
-      // Need to update world matrices before collecting bone positions
       model.updateMatrixWorld(true);
       setPszBones(collectBones(model));
       setPszLoaded(true);
 
-      // If PSO already loaded, scale it to match
       if (sceneRef.current!.psoModel) {
         matchPsoScaleToPsz(model, sceneRef.current!.psoModel);
       }
@@ -231,6 +296,9 @@ export default function RetargetViewer() {
         model.position.x = 1.2;
         scene.add(model);
         sceneRef.current!.psoModel = model;
+
+        // Reset to T-pose (bind pose)
+        resetToBindPose(model);
 
         const helper = createSkeletonHelper(model, 0xff4444);
         if (helper) {
@@ -266,6 +334,8 @@ export default function RetargetViewer() {
 
     return () => {
       window.removeEventListener('resize', handleResize);
+      renderer.domElement.removeEventListener('mousemove', onMouseMove);
+      renderer.domElement.removeEventListener('click', onClick);
       renderer.dispose();
       if (container.contains(renderer.domElement)) {
         container.removeChild(renderer.domElement);
@@ -273,30 +343,23 @@ export default function RetargetViewer() {
     };
   }, []);
 
-  // Update labels when selection changes
-  useEffect(() => {
-    if (!sceneRef.current || !showLabels) return;
-    const { scene, labelSprites } = sceneRef.current;
-
-    // Remove old labels
-    for (const sprite of labelSprites) scene.remove(sprite);
-    sceneRef.current.labelSprites = [];
-
-    // Add new labels
-    const pszLabels = createBoneLabels(pszBones, '#44ff44', scene, selectedPszBone);
-    const psoLabels = createBoneLabels(psoBones, '#ff4444', scene, selectedPsoBone);
-    sceneRef.current.labelSprites = [...pszLabels, ...psoLabels];
-  }, [pszBones, psoBones, selectedPszBone, selectedPsoBone, showLabels]);
-
-  // Toggle labels visibility
+  // Update bone markers when selection or bones change
   useEffect(() => {
     if (!sceneRef.current) return;
-    const { scene, labelSprites } = sceneRef.current;
-    if (!showLabels) {
-      for (const sprite of labelSprites) scene.remove(sprite);
-      sceneRef.current.labelSprites = [];
+    const { scene, boneMarkers } = sceneRef.current;
+
+    // Remove old markers
+    for (const marker of boneMarkers) scene.remove(marker.mesh);
+
+    if (!showMarkers) {
+      sceneRef.current.boneMarkers = [];
+      return;
     }
-  }, [showLabels]);
+
+    const pszMarkers = createBoneMarkers(pszBones, 0x44ff44, selectedPszBone, scene, 'psz');
+    const psoMarkers = createBoneMarkers(psoBones, 0xff4444, selectedPsoBone, scene, 'pso');
+    sceneRef.current.boneMarkers = [...pszMarkers, ...psoMarkers];
+  }, [pszBones, psoBones, selectedPszBone, selectedPsoBone, showMarkers]);
 
   // Toggle meshes visibility
   useEffect(() => {
@@ -314,12 +377,11 @@ export default function RetargetViewer() {
     toggleMeshes(psoModel);
   }, [showMeshes]);
 
-  // Build a retargeted clip that maps PSO bone tracks → PSZ bone names
+  // Build a retargeted clip that maps PSO bone tracks -> PSZ bone names
   const buildRetargetedClip = useCallback((clip: THREE.AnimationClip, boneMap: Record<string, string>): THREE.AnimationClip | null => {
     if (Object.keys(boneMap).length === 0) return null;
     const tracks: THREE.KeyframeTrack[] = [];
     for (const track of clip.tracks) {
-      // Track names are like "bone_000.quaternion" or "bone_000.position"
       const dotIdx = track.name.indexOf('.');
       if (dotIdx < 0) continue;
       const boneName = track.name.substring(0, dotIdx);
@@ -350,7 +412,6 @@ export default function RetargetViewer() {
       action.paused = !isPlaying;
       sceneRef.current.currentAction = action;
 
-      // Retarget to PSZ if enabled and mappings exist
       if (playOnBoth && pszMixer) {
         const retargeted = buildRetargetedClip(clip, mappings);
         if (retargeted) {
@@ -440,8 +501,8 @@ export default function RetargetViewer() {
                 Meshes
               </label>
               <label style={{ fontSize: '11px', color: '#888', display: 'flex', alignItems: 'center', gap: '4px' }}>
-                <input type="checkbox" checked={showLabels} onChange={(e) => setShowLabels(e.target.checked)} />
-                Labels
+                <input type="checkbox" checked={showMarkers} onChange={(e) => setShowMarkers(e.target.checked)} />
+                Bones
               </label>
               <label style={{ fontSize: '11px', color: Object.keys(mappings).length > 0 ? '#8888ff' : '#555', display: 'flex', alignItems: 'center', gap: '4px' }}>
                 <input type="checkbox" checked={playOnBoth} onChange={(e) => setPlayOnBoth(e.target.checked)} disabled={Object.keys(mappings).length === 0} />
@@ -450,6 +511,31 @@ export default function RetargetViewer() {
             </div>
           </div>
           <div style={{ flex: 1, background: '#0a0a1a', borderRadius: '8px', overflow: 'hidden', position: 'relative' }} ref={containerRef}>
+            {/* Hover tooltip */}
+            <div
+              ref={tooltipRef}
+              style={{
+                display: 'none',
+                position: 'absolute',
+                pointerEvents: 'none',
+                padding: '4px 8px',
+                background: 'rgba(0,0,0,0.85)',
+                border: `1px solid ${hoveredBone?.side === 'psz' ? '#44ff44' : '#ff4444'}`,
+                borderRadius: '4px',
+                fontSize: '11px',
+                fontFamily: 'monospace',
+                color: hoveredBone?.side === 'psz' ? '#44ff44' : '#ff4444',
+                zIndex: 10,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {hoveredBone && (
+                <>
+                  <span style={{ color: '#888', fontSize: '9px' }}>{hoveredBone.side.toUpperCase()} </span>
+                  {hoveredBone.name}
+                </>
+              )}
+            </div>
             {psoLoadError && (
               <div style={{ position: 'absolute', bottom: 12, left: 12, right: 12, padding: '8px 12px', background: 'rgba(100,20,20,0.9)', borderRadius: '6px', fontSize: '11px', color: '#f88' }}>
                 {psoLoadError}

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -154,15 +154,27 @@ function createSelectedLabel(bone: BoneInfo, color: string, scene: THREE.Scene):
   return sprite;
 }
 
-// Capture rest-pose quaternions for all bones in a model
-function captureRestQuaternions(model: THREE.Object3D): Record<string, THREE.Quaternion> {
-  const quats: Record<string, THREE.Quaternion> = {};
+interface RestPoseData {
+  localQuats: Record<string, THREE.Quaternion>;
+  worldQuats: Record<string, THREE.Quaternion>;
+  parentMap: Record<string, string | null>;
+}
+
+// Capture rest-pose local + world quaternions and parent relationships
+function captureRestPose(model: THREE.Object3D): RestPoseData {
+  const localQuats: Record<string, THREE.Quaternion> = {};
+  const worldQuats: Record<string, THREE.Quaternion> = {};
+  const parentMap: Record<string, string | null> = {};
   model.traverse((child) => {
     if ((child as THREE.Bone).isBone) {
-      quats[child.name] = child.quaternion.clone();
+      localQuats[child.name] = child.quaternion.clone();
+      const wq = new THREE.Quaternion();
+      child.getWorldQuaternion(wq);
+      worldQuats[child.name] = wq;
+      parentMap[child.name] = child.parent && (child.parent as THREE.Bone).isBone ? child.parent.name : null;
     }
   });
-  return quats;
+  return { localQuats, worldQuats, parentMap };
 }
 
 interface SceneState {
@@ -181,8 +193,8 @@ interface SceneState {
   currentPszAction: THREE.AnimationAction | null;
   boneMarkers: BoneMarker[];
   selectedLabels: THREE.Sprite[];
-  psoRestQuats: Record<string, THREE.Quaternion>;
-  pszRestQuats: Record<string, THREE.Quaternion>;
+  psoRest: RestPoseData;
+  pszRest: RestPoseData;
 }
 
 // Collapsible bone tree row component
@@ -412,7 +424,8 @@ export default function RetargetViewer() {
       pszHelper: null, psoHelper: null,
       psoMixer: null, pszMixer: null, psoAnimations: [],
       currentAction: null, currentPszAction: null, boneMarkers: [], selectedLabels: [],
-      psoRestQuats: {}, pszRestQuats: {},
+      psoRest: { localQuats: {}, worldQuats: {}, parentMap: {} },
+      pszRest: { localQuats: {}, worldQuats: {}, parentMap: {} },
     };
 
     const clock = new THREE.Clock();
@@ -506,7 +519,7 @@ export default function RetargetViewer() {
       if (helper) { scene.add(helper); sceneRef.current!.pszHelper = helper; }
       sceneRef.current!.pszMixer = new THREE.AnimationMixer(model);
       model.updateMatrixWorld(true);
-      sceneRef.current!.pszRestQuats = captureRestQuaternions(model);
+      sceneRef.current!.pszRest = captureRestPose(model);
       setPszBones(collectBones(model));
       setPszLoaded(true);
       if (sceneRef.current!.psoModel) {
@@ -535,7 +548,7 @@ export default function RetargetViewer() {
         // Now reset to T-pose and capture rest quaternions
         resetToBindPose(model);
         model.updateMatrixWorld(true);
-        sceneRef.current!.psoRestQuats = captureRestQuaternions(model);
+        sceneRef.current!.psoRest = captureRestPose(model);
 
         const helper = createSkeletonHelper(model, 0xff4444);
         if (helper) { scene.add(helper); sceneRef.current!.psoHelper = helper; }
@@ -570,13 +583,13 @@ export default function RetargetViewer() {
   // Zero out or restore PSO bone rest rotations
   useEffect(() => {
     if (!sceneRef.current?.psoModel) return;
-    const { psoModel, psoRestQuats } = sceneRef.current;
+    const { psoModel, psoRest } = sceneRef.current;
     psoModel.traverse((child) => {
       if ((child as THREE.Bone).isBone) {
         if (zeroedPsoRest) {
           child.quaternion.identity();
         } else {
-          const rest = psoRestQuats[child.name];
+          const rest = psoRest.localQuats[child.name];
           if (rest) child.quaternion.copy(rest);
         }
       }
@@ -628,9 +641,25 @@ export default function RetargetViewer() {
     toggle(sceneRef.current.psoModel);
   }, [showMeshes]);
 
+  // Compute world-space rest quaternion by walking the parent chain
+  const getWorldRestQuat = useCallback((boneName: string, restData: RestPoseData): THREE.Quaternion => {
+    const result = new THREE.Quaternion();
+    const chain: string[] = [];
+    let cur: string | null = boneName;
+    while (cur) {
+      chain.unshift(cur);
+      cur = restData.parentMap[cur] || null;
+    }
+    for (const name of chain) {
+      const local = restData.localQuats[name];
+      if (local) result.multiply(local);
+    }
+    return result;
+  }, []);
+
   const buildRetargetedClip = useCallback((clip: THREE.AnimationClip, boneMap: Record<string, string>): THREE.AnimationClip | null => {
     if (!sceneRef.current || Object.keys(boneMap).length === 0) return null;
-    const { psoRestQuats, pszRestQuats } = sceneRef.current;
+    const { psoRest, pszRest } = sceneRef.current;
 
     const tracks: THREE.KeyframeTrack[] = [];
     const identity = new THREE.Quaternion();
@@ -647,26 +676,46 @@ export default function RetargetViewer() {
       const pszBoneName = boneMap[boneName];
       if (!pszBoneName) continue;
 
-      // Get rest quaternions for pre-rotation correction
-      const psoRest = psoRestQuats[boneName] || identity;
-      const pszRest = pszRestQuats[pszBoneName] || identity;
-      const psoRestInv = psoRest.clone().invert();
+      // World-space approach:
+      // 1. Get PSO parent's world rest quat to convert PSO local anim -> world
+      // 2. Get PSZ parent's world rest quat to convert world -> PSZ local
+      const psoParent = psoRest.parentMap[boneName];
+      const pszParent = pszRest.parentMap[pszBoneName];
+      const psoParentWorldRest = psoParent ? getWorldRestQuat(psoParent, psoRest) : identity.clone();
+      const pszParentWorldRest = pszParent ? getWorldRestQuat(pszParent, pszRest) : identity.clone();
+      const pszParentWorldRestInv = pszParentWorldRest.clone().invert();
 
-      // Transform each keyframe:
-      // delta = inverse(psoRest) * psoAnim  (change from PSO rest pose)
-      // result = pszRest * delta             (apply change to PSZ rest pose)
+      // PSO local rest and PSZ local rest for this bone
+      const psoLocalRest = psoRest.localQuats[boneName] || identity;
+      const psoLocalRestInv = psoLocalRest.clone().invert();
+      const pszLocalRest = pszRest.localQuats[pszBoneName] || identity;
+
       const srcValues = track.values;
       const dstValues = new Float32Array(srcValues.length);
-      const psoAnim = new THREE.Quaternion();
-      const result = new THREE.Quaternion();
+      const psoLocalAnim = new THREE.Quaternion();
 
       for (let i = 0; i < srcValues.length; i += 4) {
-        psoAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
-        result.copy(pszRest).multiply(psoRestInv).multiply(psoAnim);
-        dstValues[i] = result.x;
-        dstValues[i + 1] = result.y;
-        dstValues[i + 2] = result.z;
-        dstValues[i + 3] = result.w;
+        psoLocalAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
+
+        // PSO local anim -> world: psoParentWorld * psoLocalAnim
+        const psoWorld = psoParentWorldRest.clone().multiply(psoLocalAnim);
+
+        // Extract delta in world space: how does this differ from PSO rest world?
+        const psoWorldRest = psoParentWorldRest.clone().multiply(psoLocalRest);
+        const psoWorldRestInv = psoWorldRest.clone().invert();
+        const worldDelta = psoWorldRestInv.clone().premultiply(psoWorld);
+        // worldDelta = psoWorld * inv(psoWorldRest) — rotation change in world space
+
+        // Apply world delta to PSZ world rest, then convert to PSZ local
+        const pszWorldRest = pszParentWorldRest.clone().multiply(pszLocalRest);
+        const pszWorldAnimated = pszWorldRest.clone().multiply(worldDelta);
+        // Convert back to local: pszLocal = inv(pszParentWorld) * pszWorld
+        const pszLocalResult = pszParentWorldRestInv.clone().multiply(pszWorldAnimated);
+
+        dstValues[i] = pszLocalResult.x;
+        dstValues[i + 1] = pszLocalResult.y;
+        dstValues[i + 2] = pszLocalResult.z;
+        dstValues[i + 3] = pszLocalResult.w;
       }
 
       tracks.push(new THREE.QuaternionKeyframeTrack(
@@ -677,7 +726,7 @@ export default function RetargetViewer() {
     }
     if (tracks.length === 0) return null;
     return new THREE.AnimationClip(clip.name + '_retargeted', clip.duration, tracks);
-  }, []);
+  }, [getWorldRestQuat]);
 
   useEffect(() => {
     if (!sceneRef.current?.psoMixer || !selectedAnimation) return;

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -342,6 +342,7 @@ export default function RetargetViewer() {
   const [pszCollapsed, setPszCollapsed] = useState<Set<string>>(new Set());
   const [psoCollapsed, setPsoCollapsed] = useState<Set<string>>(new Set());
   const [disabledPsoBones, setDisabledPsoBones] = useState<Set<string>>(new Set());
+  const [zeroedPsoRest, setZeroedPsoRest] = useState(false);
 
   const pszTree = buildBoneTree(pszBones);
   const psoTree = buildBoneTree(psoBones);
@@ -566,6 +567,23 @@ export default function RetargetViewer() {
     };
   }, []);
 
+  // Zero out or restore PSO bone rest rotations
+  useEffect(() => {
+    if (!sceneRef.current?.psoModel) return;
+    const { psoModel, psoRestQuats } = sceneRef.current;
+    psoModel.traverse((child) => {
+      if ((child as THREE.Bone).isBone) {
+        if (zeroedPsoRest) {
+          child.quaternion.identity();
+        } else {
+          const rest = psoRestQuats[child.name];
+          if (rest) child.quaternion.copy(rest);
+        }
+      }
+    });
+    psoModel.updateMatrixWorld(true);
+  }, [zeroedPsoRest]);
+
   // Update bone markers + selected labels
   useEffect(() => {
     if (!sceneRef.current) return;
@@ -752,6 +770,10 @@ export default function RetargetViewer() {
               <label style={{ fontSize: '11px', color: '#888', display: 'flex', alignItems: 'center', gap: '4px' }}>
                 <input type="checkbox" checked={showMarkers} onChange={(e) => setShowMarkers(e.target.checked)} />
                 Bones
+              </label>
+              <label style={{ fontSize: '11px', color: '#c84', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <input type="checkbox" checked={zeroedPsoRest} onChange={(e) => setZeroedPsoRest(e.target.checked)} />
+                Zero PSO Rest
               </label>
               <label style={{ fontSize: '11px', color: Object.keys(mappings).length > 0 ? '#8888ff' : '#555', display: 'flex', alignItems: 'center', gap: '4px' }}>
                 <input type="checkbox" checked={playOnBoth} onChange={(e) => setPlayOnBoth(e.target.checked)} disabled={Object.keys(mappings).length === 0} />

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -154,6 +154,17 @@ function createSelectedLabel(bone: BoneInfo, color: string, scene: THREE.Scene):
   return sprite;
 }
 
+// Capture rest-pose quaternions for all bones in a model
+function captureRestQuaternions(model: THREE.Object3D): Record<string, THREE.Quaternion> {
+  const quats: Record<string, THREE.Quaternion> = {};
+  model.traverse((child) => {
+    if ((child as THREE.Bone).isBone) {
+      quats[child.name] = child.quaternion.clone();
+    }
+  });
+  return quats;
+}
+
 interface SceneState {
   scene: THREE.Scene;
   camera: THREE.PerspectiveCamera;
@@ -170,6 +181,8 @@ interface SceneState {
   currentPszAction: THREE.AnimationAction | null;
   boneMarkers: BoneMarker[];
   selectedLabels: THREE.Sprite[];
+  psoRestQuats: Record<string, THREE.Quaternion>;
+  pszRestQuats: Record<string, THREE.Quaternion>;
 }
 
 // Collapsible bone tree row component
@@ -398,6 +411,7 @@ export default function RetargetViewer() {
       pszHelper: null, psoHelper: null,
       psoMixer: null, pszMixer: null, psoAnimations: [],
       currentAction: null, currentPszAction: null, boneMarkers: [], selectedLabels: [],
+      psoRestQuats: {}, pszRestQuats: {},
     };
 
     const clock = new THREE.Clock();
@@ -491,6 +505,7 @@ export default function RetargetViewer() {
       if (helper) { scene.add(helper); sceneRef.current!.pszHelper = helper; }
       sceneRef.current!.pszMixer = new THREE.AnimationMixer(model);
       model.updateMatrixWorld(true);
+      sceneRef.current!.pszRestQuats = captureRestQuaternions(model);
       setPszBones(collectBones(model));
       setPszLoaded(true);
       if (sceneRef.current!.psoModel) {
@@ -516,8 +531,10 @@ export default function RetargetViewer() {
           model.updateMatrixWorld(true);
         }
 
-        // Now reset to T-pose
+        // Now reset to T-pose and capture rest quaternions
         resetToBindPose(model);
+        model.updateMatrixWorld(true);
+        sceneRef.current!.psoRestQuats = captureRestQuaternions(model);
 
         const helper = createSkeletonHelper(model, 0xff4444);
         if (helper) { scene.add(helper); sceneRef.current!.psoHelper = helper; }
@@ -594,24 +611,51 @@ export default function RetargetViewer() {
   }, [showMeshes]);
 
   const buildRetargetedClip = useCallback((clip: THREE.AnimationClip, boneMap: Record<string, string>): THREE.AnimationClip | null => {
-    if (Object.keys(boneMap).length === 0) return null;
+    if (!sceneRef.current || Object.keys(boneMap).length === 0) return null;
+    const { psoRestQuats, pszRestQuats } = sceneRef.current;
+
     const tracks: THREE.KeyframeTrack[] = [];
+    const identity = new THREE.Quaternion();
+
     for (const track of clip.tracks) {
-      // Track names are like "bone_000.quaternion", "bone_000.position", "bone_000.scale"
       const dotIdx = track.name.indexOf('.');
       if (dotIdx < 0) continue;
       const boneName = track.name.substring(0, dotIdx);
       const prop = track.name.substring(dotIdx);
 
-      // Only transfer rotation tracks — position and scale are skeleton-specific
+      // Only transfer rotation tracks
       if (prop !== '.quaternion') continue;
 
       const pszBoneName = boneMap[boneName];
-      if (pszBoneName) {
-        const newTrack = track.clone();
-        newTrack.name = pszBoneName + prop;
-        tracks.push(newTrack);
+      if (!pszBoneName) continue;
+
+      // Get rest quaternions for pre-rotation correction
+      const psoRest = psoRestQuats[boneName] || identity;
+      const pszRest = pszRestQuats[pszBoneName] || identity;
+      const psoRestInv = psoRest.clone().invert();
+
+      // Transform each keyframe:
+      // delta = inverse(psoRest) * psoAnim  (change from PSO rest pose)
+      // result = pszRest * delta             (apply change to PSZ rest pose)
+      const srcValues = track.values;
+      const dstValues = new Float32Array(srcValues.length);
+      const psoAnim = new THREE.Quaternion();
+      const result = new THREE.Quaternion();
+
+      for (let i = 0; i < srcValues.length; i += 4) {
+        psoAnim.set(srcValues[i], srcValues[i + 1], srcValues[i + 2], srcValues[i + 3]);
+        result.copy(pszRest).multiply(psoRestInv).multiply(psoAnim);
+        dstValues[i] = result.x;
+        dstValues[i + 1] = result.y;
+        dstValues[i + 2] = result.z;
+        dstValues[i + 3] = result.w;
       }
+
+      tracks.push(new THREE.QuaternionKeyframeTrack(
+        pszBoneName + '.quaternion',
+        Array.from(track.times),
+        Array.from(dstValues),
+      ));
     }
     if (tracks.length === 0) return null;
     return new THREE.AnimationClip(clip.name + '_retargeted', clip.duration, tracks);

--- a/web/src/retarget/RetargetViewer.tsx
+++ b/web/src/retarget/RetargetViewer.tsx
@@ -64,6 +64,17 @@ function createBoneLabels(
   return sprites;
 }
 
+function matchPsoScaleToPsz(pszModel: THREE.Object3D, psoModel: THREE.Object3D): void {
+  const pszBox = new THREE.Box3().setFromObject(pszModel);
+  const psoBox = new THREE.Box3().setFromObject(psoModel);
+  const pszHeight = pszBox.max.y - pszBox.min.y;
+  const psoHeight = psoBox.max.y - psoBox.min.y;
+  if (psoHeight > 0 && pszHeight > 0) {
+    const scale = pszHeight / psoHeight;
+    psoModel.scale.multiplyScalar(scale);
+  }
+}
+
 function createSkeletonHelper(model: THREE.Object3D, color: number): THREE.SkeletonHelper | null {
   let skeleton: THREE.Skeleton | null = null;
   model.traverse((child) => {
@@ -205,6 +216,11 @@ export default function RetargetViewer() {
       model.updateMatrixWorld(true);
       setPszBones(collectBones(model));
       setPszLoaded(true);
+
+      // If PSO already loaded, scale it to match
+      if (sceneRef.current!.psoModel) {
+        matchPsoScaleToPsz(model, sceneRef.current!.psoModel);
+      }
     });
 
     // PSO model on the right
@@ -227,6 +243,11 @@ export default function RetargetViewer() {
         sceneRef.current!.psoAnimations = gltf.animations;
         const animNames = gltf.animations.map((a) => a.name);
         setPsoAnimations(animNames);
+
+        // Scale PSO to match PSZ height
+        if (sceneRef.current!.pszModel) {
+          matchPsoScaleToPsz(sceneRef.current!.pszModel, model);
+        }
 
         model.updateMatrixWorld(true);
         setPsoBones(collectBones(model));


### PR DESCRIPTION
## Summary
- Interactive retargeting viewer at `/retarget` with side-by-side PSO/PSZ skeleton visualization
- Conjugation-based retargeting math that correctly re-expresses animation deltas between different bone coordinate frames
- Per-bone arm rest pose correction to account for PSO (arms at sides) vs PSZ (arms at 45°) rest pose difference
- Scaled root bone position tracks for locomotion/falling animations
- 12-bone mapping from PSO's 64-bone skeleton to PSZ's 12-bone skeleton
- 572 PSO animations available for preview

## Test plan
- [ ] Open `/retarget` viewer, verify both skeletons render side by side
- [ ] Play a PSO animation and verify retargeted PSZ model moves correctly
- [ ] Check saber hold animation — PSZ arms should be at shoulder level, not above head
- [ ] Check animations with root movement (falling, walking) — PSZ model should translate correctly
- [ ] Verify bone mapping UI works (select, map, remove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)