### PR TITLE
Restyle all 2D menus and HUD to PSZ pale icy blue palette

### DIFF
--- a/scenes/2d/city.tscn
+++ b/scenes/2d/city.tscn
@@ -6,12 +6,12 @@
 [ext_resource type="PackedScene" path="res://scenes/3d/maps/city_market.tscn" id="4_city_market"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.80)
+bg_color = Color(0.10, 0.14, 0.22, 0.85)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.25, 0.45, 0.70, 0.5)
+border_color = Color(0.48, 0.63, 0.75, 0.5)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/scenes/2d/equipment.tscn
+++ b/scenes/2d/equipment.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/equipment_screen.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="Equipment" type="Control"]
 layout_mode = 3

--- a/scenes/2d/guild_counter.tscn
+++ b/scenes/2d/guild_counter.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/guild_counter.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="GuildCounter" type="Control"]
 layout_mode = 3

--- a/scenes/2d/inventory.tscn
+++ b/scenes/2d/inventory.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/inventory_screen.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="Inventory" type="Control"]
 layout_mode = 3

--- a/scenes/2d/shops/item_shop.tscn
+++ b/scenes/2d/shops/item_shop.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/shops/item_shop.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="ItemShop" type="Control"]
 layout_mode = 3

--- a/scenes/2d/shops/tekker.tscn
+++ b/scenes/2d/shops/tekker.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/shops/tekker.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="Tekker" type="Control"]
 layout_mode = 3

--- a/scenes/2d/shops/weapon_shop.tscn
+++ b/scenes/2d/shops/weapon_shop.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/shops/weapon_shop.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="WeaponShop" type="Control"]
 layout_mode = 3

--- a/scenes/2d/status.tscn
+++ b/scenes/2d/status.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/status.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="Status" type="Control"]
 layout_mode = 3

--- a/scenes/2d/storage.tscn
+++ b/scenes/2d/storage.tscn
@@ -4,12 +4,28 @@
 [ext_resource type="Script" path="res://scripts/2d/storage.gd" id="2_script"]
 
 [sub_resource type="StyleBoxFlat" id="panel_style"]
-bg_color = Color(0.04, 0.07, 0.15, 0.6)
+bg_color = Color(1.0, 1.0, 1.0, 0.3)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.20, 0.35, 0.55, 0.5)
+border_color = Color(0.59, 0.71, 0.82, 0.4)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -18,22 +34,6 @@ content_margin_left = 12.0
 content_margin_top = 12.0
 content_margin_right = 12.0
 content_margin_bottom = 12.0
-
-[sub_resource type="StyleBoxFlat" id="outer_panel_style"]
-bg_color = Color(0.06, 0.10, 0.20, 0.92)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.25, 0.45, 0.70, 0.8)
-corner_radius_top_left = 12
-corner_radius_top_right = 12
-corner_radius_bottom_right = 12
-corner_radius_bottom_left = 12
-content_margin_left = 16.0
-content_margin_top = 16.0
-content_margin_right = 16.0
-content_margin_bottom = 16.0
 
 [node name="Storage" type="Control"]
 layout_mode = 3

--- a/scenes/3d/city/city_menu.tscn
+++ b/scenes/3d/city/city_menu.tscn
@@ -1,8 +1,24 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="Theme" path="res://themes/rpg_theme.tres" id="1_theme"]
 [ext_resource type="Script" path="res://scripts/3d/city/city_menu.gd" id="2_script"]
 [ext_resource type="Script" path="res://scripts/2d/components/menu_list.gd" id="3_menu"]
+
+[sub_resource type="StyleBoxFlat" id="panel_style"]
+bg_color = Color(0.66, 0.80, 0.91, 1.0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+content_margin_left = 12.0
+content_margin_top = 12.0
+content_margin_right = 12.0
+content_margin_bottom = 12.0
 
 [node name="CityMenu" type="Control"]
 layout_mode = 3
@@ -27,6 +43,7 @@ offset_right = 200.0
 offset_bottom = 180.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/panel = SubResource("panel_style")
 
 [node name="VBox" type="VBoxContainer" parent="CenterPanel"]
 layout_mode = 2
@@ -34,9 +51,9 @@ theme_override_constants/separation = 8
 
 [node name="TitleLabel" type="Label" parent="CenterPanel/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.40, 0.75, 0.85, 1)
-theme_override_font_sizes/font_size = 18
-text = "MENU"
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 16
+text = "Menu"
 horizontal_alignment = 1
 
 [node name="MenuList" type="VBoxContainer" parent="CenterPanel/VBox"]
@@ -47,7 +64,7 @@ script = ExtResource("3_menu")
 [node name="FeedbackLabel" type="Label" parent="CenterPanel/VBox"]
 visible = false
 layout_mode = 2
-theme_override_colors/font_color = Color(0.88, 0.90, 0.94, 1)
+theme_override_colors/font_color = Color(0.13, 0.53, 0.13, 1)
 horizontal_alignment = 1
 
 [node name="HintLabel" type="Label" parent="."]
@@ -59,6 +76,6 @@ anchor_bottom = 1.0
 offset_top = -30.0
 grow_horizontal = 2
 grow_vertical = 0
-theme_override_colors/font_color = Color(0.816, 0.847, 0.878, 1)
-theme_override_font_sizes/font_size = 14
+theme_override_colors/font_color = Color(0.75, 0.82, 0.90, 1)
+theme_override_font_sizes/font_size = 13
 horizontal_alignment = 1

--- a/scenes/3d/ui/hud.tscn
+++ b/scenes/3d/ui/hud.tscn
@@ -5,16 +5,16 @@
 [ext_resource type="Script" path="res://scripts/2d/components/stat_bar.gd" id="3_statbar"]
 
 [sub_resource type="StyleBoxFlat" id="hud_panel"]
-bg_color = Color(0.165, 0.227, 0.353, 0.85)
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color(0.753, 0.816, 0.878, 0.6)
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
+bg_color = Color(0.66, 0.80, 0.91, 0.95)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.48, 0.63, 0.75, 1.0)
+corner_radius_top_left = 4
+corner_radius_top_right = 16
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 12
 content_margin_left = 8.0
 content_margin_top = 6.0
 content_margin_right = 8.0
@@ -41,7 +41,7 @@ theme_override_constants/separation = 2
 
 [node name="CharInfoLabel" type="Label" parent="TopLeft/Panel/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.878, 0.502, 0.063, 1)
+theme_override_colors/font_color = Color(0.1, 0.1, 0.17, 1)
 theme_override_font_sizes/font_size = 12
 text = ""
 
@@ -50,24 +50,24 @@ layout_mode = 2
 script = ExtResource("3_statbar")
 stat_name = "HP"
 bar_width = 12
-fill_color = Color(0.188, 0.753, 0.314, 1)
-bg_color = Color(0.102, 0.188, 0.125, 1)
+fill_color = Color(0.27, 0.73, 0.27, 1)
+bg_color = Color(0.85, 0.91, 0.85, 1)
 
 [node name="NameLabel" type="Label" parent="TopLeft/Panel/VBox/HPBar"]
 layout_mode = 2
 custom_minimum_size = Vector2(28, 0)
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.2, 0.53, 0.2, 1)
 text = "HP"
 
 [node name="BarLabel" type="Label" parent="TopLeft/Panel/VBox/HPBar"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.27, 0.73, 0.27, 1)
 text = "████████████"
 
 [node name="ValueLabel" type="Label" parent="TopLeft/Panel/VBox/HPBar"]
 layout_mode = 2
 custom_minimum_size = Vector2(80, 0)
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.1, 0.1, 0.17, 1)
 text = "100/100"
 horizontal_alignment = 2
 
@@ -76,57 +76,26 @@ layout_mode = 2
 script = ExtResource("3_statbar")
 stat_name = "PP"
 bar_width = 12
-fill_color = Color(0.251, 0.502, 0.878, 1)
-bg_color = Color(0.102, 0.125, 0.251, 1)
+fill_color = Color(0.2, 0.53, 0.93, 1)
+bg_color = Color(0.85, 0.85, 0.94, 1)
 show_danger_color = false
 
 [node name="NameLabel" type="Label" parent="TopLeft/Panel/VBox/PPBar"]
 layout_mode = 2
 custom_minimum_size = Vector2(28, 0)
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.2, 0.4, 0.73, 1)
 text = "PP"
 
 [node name="BarLabel" type="Label" parent="TopLeft/Panel/VBox/PPBar"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.2, 0.53, 0.93, 1)
 text = "████████████"
 
 [node name="ValueLabel" type="Label" parent="TopLeft/Panel/VBox/PPBar"]
 layout_mode = 2
 custom_minimum_size = Vector2(80, 0)
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.1, 0.1, 0.17, 1)
 text = "50/50"
-horizontal_alignment = 2
-
-[node name="TopRight" type="MarginContainer" parent="."]
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -170.0
-offset_bottom = 50.0
-grow_horizontal = 0
-theme = ExtResource("2_theme")
-theme_override_constants/margin_right = 12
-theme_override_constants/margin_top = 12
-
-[node name="MesetaPanel" type="PanelContainer" parent="TopRight"]
-layout_mode = 2
-theme_override_styles/panel = SubResource("hud_panel")
-
-[node name="HBox" type="HBoxContainer" parent="TopRight/MesetaPanel"]
-layout_mode = 2
-theme_override_constants/separation = 6
-
-[node name="MesetaIcon" type="Label" parent="TopRight/MesetaPanel/HBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.878, 0.627, 0.063, 1)
-text = "M"
-
-[node name="MesetaLabel" type="Label" parent="TopRight/MesetaPanel/HBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-text = "0"
 horizontal_alignment = 2
 
 [node name="BottomCenter" type="MarginContainer" parent="."]
@@ -150,5 +119,5 @@ theme_override_styles/panel = SubResource("hud_panel")
 
 [node name="PromptLabel" type="Label" parent="BottomCenter/InteractionPrompt"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.1, 0.1, 0.17, 1)
 horizontal_alignment = 1

--- a/scripts/2d/city.gd
+++ b/scripts/2d/city.gd
@@ -32,10 +32,15 @@ func _ready() -> void:
 	title_label.text = "CITY"
 	hint_label.text = "[↑/↓] Navigate  [ENTER] Select  [ESC] Quick Save & Quit"
 
-	title_label.add_theme_color_override("font_color", ThemeColors.HEADER_TEXT)
-	title_label.add_theme_font_size_override("font_size", 18)
-	hint_label.add_theme_color_override("font_color", ThemeColors.HINT_TEXT)
-	hint_label.add_theme_font_size_override("font_size", 14)
+	# Style title with PSZ dark navy bar
+	title_label.add_theme_stylebox_override("normal", PszStyle.title_style())
+	title_label.add_theme_color_override("font_color", PszStyle.TEXT_WHITE)
+	title_label.add_theme_font_size_override("font_size", PszStyle.FONT_TITLE)
+	title_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+
+	# Style hint label
+	hint_label.add_theme_color_override("font_color", Color(0.75, 0.82, 0.90))
+	hint_label.add_theme_font_size_override("font_size", PszStyle.FONT_HINT)
 
 	# Heal character to full on entering the city
 	var character = CharacterManager.get_active_character()
@@ -149,44 +154,51 @@ func _update_char_info() -> void:
 	if class_data:
 		stats = class_data.get_stats_at_level(int(character.get("level", 1)))
 
-	_add_info_line("CHARACTER", ThemeColors.HEADER)
-	_add_info_line("")
-	_add_info_line(str(character.get("name", "???")), ThemeColors.TEXT_HIGHLIGHT)
-	_add_info_line("%s  Lv.%d" % [str(character.get("class_id", "???")), int(character.get("level", 1))])
-	_add_info_line("")
+	# Character name and class
+	_add_info_line(str(character.get("name", "???")), PszStyle.TEXT_WHITE)
+	_add_info_line("%s  Lv.%d" % [str(character.get("class_id", "???")), int(character.get("level", 1))], PszStyle.TEXT_HIGHLIGHT)
+	_add_spacer()
 
 	# HP bar
 	var hp: int = int(character.get("hp", 0))
 	var max_hp: int = int(character.get("max_hp", 1))
 	var hp_ratio := clampf(float(hp) / float(max_hp), 0.0, 1.0)
 	var hp_filled := int(hp_ratio * 10)
-	_add_info_line("HP %s %d/%d" % ["█".repeat(hp_filled) + "░".repeat(10 - hp_filled), hp, max_hp])
+	_add_info_line("HP %s %d/%d" % ["█".repeat(hp_filled) + "░".repeat(10 - hp_filled), hp, max_hp],
+		PszStyle.TEXT_SUCCESS if hp_ratio > 0.25 else PszStyle.TEXT_DANGER)
 
 	# PP bar
 	var pp: int = int(character.get("pp", 0))
 	var max_pp: int = int(character.get("max_pp", 1))
 	var pp_ratio := clampf(float(pp) / float(max_pp), 0.0, 1.0)
 	var pp_filled := int(pp_ratio * 10)
-	_add_info_line("PP %s %d/%d" % ["█".repeat(pp_filled) + "░".repeat(10 - pp_filled), pp, max_pp])
+	_add_info_line("PP %s %d/%d" % ["█".repeat(pp_filled) + "░".repeat(10 - pp_filled), pp, max_pp],
+		Color(0.40, 0.60, 0.85))
 
-	_add_info_line("")
-	_add_info_line("Meseta: %s" % _format_number(int(character.get("meseta", 0))), ThemeColors.MESETA_GOLD)
+	_add_spacer()
+	_add_info_line("Meseta: %s" % _format_number(int(character.get("meseta", 0))), PszStyle.TEXT_MESETA)
 
 	# Stats
-	_add_info_line("")
-	_add_info_line("STATS", ThemeColors.HEADER)
-	_add_info_line("  ATK  %d" % stats.get("attack", 0))
-	_add_info_line("  DEF  %d" % stats.get("defense", 0))
-	_add_info_line("  ACC  %d" % stats.get("accuracy", 0))
-	_add_info_line("  EVA  %d" % stats.get("evasion", 0))
-	_add_info_line("  TEC  %d" % stats.get("technique", 0))
+	_add_spacer()
+	_add_info_line("ATK  %d" % stats.get("attack", 0), PszStyle.TEXT_WHITE)
+	_add_info_line("DEF  %d" % stats.get("defense", 0), PszStyle.TEXT_WHITE)
+	_add_info_line("ACC  %d" % stats.get("accuracy", 0), PszStyle.TEXT_WHITE)
+	_add_info_line("EVA  %d" % stats.get("evasion", 0), PszStyle.TEXT_WHITE)
+	_add_info_line("TEC  %d" % stats.get("technique", 0), PszStyle.TEXT_WHITE)
 
 
-func _add_info_line(text: String, color: Color = ThemeColors.TEXT_PRIMARY) -> void:
+func _add_info_line(text: String, color: Color = PszStyle.TEXT_WHITE) -> void:
 	var label := Label.new()
 	label.text = text
 	label.add_theme_color_override("font_color", color)
+	label.add_theme_font_size_override("font_size", PszStyle.FONT_DETAIL)
 	char_panel.add_child(label)
+
+
+func _add_spacer() -> void:
+	var spacer := Control.new()
+	spacer.custom_minimum_size = Vector2(0, 4)
+	char_panel.add_child(spacer)
 
 
 func _format_number(n: int) -> String:

--- a/scripts/2d/components/menu_list.gd
+++ b/scripts/2d/components/menu_list.gd
@@ -1,5 +1,5 @@
 extends VBoxContainer
-## Keyboard-navigable menu with PSZ DS-style pill-shaped rows.
+## Keyboard-navigable menu with PSZ-style pill-shaped rows.
 ## Use add_item() to populate, then arrow keys + enter to navigate.
 
 signal item_selected(index: int)
@@ -12,7 +12,7 @@ var _active: bool = true
 
 
 func _ready() -> void:
-	add_theme_constant_override("separation", 4)
+	add_theme_constant_override("separation", 3)
 	_update_display()
 
 
@@ -104,44 +104,17 @@ func _update_display() -> void:
 		var is_disabled: bool = _disabled[i]
 		var is_separator: bool = _items[i].begins_with("────")
 
-		# Separators render as simple labels (no panel)
+		# Separators render as thin spacers
 		if is_separator:
-			var sep_label := Label.new()
-			sep_label.text = _items[i]
-			var sep_settings := LabelSettings.new()
-			sep_settings.font_color = ThemeColors.TEXT_DISABLED
-			sep_label.label_settings = sep_settings
-			add_child(sep_label)
+			var spacer := Control.new()
+			spacer.custom_minimum_size = Vector2(0, 4)
+			add_child(spacer)
 			continue
 
-		var panel := PanelContainer.new()
-		var style := StyleBoxFlat.new()
-
-		if is_selected:
-			style.bg_color = ThemeColors.MENU_SELECTED
-		elif is_disabled:
-			style.bg_color = Color(ThemeColors.MENU_BG, 0.5)
-		else:
-			style.bg_color = ThemeColors.MENU_BG
-
-		style.corner_radius_top_left = 12
-		style.corner_radius_top_right = 12
-		style.corner_radius_bottom_right = 12
-		style.corner_radius_bottom_left = 12
-		style.content_margin_left = 12
-		style.content_margin_right = 12
-		style.content_margin_top = 6
-		style.content_margin_bottom = 6
-		panel.add_theme_stylebox_override("panel", style)
-
-		var label := Label.new()
-		label.text = _items[i]
-		var settings := LabelSettings.new()
+		var pill := PszStyle.create_pill(_items[i], is_selected)
 		if is_disabled:
-			settings.font_color = ThemeColors.TEXT_DISABLED
-		else:
-			settings.font_color = ThemeColors.MENU_TEXT
-		label.label_settings = settings
-		panel.add_child(label)
-
-		add_child(panel)
+			# Override colors for disabled items
+			var label: Label = pill.get_child(0).get_child(0) if pill.get_child_count() > 0 else null
+			if label:
+				label.add_theme_color_override("font_color", PszStyle.TEXT_MUTED)
+		add_child(pill)

--- a/scripts/2d/equipment_screen.gd
+++ b/scripts/2d/equipment_screen.gd
@@ -22,8 +22,9 @@ var _selected_item: int = 0
 
 
 func _ready() -> void:
-	title_label.text = "EQUIPMENT"
-	hint_label.text = "[↑/↓] Select Slot  [ENTER] Equip/Unequip  [ESC] Back"
+	PszStyle.style_menu(title_label, hint_label, [equip_panel, stats_panel])
+	title_label.text = "Equipment"
+	hint_label.text = "Up/Down: Select Slot  Enter: Equip/Unequip  Esc: Back"
 	_refresh_display()
 
 
@@ -66,7 +67,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		if _choosing_item:
 			_choosing_item = false
-			hint_label.text = "[↑/↓] Select Slot  [ENTER] Equip/Unequip  [ESC] Back"
+			hint_label.text = "Up/Down: Select Slot  Enter: Equip/Unequip  Esc: Back"
 			_refresh_display()
 		else:
 			SceneManager.pop_scene()
@@ -143,7 +144,7 @@ func _open_item_selection() -> void:
 
 	_choosing_item = true
 	_selected_item = 0
-	hint_label.text = "[↑/↓] Select Item  [ENTER] Equip  [ESC] Cancel"
+	hint_label.text = "Up/Down: Select Item  Enter: Equip  Esc: Cancel"
 	_refresh_display()
 
 
@@ -203,7 +204,7 @@ func _equip_selected_item() -> void:
 	# Selecting the already-equipped item — no-op, just close
 	if item.get("equipped", false):
 		_choosing_item = false
-		hint_label.text = "[↑/↓] Select Slot  [ENTER] Equip/Unequip  [ESC] Back"
+		hint_label.text = "Up/Down: Select Slot  Enter: Equip/Unequip  Esc: Back"
 		_refresh_display()
 		return
 
@@ -242,83 +243,77 @@ func _refresh_display() -> void:
 	for child in equip_panel.get_children():
 		child.queue_free()
 
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
-	vbox.add_theme_constant_override("separation", 8)
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
-	var header := Label.new()
-	header.text = "── Equipment Slots ──"
-	header.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(header)
+	var selected_pill: Control = null
 
 	if _choosing_item:
-		# Show item selection list
-		var slot_label := Label.new()
-		slot_label.text = "Select %s:" % visible_names[_selected_slot]
-		slot_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-		vbox.add_child(slot_label)
+		# Item selection header
+		vbox.add_child(PszStyle.create_section_header("Select %s" % visible_names[_selected_slot]))
 
 		for i in range(_equippable_items.size()):
 			var item: Dictionary = _equippable_items[i]
-			var label := Label.new()
 			var item_id: String = str(item.get("id", ""))
 			var is_equipped: bool = item.get("equipped", false)
 			var is_unequip: bool = item_id == UNEQUIP_SENTINEL
 
+			var display_text: String
+			var text_color := Color.TRANSPARENT
+
 			if is_unequip:
-				label.text = item.name
+				display_text = item.name
+				text_color = PszStyle.TEXT_DANGER
 			else:
 				var detail_str := _get_item_brief(item_id)
 				var tag: String = " [Equipped]" if is_equipped else ""
 				if detail_str.is_empty():
-					label.text = "%s%s" % [item.name, tag]
+					display_text = "%s%s" % [item.name, tag]
 				else:
-					label.text = "%-16s %s%s" % [str(item.get("name", "")), detail_str, tag]
+					display_text = "%s  %s%s" % [str(item.get("name", "")), detail_str, tag]
+				if is_equipped:
+					text_color = PszStyle.TEXT_HIGHLIGHT
 
+			var pill := PszStyle.create_pill(display_text, i == _selected_item, "", text_color)
+			vbox.add_child(pill)
 			if i == _selected_item:
-				label.text = "> " + label.text
-				if is_equipped:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				elif is_unequip:
-					label.add_theme_color_override("font_color", ThemeColors.DANGER)
-				else:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			else:
-				label.text = "  " + label.text
-				if is_equipped:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				elif is_unequip:
-					label.add_theme_color_override("font_color", ThemeColors.DANGER)
-			vbox.add_child(label)
+				selected_pill = pill
 	else:
-		# Show equipment slots (dynamic based on armor)
+		# Equipment slots
+		vbox.add_child(PszStyle.create_section_header("Equipment Slots"))
+
 		for i in range(visible_slots.size()):
 			var slot_key: String = visible_slots[i]
 			var equipped: String = str(equipment.get(slot_key, ""))
 			var slot_name: String = visible_names[i]
 
 			var item_display: String = "[Empty]"
-			if not equipped.is_empty():
+			var text_color := Color.TRANSPARENT
+			if equipped.is_empty():
+				text_color = PszStyle.TEXT_MUTED
+			else:
 				var info: Dictionary = Inventory._lookup_item(equipped)
 				item_display = info.name
-				# Show grind level for weapons
 				if slot_key == "weapon":
 					var grind: int = int(character.get("weapon_grinds", {}).get(equipped, 0))
 					if grind > 0:
 						item_display += " +%d" % grind
 
-			var label := Label.new()
-			label.text = "%-8s %s" % [slot_name, item_display]
+			var pill := PszStyle.create_pill(slot_name, i == _selected_slot, item_display, text_color)
+			vbox.add_child(pill)
 			if i == _selected_slot:
-				label.text = "> " + label.text
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			else:
-				label.text = "  " + label.text
-				if equipped.is_empty():
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
+				selected_pill = pill
 
-			vbox.add_child(label)
+	scroll.add_child(vbox)
+	equip_panel.add_child(scroll)
 
-	equip_panel.add_child(vbox)
+	if selected_pill != null:
+		scroll.ensure_control_visible.call_deferred(selected_pill)
 
 	# Stats panel
 	_refresh_stats()
@@ -426,26 +421,19 @@ func _refresh_stats() -> void:
 				preview_bonuses = _calc_equip_bonuses(preview_equip, character)
 				has_preview = true
 
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
-	vbox.add_theme_constant_override("separation", 4)
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
-	var stat_header := Label.new()
-	stat_header.text = "── Stats ──"
-	stat_header.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(stat_header)
-
-	var name_label := Label.new()
-	name_label.text = "%s  %s Lv.%d" % [
+	vbox.add_child(PszStyle.create_section_header("%s  %s Lv.%d" % [
 		str(character.get("name", "???")),
 		str(character.get("class_id", "???")),
 		level
-	]
-	name_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(name_label)
-
-	var sep := Label.new()
-	sep.text = ""
-	vbox.add_child(sep)
+	]))
 
 	var stat_order := ["hp", "pp", "attack", "defense", "accuracy", "evasion", "technique"]
 	var display_names := ["HP", "PP", "ATK", "DEF", "ACC", "EVA", "TEC"]
@@ -455,26 +443,24 @@ func _refresh_stats() -> void:
 		var base: int = int(base_stats.get(stat_order[i], 0))
 		var cur_bonus: int = int(current_bonuses.get(bonus_keys[i], 0))
 		var effective: int = base + cur_bonus
-		var stat_label := Label.new()
 
 		if has_preview:
 			var pre_bonus: int = int(preview_bonuses.get(bonus_keys[i], 0))
 			var preview_val: int = base + pre_bonus
 			var diff: int = preview_val - effective
 			if diff > 0:
-				stat_label.text = "  %-4s %d → %d (+%d)" % [display_names[i], effective, preview_val, diff]
-				stat_label.add_theme_color_override("font_color", ThemeColors.STAT_POSITIVE)
+				vbox.add_child(PszStyle.create_pill(display_names[i], false,
+					"%d -> %d (+%d)" % [effective, preview_val, diff], PszStyle.TEXT_SUCCESS))
 			elif diff < 0:
-				stat_label.text = "  %-4s %d → %d (%d)" % [display_names[i], effective, preview_val, diff]
-				stat_label.add_theme_color_override("font_color", ThemeColors.STAT_NEGATIVE)
+				vbox.add_child(PszStyle.create_pill(display_names[i], false,
+					"%d -> %d (%d)" % [effective, preview_val, diff], PszStyle.TEXT_DANGER))
 			else:
-				stat_label.text = "  %-4s %d" % [display_names[i], effective]
+				vbox.add_child(PszStyle.create_pill(display_names[i], false, str(effective)))
 		else:
-			stat_label.text = "  %-4s %d" % [display_names[i], effective]
+			vbox.add_child(PszStyle.create_pill(display_names[i], false, str(effective)))
 
-		vbox.add_child(stat_label)
-
-	stats_panel.add_child(vbox)
+	scroll.add_child(vbox)
+	stats_panel.add_child(scroll)
 
 
 func _notify_player_weapon_changed() -> void:

--- a/scripts/2d/guild_counter.gd
+++ b/scripts/2d/guild_counter.gd
@@ -14,6 +14,9 @@ var _selected_difficulty: int = 0
 enum Tab { QUESTS, TUI }
 var _tab: int = Tab.QUESTS
 
+var _mode_bar: HBoxContainer
+
+const TAB_NAMES := ["Quests", "TUI"]
 const DIFFICULTIES := ["Normal", "Hard", "Super-Hard"]
 
 ## Progression order by area
@@ -60,8 +63,10 @@ const AREA_DISPLAY := {
 
 
 func _ready() -> void:
-	title_label.text = "GUILD COUNTER"
-	hint_label.text = "[↑/↓] Select  [ENTER] Accept  [ESC] Leave"
+	_mode_bar = mode_label.get_parent()
+	PszStyle.style_menu(title_label, hint_label, [list_panel, detail_panel])
+	title_label.text = "Guild Counter"
+	hint_label.text = "Up/Down: Select  Enter: Accept  Esc: Leave"
 	_load_entries()
 	_refresh_display()
 	# Show quest status hints
@@ -319,47 +324,41 @@ func _report_quest() -> void:
 
 
 func _refresh_display() -> void:
-	# Mode bar (hidden during active quest)
-	if _has_active_quest():
-		mode_label.text = ""
-	elif _tab == Tab.QUESTS:
-		mode_label.text = "[◄ QUESTS ►]    TUI"
-	else:
-		mode_label.text = "   QUESTS    [◄ TUI ►]"
+	# Tab bar (hidden during active quest)
+	for child in _mode_bar.get_children():
+		child.queue_free()
+	if not _has_active_quest():
+		_mode_bar.add_child(PszStyle.create_tab_bar(TAB_NAMES, _tab))
 
+	# List panel — pill rows
 	for child in list_panel.get_children():
 		child.queue_free()
 
 	var scroll := ScrollContainer.new()
 	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
 	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	var selected_control: Control = null
+	vbox.add_theme_constant_override("separation", 3)
+	var selected_pill: Control = null
 
 	if _selecting_difficulty and not _entries.is_empty():
 		var entry: Dictionary = _entries[_selected_index]
-		var header := Label.new()
-		header.text = "── %s ──\n\nSelect Difficulty:" % entry["name"]
-		header.add_theme_color_override("font_color", ThemeColors.HEADER)
-		vbox.add_child(header)
+		vbox.add_child(PszStyle.create_section_header(entry["name"]))
+		vbox.add_child(PszStyle.detail_label(""))
+		vbox.add_child(PszStyle.detail_label("Select Difficulty:"))
 
 		for i in range(DIFFICULTIES.size()):
-			var label := Label.new()
+			var pill := PszStyle.create_pill(DIFFICULTIES[i], i == _selected_difficulty)
+			vbox.add_child(pill)
 			if i == _selected_difficulty:
-				label.text = "> " + DIFFICULTIES[i]
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				selected_control = label
-			else:
-				label.text = "  " + DIFFICULTIES[i]
-			vbox.add_child(label)
-		hint_label.text = "[↑/↓] Select Difficulty  [ENTER] Accept  [ESC] Back"
+				selected_pill = pill
+		hint_label.text = "Up/Down: Select Difficulty  Enter: Accept  Esc: Back"
 	else:
 		if _entries.is_empty():
-			var empty := Label.new()
-			empty.text = "  (No quests available)" if _tab == Tab.QUESTS else "  (No missions available)"
-			empty.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-			vbox.add_child(empty)
+			var empty_text := "(No quests available)" if _tab == Tab.QUESTS else "(No missions available)"
+			vbox.add_child(PszStyle.create_pill(empty_text, false, "", PszStyle.TEXT_MUTED))
 		else:
 			var last_area := ""
 			for i in range(_entries.size()):
@@ -369,15 +368,10 @@ func _refresh_display() -> void:
 					var area: String = entry["area"]
 					if area != last_area:
 						if not last_area.is_empty():
-							var spacer := Label.new()
-							spacer.text = ""
-							vbox.add_child(spacer)
-						var area_header := Label.new()
-						area_header.text = "── %s ──" % area
-						area_header.add_theme_color_override("font_color", ThemeColors.HEADER)
-						vbox.add_child(area_header)
+							vbox.add_child(PszStyle.detail_label(""))
+						vbox.add_child(PszStyle.create_section_header(area))
 						last_area = area
-				var label := Label.new()
+
 				var unlocked: bool = entry.get("available", true)
 				var entry_type: String = str(entry["type"])
 				var completed: bool = (entry_type == "mission" or entry_type == "quest") and GameState.is_mission_completed(entry["id"])
@@ -390,32 +384,33 @@ func _refresh_display() -> void:
 					status_tag = " [CLEAR]"
 				elif not unlocked:
 					status_tag = " [LOCKED]"
-				label.text = "%-24s%s" % [entry["name"], status_tag]
+
+				# Determine text color
+				var text_color := Color.TRANSPARENT
+				if entry_type == "report":
+					text_color = PszStyle.TEXT_HIGHLIGHT
+				elif entry_type == "cancel":
+					text_color = PszStyle.TEXT_DANGER
+				elif not unlocked:
+					text_color = PszStyle.TEXT_MUTED
+				elif completed:
+					text_color = PszStyle.TEXT_CLEAR
+				elif entry_type == "quest":
+					text_color = PszStyle.TEXT_QUEST
+
+				var pill := PszStyle.create_pill(
+					entry["name"] + status_tag, i == _selected_index, "", text_color)
+				vbox.add_child(pill)
 				if i == _selected_index:
-					label.text = "> " + label.text
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-					selected_control = label
-				else:
-					label.text = "  " + label.text
-					if entry_type == "report":
-						label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-					elif entry_type == "cancel":
-						label.add_theme_color_override("font_color", ThemeColors.DANGER)
-					elif not unlocked:
-						label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-					elif completed:
-						label.add_theme_color_override("font_color", ThemeColors.COMPLETED)
-					elif entry_type == "quest":
-						label.add_theme_color_override("font_color", ThemeColors.QUEST)
-				vbox.add_child(label)
-		hint_label.text = "[←/→] Switch Tab  [↑/↓] Select  [ENTER] Choose  [ESC] Leave"
+					selected_pill = pill
+		hint_label.text = "Left/Right: Switch Tab  Up/Down: Select  Enter: Choose  Esc: Leave"
 
 	scroll.add_child(vbox)
 	list_panel.add_child(scroll)
 
 	# Scroll to selected item after layout
-	if selected_control:
-		scroll.ensure_control_visible.call_deferred(selected_control)
+	if selected_pill:
+		scroll.ensure_control_visible.call_deferred(selected_pill)
 
 	# Detail panel
 	_refresh_detail()
@@ -432,30 +427,21 @@ func _refresh_detail() -> void:
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 4)
 
-	var name_label := Label.new()
-	name_label.text = "── %s ──" % entry["name"]
-	name_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(name_label)
+	vbox.add_child(PszStyle.detail_label(entry["name"], PszStyle.TITLE_BG))
 
-	var area_label := Label.new()
-	area_label.text = "Area: %s" % entry["area"]
-	vbox.add_child(area_label)
+	if not str(entry["area"]).is_empty():
+		vbox.add_child(PszStyle.detail_label("Area: %s" % entry["area"]))
 
 	if entry["type"] == "quest":
-		var type_label := Label.new()
-		type_label.text = "Type: Quest"
-		type_label.add_theme_color_override("font_color", ThemeColors.QUEST)
-		vbox.add_child(type_label)
+		vbox.add_child(PszStyle.detail_label("Type: Quest", PszStyle.TEXT_QUEST))
 		var desc: String = str(entry.get("description", ""))
 		if not desc.is_empty():
-			var desc_label := Label.new()
-			desc_label.text = desc
+			var desc_label := PszStyle.detail_label(desc)
 			desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			vbox.add_child(desc_label)
 	else:
-		var type_label := Label.new()
-		type_label.text = "Type: %s" % ("Main Story" if entry["is_main"] else "Side Quest")
-		vbox.add_child(type_label)
+		var type_text := "Main Story" if entry.get("is_main", false) else "Side Quest"
+		vbox.add_child(PszStyle.detail_label("Type: %s" % type_text))
 
 		var requires: Array = entry["requires"]
 		if not requires.is_empty():
@@ -463,30 +449,20 @@ func _refresh_detail() -> void:
 			for req_id in requires:
 				var req_mission = MissionRegistry.get_mission(req_id)
 				req_names.append(req_mission.name if req_mission else req_id)
-			var req_label := Label.new()
-			req_label.text = "Requires: %s" % ", ".join(req_names)
-			req_label.add_theme_color_override("font_color", ThemeColors.DANGER)
-			vbox.add_child(req_label)
+			vbox.add_child(PszStyle.detail_label("Requires: %s" % ", ".join(req_names), PszStyle.TEXT_DANGER))
 
 		# Rewards
 		var rewards: Dictionary = entry["rewards"]
 		if not rewards.is_empty():
-			var sep := Label.new()
-			sep.text = ""
-			vbox.add_child(sep)
-			var rewards_header := Label.new()
-			rewards_header.text = "Rewards:"
-			rewards_header.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			vbox.add_child(rewards_header)
+			vbox.add_child(PszStyle.detail_label(""))
+			vbox.add_child(PszStyle.detail_label("Rewards:", PszStyle.TEXT_HIGHLIGHT))
 			for diff_key in rewards:
 				var reward: Dictionary = rewards[diff_key]
-				var r := Label.new()
-				r.text = "  %s: %s x%s, %s M" % [
+				vbox.add_child(PszStyle.detail_label("  %s: %s x%s, %s M" % [
 					str(diff_key).capitalize(),
 					str(reward.get("item", "???")),
 					str(reward.get("quantity", 1)),
 					str(reward.get("meseta", 0)),
-				]
-				vbox.add_child(r)
+				]))
 
 	detail_panel.add_child(vbox)

--- a/scripts/2d/inventory_screen.gd
+++ b/scripts/2d/inventory_screen.gd
@@ -5,7 +5,7 @@ const CATEGORY_ORDER := ["Weapon", "Armor", "Unit", "Mag", "Disk", "Consumable",
 
 var _selected_index: int = 0
 var _items: Array = []
-var _item_labels: Array = []  # maps item index -> Label node for scroll-to
+var _item_pills: Array = []  # maps item index -> pill Control for scroll-to
 
 @onready var title_label: Label = $Panel/VBox/TitleLabel
 @onready var grid_panel: PanelContainer = $Panel/VBox/HBox/GridPanel
@@ -14,8 +14,9 @@ var _item_labels: Array = []  # maps item index -> Label node for scroll-to
 
 
 func _ready() -> void:
-	title_label.text = "INVENTORY"
-	hint_label.text = "[↑/↓] Select  [ENTER] Use/Equip  [D] Drop  [ESC] Back"
+	PszStyle.style_menu(title_label, hint_label, [grid_panel, detail_panel])
+	title_label.text = "Inventory"
+	hint_label.text = "Up/Down: Select  Enter: Use/Equip  D: Drop  Esc: Back"
 	_refresh_items()
 	_refresh_display()
 
@@ -42,11 +43,28 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _refresh_items() -> void:
 	_items = Inventory.get_all_items()
+	# Sort by category, then within Weapon by weapon_type + rarity, else alphabetical
 	_items.sort_custom(func(a, b):
-		var ca: int = CATEGORY_ORDER.find(_get_item_category(a.get("id", "")))
-		var cb: int = CATEGORY_ORDER.find(_get_item_category(b.get("id", "")))
+		var id_a: String = str(a.get("id", ""))
+		var id_b: String = str(b.get("id", ""))
+		var ca: int = CATEGORY_ORDER.find(_get_item_category(id_a))
+		var cb: int = CATEGORY_ORDER.find(_get_item_category(id_b))
 		if ca != cb:
 			return ca < cb
+		# Within Weapon category, sort by weapon type then rarity ascending
+		if ca == 0:  # Weapon
+			var wa = WeaponRegistry.get_weapon(id_a)
+			var wb = WeaponRegistry.get_weapon(id_b)
+			if wa and wb:
+				if int(wa.weapon_type) != int(wb.weapon_type):
+					return int(wa.weapon_type) < int(wb.weapon_type)
+				return int(wa.rarity) < int(wb.rarity)
+		# Within Armor category, sort by rarity ascending
+		if ca == 1:  # Armor
+			var aa = ArmorRegistry.get_armor(id_a)
+			var ab = ArmorRegistry.get_armor(id_b)
+			if aa and ab:
+				return int(aa.rarity) < int(ab.rarity)
 		return str(a.get("name", "")) < str(b.get("name", ""))
 	)
 
@@ -110,10 +128,10 @@ func _use_disk(item_id: String) -> void:
 
 
 func _refresh_display() -> void:
-	# Grid panel
+	# Grid panel — pill rows
 	for child in grid_panel.get_children():
 		child.queue_free()
-	_item_labels.clear()
+	_item_pills.clear()
 
 	var scroll := ScrollContainer.new()
 	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -121,12 +139,10 @@ func _refresh_display() -> void:
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
 	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
 	var slot_count := "%d/40 slots" % Inventory.get_total_slots()
-	var header := Label.new()
-	header.text = slot_count
-	header.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-	vbox.add_child(header)
+	vbox.add_child(PszStyle.create_section_header(slot_count))
 
 	# Get equipped item IDs for marking
 	var equipped_ids: Array = []
@@ -148,12 +164,10 @@ func _refresh_display() -> void:
 		char_level = int(character.get("level", 1))
 
 	if _items.is_empty():
-		var empty := Label.new()
-		empty.text = "\n  (Inventory is empty)"
-		empty.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-		vbox.add_child(empty)
+		vbox.add_child(PszStyle.create_pill("(Inventory is empty)", false, "", PszStyle.TEXT_MUTED))
 	else:
 		var current_category := ""
+		var current_weapon_type := -1
 		for i in range(_items.size()):
 			var item: Dictionary = _items[i]
 			var item_id: String = item.get("id", "???")
@@ -164,22 +178,22 @@ func _refresh_display() -> void:
 			var cat: String = _get_item_category(item_id)
 			if cat != current_category:
 				current_category = cat
-				var cat_label := Label.new()
-				cat_label.text = "── %s ──" % cat
-				cat_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-				vbox.add_child(cat_label)
+				current_weapon_type = -1
+				vbox.add_child(PszStyle.create_section_header(cat))
 
-			# Try to resolve weapon/armor data (raw ID first, then normalized)
+			# Weapon type sub-header
 			var weapon = WeaponRegistry.get_weapon(item_id)
 			if weapon == null and is_unresolved:
 				weapon = WeaponRegistry.get_weapon(norm_id)
+			if cat == "Weapon" and weapon:
+				if int(weapon.weapon_type) != current_weapon_type:
+					current_weapon_type = int(weapon.weapon_type)
+
 			var armor_data = ArmorRegistry.get_armor(item_id)
 			if armor_data == null and is_unresolved:
 				armor_data = ArmorRegistry.get_armor(norm_id)
 
-			var label := Label.new()
 			var item_name: String = item.get("name", item_id)
-			# Use proper name from registry for unresolved items
 			if is_unresolved:
 				if weapon:
 					item_name = weapon.name
@@ -195,45 +209,41 @@ func _refresh_display() -> void:
 				if grind > 0:
 					grind_tag = " +%d" % grind
 
-			# Add stars and type for weapons/armor
+			# Stars and type suffix
 			var suffix := ""
 			if weapon:
-				suffix = "%s %s [%s]" % [grind_tag, weapon.get_rarity_string(), weapon.get_weapon_type_name()]
+				suffix = "%s %s" % [grind_tag, weapon.get_rarity_string()]
 			elif armor_data:
-				suffix = " %s [%s]" % [armor_data.get_rarity_string(), armor_data.get_type_name()]
+				suffix = " %s" % armor_data.get_rarity_string()
 
-			if qty > 1:
-				label.text = "%-20s x%d%s%s" % [item_name, qty, equip_tag, suffix]
-			else:
-				label.text = "%s%s%s" % [item_name, equip_tag, suffix]
+			var display_name := item_name + equip_tag + suffix
+			var right_text := "x%d" % qty if qty > 1 else ""
 
-			if i == _selected_index:
-				label.text = "> " + label.text
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			else:
-				label.text = "  " + label.text
-				# Color coding for equippability and unresolved refs
-				if is_unresolved:
-					label.add_theme_color_override("font_color", ThemeColors.RESTRICT_ID)
-				elif weapon and not class_type_race.is_empty():
-					if not weapon.can_be_used_by(class_type_race):
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-					elif char_level < weapon.level:
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-				elif armor_data and not class_type_race.is_empty():
-					if not armor_data.can_be_used_by(class_type_race):
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-					elif char_level < armor_data.level:
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-			vbox.add_child(label)
-			_item_labels.append(label)
+			# Color coding for equippability
+			var text_color := Color.TRANSPARENT
+			if is_unresolved:
+				text_color = PszStyle.TEXT_DANGER
+			elif weapon and not class_type_race.is_empty():
+				if not weapon.can_be_used_by(class_type_race):
+					text_color = PszStyle.TEXT_DANGER
+				elif char_level < weapon.level:
+					text_color = PszStyle.TEXT_WARNING
+			elif armor_data and not class_type_race.is_empty():
+				if not armor_data.can_be_used_by(class_type_race):
+					text_color = PszStyle.TEXT_DANGER
+				elif char_level < armor_data.level:
+					text_color = PszStyle.TEXT_WARNING
+
+			var pill := PszStyle.create_pill(display_name, i == _selected_index, right_text, text_color)
+			vbox.add_child(pill)
+			_item_pills.append(pill)
 
 	scroll.add_child(vbox)
 	grid_panel.add_child(scroll)
 
 	# Scroll to selected item after layout
-	if _selected_index >= 0 and _selected_index < _item_labels.size():
-		scroll.ensure_control_visible.call_deferred(_item_labels[_selected_index])
+	if _selected_index >= 0 and _selected_index < _item_pills.size():
+		scroll.ensure_control_visible.call_deferred(_item_pills[_selected_index])
 
 	# Detail panel
 	_refresh_detail()
@@ -254,14 +264,8 @@ func _refresh_detail() -> void:
 
 	var item_name: String = item.get("name", item_id)
 
-	var name_label := Label.new()
-	name_label.text = item_name
-	name_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(name_label)
-
-	var qty_label := Label.new()
-	qty_label.text = "Quantity: %d" % int(item.get("quantity", 1))
-	vbox.add_child(qty_label)
+	vbox.add_child(PszStyle.detail_label(item_name, PszStyle.TITLE_BG))
+	vbox.add_child(PszStyle.detail_label("Quantity: %d" % int(item.get("quantity", 1))))
 
 	# Check if equipped
 	var character2 = CharacterManager.get_active_character()
@@ -269,30 +273,21 @@ func _refresh_detail() -> void:
 		var equip2: Dictionary = character2.get("equipment", {})
 		for slot_key in equip2:
 			if str(equip2.get(slot_key, "")) == item_id:
-				var equip_label := Label.new()
-				equip_label.text = "[Equipped]"
-				equip_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				vbox.add_child(equip_label)
+				vbox.add_child(PszStyle.detail_label("[Equipped]", PszStyle.TEXT_HIGHLIGHT))
 				break
 
 	# Unresolved reference warning
 	if item_id != norm_id:
-		var warn_label := Label.new()
-		warn_label.text = "[Mismatched ID: %s]" % item_id
-		warn_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_ID)
-		vbox.add_child(warn_label)
+		vbox.add_child(PszStyle.detail_label("[Mismatched ID: %s]" % item_id, PszStyle.TEXT_DANGER))
 
-	# Look up item data from registries (try raw then normalized)
+	# Look up item data from registries
 	var item_data = ItemRegistry.get_item(item_id)
 	if item_data == null:
 		item_data = ItemRegistry.get_item(norm_id)
 	if item_data:
-		var type_label := Label.new()
-		type_label.text = "Type: %s" % item_data.get_type_name()
-		vbox.add_child(type_label)
+		vbox.add_child(PszStyle.detail_label("Type: %s" % item_data.get_type_name()))
 		if not item_data.description.is_empty():
-			var desc_label := Label.new()
-			desc_label.text = item_data.description
+			var desc_label := PszStyle.detail_label(item_data.description)
 			desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			vbox.add_child(desc_label)
 
@@ -300,8 +295,7 @@ func _refresh_detail() -> void:
 	if consumable == null:
 		consumable = ConsumableRegistry.get_consumable(norm_id)
 	if consumable:
-		var details := Label.new()
-		details.text = consumable.details
+		var details := PszStyle.detail_label(consumable.details)
 		details.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 		vbox.add_child(details)
 
@@ -319,59 +313,47 @@ func _refresh_detail() -> void:
 	if weapon == null:
 		weapon = WeaponRegistry.get_weapon(norm_id)
 	if weapon:
-		_add_detail_line(vbox, "Type: %s" % weapon.get_weapon_type_name())
+		vbox.add_child(PszStyle.detail_label("Type: %s" % weapon.get_weapon_type_name()))
 		var grind: int = int(character2.get("weapon_grinds", {}).get(item_id, 0)) if character2 else 0
 		if grind > 0:
-			_add_detail_line(vbox, "ATK: %d (+%d)" % [weapon.attack_base + grind, grind])
+			vbox.add_child(PszStyle.detail_label("ATK: %d (+%d)" % [weapon.attack_base + grind, grind]))
 		else:
-			_add_detail_line(vbox, "ATK: %d" % weapon.attack_base)
-		_add_detail_line(vbox, "ACC: %d" % weapon.accuracy_base)
+			vbox.add_child(PszStyle.detail_label("ATK: %d" % weapon.attack_base))
+		vbox.add_child(PszStyle.detail_label("ACC: %d" % weapon.accuracy_base))
 		if not weapon.element.is_empty() and weapon.element != "None":
-			_add_detail_line(vbox, "Element: %s" % weapon.element)
-		_add_detail_line(vbox, "Rarity: %s" % weapon.get_rarity_string())
+			vbox.add_child(PszStyle.detail_label("Element: %s" % weapon.element))
+		vbox.add_child(PszStyle.detail_label("Rarity: %s" % weapon.get_rarity_string()))
 		if weapon.level > 0:
-			var lvl_label := Label.new()
-			lvl_label.text = "Req. Lv: %d" % weapon.level
-			if char_level < weapon.level:
-				lvl_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-			vbox.add_child(lvl_label)
+			var lvl_color := PszStyle.TEXT_WARNING if char_level < weapon.level else PszStyle.TEXT
+			vbox.add_child(PszStyle.detail_label("Req. Lv: %d" % weapon.level, lvl_color))
 		if not weapon.usable_by.is_empty() and not class_type_race.is_empty():
 			if not weapon.can_be_used_by(class_type_race):
-				var restrict_label := Label.new()
-				restrict_label.text = "[Cannot equip — wrong class]"
-				restrict_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-				vbox.add_child(restrict_label)
+				vbox.add_child(PszStyle.detail_label("[Cannot equip — wrong class]", PszStyle.TEXT_DANGER))
 
 	# Armor details
 	var armor = ArmorRegistry.get_armor(item_id)
 	if armor == null:
 		armor = ArmorRegistry.get_armor(norm_id)
 	if armor:
-		_add_detail_line(vbox, "Type: %s" % armor.get_type_name())
-		_add_detail_line(vbox, "DEF: %d" % armor.defense_base)
-		_add_detail_line(vbox, "EVA: %d" % armor.evasion_base)
-		_add_detail_line(vbox, "Rarity: %s" % armor.get_rarity_string())
+		vbox.add_child(PszStyle.detail_label("Type: %s" % armor.get_type_name()))
+		vbox.add_child(PszStyle.detail_label("DEF: %d" % armor.defense_base))
+		vbox.add_child(PszStyle.detail_label("EVA: %d" % armor.evasion_base))
+		vbox.add_child(PszStyle.detail_label("Rarity: %s" % armor.get_rarity_string()))
 		if armor.level > 0:
-			var lvl_label := Label.new()
-			lvl_label.text = "Req. Lv: %d" % armor.level
-			if char_level < armor.level:
-				lvl_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-			vbox.add_child(lvl_label)
+			var lvl_color := PszStyle.TEXT_WARNING if char_level < armor.level else PszStyle.TEXT
+			vbox.add_child(PszStyle.detail_label("Req. Lv: %d" % armor.level, lvl_color))
 		if not armor.usable_by.is_empty() and not class_type_race.is_empty():
 			if not armor.can_be_used_by(class_type_race):
-				var restrict_label := Label.new()
-				restrict_label.text = "[Cannot equip — wrong class]"
-				restrict_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-				vbox.add_child(restrict_label)
+				vbox.add_child(PszStyle.detail_label("[Cannot equip — wrong class]", PszStyle.TEXT_DANGER))
 
 	# Unit details
 	var unit = UnitRegistry.get_unit(item_id)
 	if unit == null:
 		unit = UnitRegistry.get_unit(norm_id)
 	if unit:
-		_add_detail_line(vbox, "Type: Unit")
+		vbox.add_child(PszStyle.detail_label("Type: Unit"))
 		if unit.effect and not str(unit.effect).is_empty():
-			_add_detail_line(vbox, "Effect: %s" % unit.effect)
+			vbox.add_child(PszStyle.detail_label("Effect: %s" % unit.effect, PszStyle.TEXT_SUCCESS))
 
 	# Disk details
 	if item_id.begins_with("disk_"):
@@ -381,58 +363,49 @@ func _refresh_detail() -> void:
 			var level: int = int(parts[2])
 			var tech: Dictionary = TechniqueManager.get_technique(tech_id)
 			if not tech.is_empty():
-				_add_detail_line(vbox, "Type: Technique Disk")
-				_add_detail_line(vbox, "Element: %s" % str(tech.get("element", "none")).capitalize())
-				_add_detail_line(vbox, "Target: %s" % str(tech.get("target", "single")).capitalize())
+				vbox.add_child(PszStyle.detail_label("Type: Technique Disk"))
+				vbox.add_child(PszStyle.detail_label("Element: %s" % str(tech.get("element", "none")).capitalize()))
+				vbox.add_child(PszStyle.detail_label("Target: %s" % str(tech.get("target", "single")).capitalize()))
 				var power: int = int(tech.get("power", 0))
 				if power > 0:
 					var scaled_power: int = int(float(power) * (1.0 + float(level) / 10.0))
-					_add_detail_line(vbox, "Power: %d (Lv.%d)" % [scaled_power, level])
+					vbox.add_child(PszStyle.detail_label("Power: %d (Lv.%d)" % [scaled_power, level]))
 				var pp_cost: int = maxi(1, int(tech.get("pp", 5)) - int(float(level) / 5.0))
-				_add_detail_line(vbox, "PP Cost: %d" % pp_cost)
+				vbox.add_child(PszStyle.detail_label("PP Cost: %d" % pp_cost))
 				var required_level: int = TechniqueManager.get_disk_required_level(level)
-				var req_label := Label.new()
-				req_label.text = "Req. Level: %d" % required_level
-				if char_level < required_level:
-					req_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-				vbox.add_child(req_label)
+				var req_color := PszStyle.TEXT_WARNING if char_level < required_level else PszStyle.TEXT
+				vbox.add_child(PszStyle.detail_label("Req. Level: %d" % required_level, req_color))
 				if character2:
 					var current_tech_level: int = TechniqueManager.get_technique_level(character2, tech_id)
 					if current_tech_level > 0:
-						var cur_label := Label.new()
 						if current_tech_level >= level:
-							cur_label.text = "Known: Lv.%d (already higher)" % current_tech_level
-							cur_label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
+							vbox.add_child(PszStyle.detail_label("Known: Lv.%d (already higher)" % current_tech_level, PszStyle.TEXT_MUTED))
 						else:
-							cur_label.text = "Known: Lv.%d → Lv.%d" % [current_tech_level, level]
-							cur_label.add_theme_color_override("font_color", ThemeColors.EQUIPPABLE)
-						vbox.add_child(cur_label)
+							vbox.add_child(PszStyle.detail_label("Known: Lv.%d -> Lv.%d" % [current_tech_level, level], PszStyle.TEXT_SUCCESS))
 
 	# Material details
 	if CombatManager.MATERIAL_STAT_MAP.has(item_id):
 		var mat = MaterialRegistry.get_material(item_id)
 		if mat:
-			_add_detail_line(vbox, "Type: Material")
+			vbox.add_child(PszStyle.detail_label("Type: Material"))
 			if not mat.details.is_empty():
-				var detail_label := Label.new()
-				detail_label.text = mat.details
-				detail_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-				vbox.add_child(detail_label)
+				var detail_lbl := PszStyle.detail_label(mat.details)
+				detail_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+				vbox.add_child(detail_lbl)
 		var stat_name: String = CombatManager.MATERIAL_STAT_MAP[item_id]
 		if stat_name == "reset":
-			_add_detail_line(vbox, "Resets all material bonuses")
+			vbox.add_child(PszStyle.detail_label("Resets all material bonuses"))
 		else:
-			_add_detail_line(vbox, "Stat: %s +2" % stat_name.capitalize())
+			vbox.add_child(PszStyle.detail_label("Stat: %s +2" % stat_name.capitalize()))
 		var character3 = CharacterManager.get_active_character()
 		if character3:
 			var used: int = int(character3.get("materials_used", 0))
-			_add_detail_line(vbox, "Materials used: %d/%d" % [used, CombatManager.MAX_MATERIALS])
+			vbox.add_child(PszStyle.detail_label("Materials used: %d/%d" % [used, CombatManager.MAX_MATERIALS]))
 
 	detail_panel.add_child(vbox)
 
 
 func _get_item_category(item_id: String) -> String:
-	# Normalize ID for registry lookups (save data may have hyphens/slashes)
 	var norm_id: String = item_id.replace("-", "_").replace("/", "_")
 	if WeaponRegistry.get_weapon(item_id) or WeaponRegistry.get_weapon(norm_id):
 		return "Weapon"
@@ -456,9 +429,3 @@ func _get_item_category(item_id: String) -> String:
 	if item_data:
 		return "Key Item"
 	return "Other"
-
-
-func _add_detail_line(parent: VBoxContainer, text: String) -> void:
-	var label := Label.new()
-	label.text = text
-	parent.add_child(label)

--- a/scripts/2d/shops/item_shop.gd
+++ b/scripts/2d/shops/item_shop.gd
@@ -8,6 +8,7 @@ const TAB_NAMES := ["Items", "Disks", "Sell"]
 
 var _tab: int = Tab.ITEMS
 var _selected_index: int = 0
+var _confirming: bool = false
 
 # Items tab data
 var _shop_items: Array = []
@@ -79,11 +80,21 @@ func _update_hint() -> void:
 		hint_label.text = "Left/Right: Category  Up/Down: Select  Enter: Buy  Esc: Leave"
 
 
+func _cancel_confirm() -> void:
+	_confirming = false
+	_update_hint()
+	_refresh_display()
+
+
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
-		SceneManager.pop_scene()
+		if _confirming:
+			_cancel_confirm()
+		else:
+			SceneManager.pop_scene()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_left"):
+		_confirming = false
 		_tab = wrapi(_tab - 1, 0, TAB_COUNT)
 		_selected_index = 0
 		if _tab == Tab.SELL:
@@ -92,6 +103,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_right"):
+		_confirming = false
 		_tab = wrapi(_tab + 1, 0, TAB_COUNT)
 		_selected_index = 0
 		if _tab == Tab.SELL:
@@ -100,15 +112,23 @@ func _unhandled_input(event: InputEvent) -> void:
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_up"):
+		_confirming = false
 		_selected_index = wrapi(_selected_index - 1, 0, maxi(_get_current_list().size(), 1))
+		_update_hint()
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_down"):
+		_confirming = false
 		_selected_index = wrapi(_selected_index + 1, 0, maxi(_get_current_list().size(), 1))
+		_update_hint()
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_accept"):
-		_on_select()
+		if _confirming:
+			_confirming = false
+			_on_select()
+		else:
+			_ask_confirm()
 		get_viewport().set_input_as_handled()
 
 
@@ -118,6 +138,23 @@ func _get_current_list() -> Array:
 		Tab.DISKS: return _disk_items
 		Tab.SELL: return _sell_items
 	return _shop_items
+
+
+func _ask_confirm() -> void:
+	var list := _get_current_list()
+	if list.is_empty() or _selected_index >= list.size():
+		return
+	var item: Dictionary = list[_selected_index]
+	if _tab == Tab.SELL:
+		var sell_price: int = int(item.get("sell_price", 0))
+		hint_label.text = "Sell %s for %d M? [Enter] Yes  [Esc] No" % [str(item.get("name", "???")), sell_price]
+	elif _tab == Tab.ITEMS:
+		var cost: int = int(item.get("cost", 0))
+		hint_label.text = "Buy %s for %d M? [Enter] Yes  [Esc] No" % [str(item.get("item", "???")), cost]
+	else:
+		var cost: int = int(item.get("cost", 0))
+		hint_label.text = "Buy %s for %d M? [Enter] Yes  [Esc] No" % [str(item.get("name", "???")), cost]
+	_confirming = true
 
 
 func _on_select() -> void:

--- a/scripts/2d/shops/item_shop.gd
+++ b/scripts/2d/shops/item_shop.gd
@@ -4,6 +4,7 @@ extends Control
 enum Tab { ITEMS, DISKS, SELL }
 
 const TAB_COUNT := 3
+const TAB_NAMES := ["Items", "Disks", "Sell"]
 
 var _tab: int = Tab.ITEMS
 var _selected_index: int = 0
@@ -17,6 +18,8 @@ var _disk_items: Array = []
 # Sell tab data
 var _sell_items: Array = []
 
+var _mode_bar: HBoxContainer
+
 @onready var title_label: Label = $Panel/VBox/TitleLabel
 @onready var mode_label: Label = $Panel/VBox/ModeBar/ModeLabel
 @onready var shop_panel: PanelContainer = $Panel/VBox/HBox/ShopPanel
@@ -25,7 +28,9 @@ var _sell_items: Array = []
 
 
 func _ready() -> void:
-	title_label.text = "SHOP"
+	_mode_bar = mode_label.get_parent()
+	PszStyle.style_menu(title_label, hint_label, [shop_panel, detail_panel])
+	title_label.text = "Item Shop"
 	_update_hint()
 	_load_shop_items()
 	_generate_disk_inventory()
@@ -69,9 +74,9 @@ func _generate_sell_list() -> void:
 
 func _update_hint() -> void:
 	if _tab == Tab.SELL:
-		hint_label.text = "[←/→] Category  [↑/↓] Select  [ENTER] Sell  [ESC] Leave"
+		hint_label.text = "Left/Right: Category  Up/Down: Select  Enter: Sell  Esc: Leave"
 	else:
-		hint_label.text = "[←/→] Category  [↑/↓] Select  [ENTER] Buy  [ESC] Leave"
+		hint_label.text = "Left/Right: Category  Up/Down: Select  Enter: Buy  Esc: Leave"
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -191,17 +196,15 @@ func _sell_selected() -> void:
 
 
 func _refresh_display() -> void:
-	# Mode bar
-	var tab_names := ["ITEMS", "DISKS", "SELL"]
-	var parts := []
-	for i in range(TAB_COUNT):
-		if i == _tab:
-			parts.append("[◄ %s ►]" % tab_names[i])
-		else:
-			parts.append("   %s   " % tab_names[i])
-	mode_label.text = "%s |  Meseta: %s" % ["  ".join(PackedStringArray(parts)), _get_meseta_str()]
+	# Tab bar
+	for child in _mode_bar.get_children():
+		child.queue_free()
+	var tab_bar := PszStyle.create_tab_bar(TAB_NAMES, _tab)
+	_mode_bar.add_child(tab_bar)
+	var meseta_lbl := PszStyle.create_meseta_label(_get_meseta())
+	_mode_bar.add_child(meseta_lbl)
 
-	# Shop panel
+	# Shop panel — pill rows
 	for child in shop_panel.get_children():
 		child.queue_free()
 
@@ -212,51 +215,41 @@ func _refresh_display() -> void:
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
 	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
-	var selected_label: Label = null
+	var selected_pill: Control = null
 
 	if list.is_empty():
-		var empty := Label.new()
-		if _tab == Tab.SELL:
-			empty.text = "  (Nothing to sell)"
-		elif _tab == Tab.ITEMS:
-			empty.text = "  (No items)"
-		else:
-			empty.text = "  (No techniques available)"
-		empty.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-		vbox.add_child(empty)
+		var empty_text := "(Nothing to sell)" if _tab == Tab.SELL else "(No items)" if _tab == Tab.ITEMS else "(No techniques available)"
+		var pill := PszStyle.create_pill(empty_text, false, "", PszStyle.TEXT_MUTED)
+		vbox.add_child(pill)
 	elif _tab == Tab.SELL:
 		for i in range(list.size()):
 			var item: Dictionary = list[i]
 			var sell_price: int = int(item.get("sell_price", 0))
 			var qty: int = int(item.get("quantity", 1))
 			var qty_str := " x%d" % qty if qty > 1 else ""
-			var label := Label.new()
-			label.text = "%-18s%s %6d M" % [str(item.get("name", "???")), qty_str, sell_price]
+			var pill := PszStyle.create_pill(
+				str(item.get("name", "???")) + qty_str,
+				i == _selected_index, "%d M" % sell_price)
+			vbox.add_child(pill)
 			if i == _selected_index:
-				label.text = "> " + label.text
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				selected_label = label
-			else:
-				label.text = "  " + label.text
-			vbox.add_child(label)
+				selected_pill = pill
 	elif _tab == Tab.ITEMS:
 		for i in range(list.size()):
-			var label := Label.new()
 			var item: Dictionary = list[i]
 			var shop_name: String = str(item.get("item", "???"))
 			var item_id: String = shop_name.to_lower().replace(" ", "_").replace("-", "_").replace("/", "_")
 			var held: int = Inventory.get_item_count(item_id)
 			var held_str: String = " (%d)" % held if held > 0 else ""
-			label.text = "%-18s%s %5d M" % [shop_name, held_str, int(item.get("cost", 0))]
+			var pill := PszStyle.create_pill(
+				shop_name + held_str,
+				i == _selected_index, "%d M" % int(item.get("cost", 0)))
+			vbox.add_child(pill)
 			if i == _selected_index:
-				label.text = "> " + label.text
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				selected_label = label
-			else:
-				label.text = "  " + label.text
-			vbox.add_child(label)
+				selected_pill = pill
 	else:
+		# Disks tab
 		var character = CharacterManager.get_active_character()
 		var char_level: int = int(character.get("level", 1)) if character else 1
 		var current_meseta: int = int(character.get("meseta", 0)) if character else 0
@@ -277,45 +270,33 @@ func _refresh_display() -> void:
 			var too_low_level: bool = char_level < required_level
 			var already_higher: bool = current_tech_level >= level
 
-			var status_tag := ""
+			var text_color := Color.TRANSPARENT
 			if already_higher:
-				status_tag = " [Lv.%d]" % current_tech_level
-			elif current_tech_level > 0:
+				text_color = PszStyle.TEXT_MUTED
+			elif too_low_level:
+				text_color = PszStyle.TEXT_WARNING
+			elif cant_afford:
+				text_color = PszStyle.TEXT_WARNING
+
+			var status_tag := ""
+			if current_tech_level > 0:
 				status_tag = " [Lv.%d]" % current_tech_level
 			if too_low_level:
 				status_tag += " [Req.%d]" % required_level
 
-			var label := Label.new()
-			label.text = "%-22s %5d M%s" % [disk_name, cost, status_tag]
-
+			var pill := PszStyle.create_pill(
+				disk_name + status_tag,
+				i == _selected_index, "%d M" % cost, text_color)
+			vbox.add_child(pill)
 			if i == _selected_index:
-				label.text = "> " + label.text
-				if already_higher:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-				elif too_low_level:
-					label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-				elif cant_afford:
-					label.add_theme_color_override("font_color", ThemeColors.WARNING)
-				else:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				selected_label = label
-			else:
-				label.text = "  " + label.text
-				if already_higher:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-				elif too_low_level:
-					label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-				elif cant_afford:
-					label.add_theme_color_override("font_color", ThemeColors.WARNING)
-			vbox.add_child(label)
+				selected_pill = pill
 
 	scroll.add_child(vbox)
 	shop_panel.add_child(scroll)
 
-	if selected_label != null:
-		scroll.ensure_control_visible.call_deferred(selected_label)
+	if selected_pill != null:
+		scroll.ensure_control_visible.call_deferred(selected_pill)
 
-	# Detail panel
 	_refresh_detail()
 
 
@@ -339,26 +320,21 @@ func _refresh_item_detail(item: Dictionary) -> void:
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 4)
 
-	var name_label := Label.new()
-	name_label.text = "── %s ──" % str(item.get("item", "???"))
-	name_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(name_label)
+	vbox.add_child(PszStyle.detail_label(str(item.get("item", "???")), PszStyle.TITLE_BG))
 
-	var cat_label := Label.new()
-	cat_label.text = "Category: %s" % str(item.get("category", "unknown"))
+	var cat_label := PszStyle.detail_label("Category: %s" % str(item.get("category", "unknown")))
 	vbox.add_child(cat_label)
 
-	var cost_label := Label.new()
-	cost_label.text = "Cost: %d %s" % [int(item.get("cost", 0)), str(item.get("currency", "Meseta"))]
-	cost_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
+	var cost_label := PszStyle.detail_label(
+		"Cost: %d %s" % [int(item.get("cost", 0)), str(item.get("currency", "Meseta"))],
+		PszStyle.TEXT_HIGHLIGHT)
 	vbox.add_child(cost_label)
 
 	var consumable = ConsumableRegistry.get_consumable(
 		str(item.get("item", "")).to_lower().replace(" ", "_").replace("-", "_").replace("/", "_")
 	)
 	if consumable:
-		var details_label := Label.new()
-		details_label.text = consumable.details
+		var details_label := PszStyle.detail_label(consumable.details)
 		details_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 		vbox.add_child(details_label)
 
@@ -375,55 +351,35 @@ func _refresh_disk_detail(item: Dictionary) -> void:
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 4)
 
-	var name_label := Label.new()
-	name_label.text = "── %s ──" % str(item.get("name", "???"))
-	name_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(name_label)
-
-	_add_line(vbox, "Element: %s" % str(tech.get("element", "none")).capitalize())
-	_add_line(vbox, "Target: %s" % str(tech.get("target", "single")).capitalize())
+	vbox.add_child(PszStyle.detail_label(str(item.get("name", "???")), PszStyle.TITLE_BG))
+	vbox.add_child(PszStyle.detail_label("Element: %s" % str(tech.get("element", "none")).capitalize()))
+	vbox.add_child(PszStyle.detail_label("Target: %s" % str(tech.get("target", "single")).capitalize()))
 
 	var power: int = int(tech.get("power", 0))
 	if power > 0:
 		var scaled_power: int = int(float(power) * (1.0 + float(level) / 10.0))
-		_add_line(vbox, "Power: %d (Lv.%d)" % [scaled_power, level])
+		vbox.add_child(PszStyle.detail_label("Power: %d (Lv.%d)" % [scaled_power, level]))
 
 	var pp_cost: int = maxi(1, int(tech.get("pp", 5)) - int(float(level) / 5.0))
-	_add_line(vbox, "PP Cost: %d" % pp_cost)
+	vbox.add_child(PszStyle.detail_label("PP Cost: %d" % pp_cost))
 
 	var required_level: int = TechniqueManager.get_disk_required_level(level)
 	var character = CharacterManager.get_active_character()
 	var char_level: int = int(character.get("level", 1)) if character else 1
-	var req_label := Label.new()
-	req_label.text = "Req. Level: %d" % required_level
-	if char_level < required_level:
-		req_label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-	vbox.add_child(req_label)
+	var req_color := PszStyle.TEXT_WARNING if char_level < required_level else PszStyle.TEXT
+	vbox.add_child(PszStyle.detail_label("Req. Level: %d" % required_level, req_color))
 
 	if character:
 		var current_level: int = TechniqueManager.get_technique_level(character, technique_id)
 		if current_level > 0:
-			var cur_label := Label.new()
 			if current_level >= level:
-				cur_label.text = "Known: Lv.%d (already higher)" % current_level
-				cur_label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
+				vbox.add_child(PszStyle.detail_label("Known: Lv.%d (already higher)" % current_level, PszStyle.TEXT_MUTED))
 			else:
-				cur_label.text = "Known: Lv.%d → Lv.%d" % [current_level, level]
-				cur_label.add_theme_color_override("font_color", ThemeColors.EQUIPPABLE)
-			vbox.add_child(cur_label)
+				vbox.add_child(PszStyle.detail_label("Known: Lv.%d -> Lv.%d" % [current_level, level], PszStyle.TEXT_SUCCESS))
 
-	var sep := Label.new()
-	sep.text = ""
-	vbox.add_child(sep)
-	var cost_label := Label.new()
-	cost_label.text = "Price: %d M" % int(item.get("cost", 0))
-	cost_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(cost_label)
-
-	var note := Label.new()
-	note.text = "Use from inventory to learn"
-	note.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-	vbox.add_child(note)
+	vbox.add_child(PszStyle.detail_label(""))
+	vbox.add_child(PszStyle.detail_label("Price: %d M" % int(item.get("cost", 0)), PszStyle.TEXT_HIGHLIGHT))
+	vbox.add_child(PszStyle.detail_label("Use from inventory to learn", PszStyle.TEXT_MUTED))
 
 	detail_panel.add_child(vbox)
 
@@ -432,34 +388,16 @@ func _refresh_sell_detail(item: Dictionary) -> void:
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 4)
 
-	var name_label := Label.new()
-	name_label.text = "── %s ──" % str(item.get("name", "???"))
-	name_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(name_label)
-
-	var qty_label := Label.new()
-	qty_label.text = "Owned: %d" % int(item.get("quantity", 0))
-	vbox.add_child(qty_label)
-
-	var sep := Label.new()
-	sep.text = ""
-	vbox.add_child(sep)
-	var sell_label := Label.new()
-	sell_label.text = "Sell: %d M" % int(item.get("sell_price", 0))
-	sell_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(sell_label)
+	vbox.add_child(PszStyle.detail_label(str(item.get("name", "???")), PszStyle.TITLE_BG))
+	vbox.add_child(PszStyle.detail_label("Owned: %d" % int(item.get("quantity", 0))))
+	vbox.add_child(PszStyle.detail_label(""))
+	vbox.add_child(PszStyle.detail_label("Sell: %d M" % int(item.get("sell_price", 0)), PszStyle.TEXT_HIGHLIGHT))
 
 	detail_panel.add_child(vbox)
 
 
-func _add_line(parent: VBoxContainer, text: String) -> void:
-	var label := Label.new()
-	label.text = text
-	parent.add_child(label)
-
-
-func _get_meseta_str() -> String:
+func _get_meseta() -> int:
 	var character = CharacterManager.get_active_character()
 	if character:
-		return str(int(character.get("meseta", 0)))
-	return "0"
+		return int(character.get("meseta", 0))
+	return 0

--- a/scripts/2d/shops/tekker.gd
+++ b/scripts/2d/shops/tekker.gd
@@ -3,10 +3,15 @@ extends Control
 
 enum Mode { GRIND, IDENTIFY }
 
+const TAB_NAMES := ["Grind", "Identify"]
+
 var _mode: int = Mode.GRIND
 var _selected_index: int = 0
 var _grindable_weapons: Array = []  # Array of {id, name, grind, max_grind, rarity}
 var _unidentified_weapons: Array = []  # Array of {id, name, rarity}
+
+var _mode_bar_parent: Control  # Parent of mode_label for tab bar rebuilding
+var _tab_row: HBoxContainer    # Persistent tab bar container
 
 ## Grinder requirements by weapon rarity
 const GRINDER_FOR_RARITY := {
@@ -26,8 +31,10 @@ const IDENTIFY_COST := {5: 1000, 6: 2500, 7: 5000}
 
 
 func _ready() -> void:
-	title_label.text = "TEKKER"
-	hint_label.text = "[←/→] Switch Mode  [↑/↓] Select  [ENTER] Confirm  [ESC] Leave"
+	_mode_bar_parent = mode_label.get_parent()
+	PszStyle.style_menu(title_label, hint_label, [content_panel])
+	title_label.text = "Tekker"
+	hint_label.text = "Left/Right: Switch Mode  Up/Down: Select  Enter: Confirm  Esc: Leave"
 	_build_lists()
 	_refresh_display()
 
@@ -171,72 +178,82 @@ func _identify_selected() -> void:
 
 
 func _refresh_display() -> void:
-	if _mode == Mode.GRIND:
-		mode_label.text = "[◄ GRIND ►]    IDENTIFY"
-	else:
-		mode_label.text = "   GRIND    [◄ IDENTIFY ►]"
+	# Tab bar — mode_label is direct child of VBox, so we hide it and
+	# reuse a persistent HBoxContainer for the tab bar
+	mode_label.visible = false
 
+	if not is_instance_valid(_tab_row):
+		_tab_row = HBoxContainer.new()
+		_tab_row.alignment = BoxContainer.ALIGNMENT_CENTER
+		_tab_row.add_theme_constant_override("separation", 8)
+		_mode_bar_parent.add_child(_tab_row)
+		_mode_bar_parent.move_child(_tab_row, mode_label.get_index() + 1)
+	for child in _tab_row.get_children():
+		child.queue_free()
+	_tab_row.add_child(PszStyle.create_tab_bar(TAB_NAMES, _mode))
+	_tab_row.add_child(PszStyle.create_meseta_label(_get_meseta()))
+
+	# Content panel — pill rows
 	for child in content_panel.get_children():
 		child.queue_free()
 
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
-	vbox.add_theme_constant_override("separation", 4)
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
-	var character = CharacterManager.get_active_character()
-	var meseta_label := Label.new()
-	meseta_label.text = "Meseta: %d" % (int(character.get("meseta", 0)) if character else 0)
-	meseta_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(meseta_label)
+	var selected_pill: Control = null
 
 	if _mode == Mode.GRIND:
-		var desc := Label.new()
-		desc.text = "Grinding increases a weapon's attack power."
-		desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		vbox.add_child(desc)
+		vbox.add_child(PszStyle.create_section_header("Grinding increases a weapon's attack power."))
 
 		if _grindable_weapons.is_empty():
-			var placeholder := Label.new()
-			placeholder.text = "(No grindable weapons in inventory)"
-			placeholder.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-			vbox.add_child(placeholder)
+			vbox.add_child(PszStyle.create_pill("(No grindable weapons in inventory)", false, "", PszStyle.TEXT_MUTED))
 		else:
 			for i in range(_grindable_weapons.size()):
 				var w: Dictionary = _grindable_weapons[i]
 				var grinder_id: String = GRINDER_FOR_RARITY.get(w["rarity"], "monogrinder")
 				var has_grinder: bool = Inventory.has_item(grinder_id)
 				var cost := int((200 + w["grind"] * 100) * RARITY_COST_MULT.get(w["rarity"], 1.0))
-				var label := Label.new()
-				label.text = "%-18s +%d/%d  %d M  [%s]" % [w["name"], w["grind"], w["max_grind"], cost, grinder_id.replace("_", " ")]
+
+				var text_color := Color.TRANSPARENT
+				if not has_grinder:
+					text_color = PszStyle.TEXT_DANGER
+
+				var pill := PszStyle.create_pill(
+					"%s  +%d/%d  [%s]" % [w["name"], w["grind"], w["max_grind"], grinder_id.replace("_", " ")],
+					i == _selected_index, "%d M" % cost, text_color)
+				vbox.add_child(pill)
 				if i == _selected_index:
-					label.text = "> " + label.text
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT if has_grinder else ThemeColors.DANGER)
-				else:
-					label.text = "  " + label.text
-					if not has_grinder:
-						label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-				vbox.add_child(label)
+					selected_pill = pill
 	else:
-		var desc := Label.new()
-		desc.text = "Identification reveals the true stats of\nunidentified weapons (5-7★ rarity)."
-		desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		vbox.add_child(desc)
+		vbox.add_child(PszStyle.create_section_header("Identify unknown weapons (5-7 star rarity)."))
 
 		if _unidentified_weapons.is_empty():
-			var placeholder := Label.new()
-			placeholder.text = "(No unidentified weapons)"
-			placeholder.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-			vbox.add_child(placeholder)
+			vbox.add_child(PszStyle.create_pill("(No unidentified weapons)", false, "", PszStyle.TEXT_MUTED))
 		else:
 			for i in range(_unidentified_weapons.size()):
 				var w: Dictionary = _unidentified_weapons[i]
 				var cost: int = IDENTIFY_COST.get(w["rarity"], 1000)
-				var label := Label.new()
-				label.text = "%-18s %s★  %d M" % [w["name"], str(w["rarity"]), cost]
+				var pill := PszStyle.create_pill(
+					"%s  %s star" % [w["name"], str(w["rarity"])],
+					i == _selected_index, "%d M" % cost)
+				vbox.add_child(pill)
 				if i == _selected_index:
-					label.text = "> " + label.text
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				else:
-					label.text = "  " + label.text
-				vbox.add_child(label)
+					selected_pill = pill
 
-	content_panel.add_child(vbox)
+	scroll.add_child(vbox)
+	content_panel.add_child(scroll)
+
+	if selected_pill != null:
+		scroll.ensure_control_visible.call_deferred(selected_pill)
+
+
+func _get_meseta() -> int:
+	var character = CharacterManager.get_active_character()
+	if character:
+		return int(character.get("meseta", 0))
+	return 0

--- a/scripts/2d/shops/weapon_shop.gd
+++ b/scripts/2d/shops/weapon_shop.gd
@@ -3,7 +3,7 @@ extends Control
 
 enum Tab { WEAPONS, ARMOR, UNITS, SELL }
 
-const TAB_NAMES := ["WEAPONS", "ARMOR", "UNITS", "SELL"]
+const TAB_NAMES := ["Weapons", "Armor", "Units", "Sell"]
 const TAB_COUNT := 4
 
 var _tab: int = Tab.WEAPONS
@@ -13,6 +13,8 @@ var _weapons: Array = []
 var _armors: Array = []
 var _units: Array = []
 var _sell_items: Array = []
+
+var _mode_bar: HBoxContainer
 
 ## Set true to show all weapon tiers in the shop (for testing)
 const DEBUG_ALL_TIERS := true
@@ -56,7 +58,9 @@ const SHOP_UNIT_IDS := [
 
 
 func _ready() -> void:
-	title_label.text = "WEAPON SHOP"
+	_mode_bar = mode_label.get_parent()
+	PszStyle.style_menu(title_label, hint_label, [list_panel, detail_panel])
+	title_label.text = "Weapon Shop"
 	_update_hint()
 	_generate_inventory()
 	_refresh_display()
@@ -80,7 +84,14 @@ func _generate_inventory() -> void:
 		_weapons.append({
 			"id": w.id, "name": w.name, "category": "weapon",
 			"cost": price, "sell_price": int(price * 0.25),
+			"weapon_type": int(w.weapon_type), "weapon_type_name": w.get_weapon_type_name(),
+			"rarity": int(w.rarity),
 		})
+	_weapons.sort_custom(func(a, b):
+		if a["weapon_type"] != b["weapon_type"]:
+			return a["weapon_type"] < b["weapon_type"]
+		return a["rarity"] < b["rarity"]
+	)
 
 	for aid in SHOP_ARMOR_IDS:
 		var a = ArmorRegistry.get_armor(aid)
@@ -133,7 +144,6 @@ func _generate_sell_list() -> void:
 					item_name = u.name
 					cat = "unit"
 				else:
-					# Consumable or other item — flat sell price
 					sell_price = 10
 					cat = "item"
 		_sell_items.append({
@@ -159,9 +169,9 @@ func _unit_price(u) -> int:
 
 func _update_hint() -> void:
 	if _tab == Tab.SELL:
-		hint_label.text = "[←/→] Category  [↑/↓] Select  [ENTER] Sell  [ESC] Leave"
+		hint_label.text = "Left/Right: Category  Up/Down: Select  Enter: Sell  Esc: Leave"
 	else:
-		hint_label.text = "[←/→] Category  [↑/↓] Select  [ENTER] Buy  [ESC] Leave"
+		hint_label.text = "Left/Right: Category  Up/Down: Select  Enter: Buy  Esc: Leave"
 
 
 func _get_current_list() -> Array:
@@ -304,16 +314,13 @@ func _sell_selected() -> void:
 
 
 func _refresh_display() -> void:
-	# Mode bar — highlight active tab
-	var parts := []
-	for i in range(TAB_COUNT):
-		if i == _tab:
-			parts.append("[◄ %s ►]" % TAB_NAMES[i])
-		else:
-			parts.append("   %s   " % TAB_NAMES[i])
-	mode_label.text = "%s |  Meseta: %s" % ["  ".join(PackedStringArray(parts)), _get_meseta_str()]
+	# Tab bar
+	for child in _mode_bar.get_children():
+		child.queue_free()
+	_mode_bar.add_child(PszStyle.create_tab_bar(TAB_NAMES, _tab))
+	_mode_bar.add_child(PszStyle.create_meseta_label(_get_meseta()))
 
-	# List panel
+	# List panel — pill rows
 	for child in list_panel.get_children():
 		child.queue_free()
 
@@ -327,38 +334,39 @@ func _refresh_display() -> void:
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
 	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
-	var selected_label: Label = null
+	var selected_pill: Control = null
 
 	if list.is_empty():
-		var empty := Label.new()
-		empty.text = "  (Nothing to sell)" if _tab == Tab.SELL else "  (Nothing for sale)"
-		empty.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-		vbox.add_child(empty)
+		var empty_text := "(Nothing to sell)" if _tab == Tab.SELL else "(Nothing for sale)"
+		vbox.add_child(PszStyle.create_pill(empty_text, false, "", PszStyle.TEXT_MUTED))
 	elif _tab == Tab.SELL:
 		for i in range(list.size()):
 			var item: Dictionary = list[i]
 			var sell_price: int = int(item.get("sell_price", 0))
 			var qty: int = int(item.get("quantity", 1))
 			var qty_str := " x%d" % qty if qty > 1 else ""
-			var label := Label.new()
-			label.text = "%-18s%s %6d M" % [str(item.get("name", "???")), qty_str, sell_price]
+			var pill := PszStyle.create_pill(
+				str(item.get("name", "???")) + qty_str,
+				i == _selected_index, "%d M" % sell_price)
+			vbox.add_child(pill)
 			if i == _selected_index:
-				label.text = "> " + label.text
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				selected_label = label
-			else:
-				label.text = "  " + label.text
-			vbox.add_child(label)
+				selected_pill = pill
 	else:
+		var last_type_name := ""
 		for i in range(list.size()):
 			var item: Dictionary = list[i]
 			var item_id: String = str(item.get("id", ""))
 			var cat: String = str(item.get("category", ""))
 			var cost: int = int(item.get("cost", 0))
 
-			var label := Label.new()
-			var held: int = int(Inventory._items.get(item_id, 0))
+			# Section headers for weapon types
+			if _tab == Tab.WEAPONS:
+				var type_name: String = str(item.get("weapon_type_name", ""))
+				if not type_name.is_empty() and type_name != last_type_name:
+					last_type_name = type_name
+					vbox.add_child(PszStyle.create_section_header(type_name))
 
 			# Rarity stars
 			var stars := ""
@@ -375,14 +383,19 @@ func _refresh_display() -> void:
 				if u:
 					stars = " " + u.get_rarity_string() if u.has_method("get_rarity_string") else " " + "*".repeat(int(u.rarity))
 
-			var held_str := ""
-			if held > 1:
-				held_str = " x%d" % held
+			var held: int = int(Inventory._items.get(item_id, 0))
+			var held_str := " x%d" % held if held > 1 else ""
 
 			var equip_check: Dictionary = _check_equippability(item_id, cat)
 			var can_equip: bool = equip_check.get("can_equip", true)
 			var reason: String = str(equip_check.get("reason", ""))
 			var cant_afford: bool = current_meseta < cost
+
+			var text_color := Color.TRANSPARENT
+			if not can_equip:
+				text_color = PszStyle.TEXT_DANGER
+			elif cant_afford:
+				text_color = PszStyle.TEXT_WARNING
 
 			var restriction_tag := ""
 			if not can_equip:
@@ -391,29 +404,18 @@ func _refresh_display() -> void:
 				elif reason == "level":
 					restriction_tag = " [Lv.%d]" % int(equip_check.get("req_level", 1))
 
-			label.text = "%-18s%s%s %6d M%s" % [str(item.get("name", "???")), stars, held_str, cost, restriction_tag]
+			var pill := PszStyle.create_pill(
+				str(item.get("name", "???")) + stars + held_str + restriction_tag,
+				i == _selected_index, "%d M" % cost, text_color)
+			vbox.add_child(pill)
 			if i == _selected_index:
-				label.text = "> " + label.text
-				if not can_equip:
-					label.add_theme_color_override("font_color", ThemeColors.DANGER)
-				elif cant_afford:
-					label.add_theme_color_override("font_color", ThemeColors.WARNING)
-				else:
-					label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-				selected_label = label
-			else:
-				label.text = "  " + label.text
-				if not can_equip:
-					label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-				elif cant_afford:
-					label.add_theme_color_override("font_color", ThemeColors.WARNING)
-			vbox.add_child(label)
+				selected_pill = pill
 
 	scroll.add_child(vbox)
 	list_panel.add_child(scroll)
 
-	if selected_label != null:
-		scroll.ensure_control_visible.call_deferred(selected_label)
+	if selected_pill != null:
+		scroll.ensure_control_visible.call_deferred(selected_pill)
 
 	_refresh_detail()
 
@@ -432,30 +434,27 @@ func _refresh_detail() -> void:
 	var vbox := VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 4)
 
-	var name_label := Label.new()
-	name_label.text = "── %s ──" % str(item.get("name", "???"))
-	name_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(name_label)
+	vbox.add_child(PszStyle.detail_label(str(item.get("name", "???")), PszStyle.TITLE_BG))
 
 	if cat == "weapon":
 		var w = WeaponRegistry.get_weapon(item_id)
 		if w:
-			_add_line(vbox, "Type: %s" % w.get_weapon_type_name())
-			_add_line(vbox, "Rarity: %s" % w.get_rarity_string(), ThemeColors.TEXT_HIGHLIGHT)
-			_add_line(vbox, "ATK: %d-%d" % [w.attack_base, w.attack_max])
-			_add_line(vbox, "ACC: %d" % w.accuracy_base)
+			vbox.add_child(PszStyle.detail_label("Type: %s" % w.get_weapon_type_name()))
+			vbox.add_child(PszStyle.detail_label("Rarity: %s" % w.get_rarity_string(), PszStyle.TEXT_HIGHLIGHT))
+			vbox.add_child(PszStyle.detail_label("ATK: %d-%d" % [w.attack_base, w.attack_max]))
+			vbox.add_child(PszStyle.detail_label("ACC: %d" % w.accuracy_base))
 			if not w.element.is_empty():
-				_add_line(vbox, "Element: %s Lv.%d" % [w.element, w.element_level])
-			_add_line(vbox, "Max Grind: +%d" % w.max_grind)
-			_add_line(vbox, "Req. Level: %d" % w.level)
+				vbox.add_child(PszStyle.detail_label("Element: %s Lv.%d" % [w.element, w.element_level]))
+			vbox.add_child(PszStyle.detail_label("Max Grind: +%d" % w.max_grind))
+			vbox.add_child(PszStyle.detail_label("Req. Level: %d" % w.level))
 	elif cat == "armor":
 		var a = ArmorRegistry.get_armor(item_id)
 		if a:
-			_add_line(vbox, "Rarity: %s" % a.get_rarity_string(), ThemeColors.TEXT_HIGHLIGHT)
-			_add_line(vbox, "DEF: %d-%d" % [a.defense_base, a.defense_max])
-			_add_line(vbox, "EVA: %d-%d" % [a.evasion_base, a.evasion_max])
-			_add_line(vbox, "Unit Slots: %d" % a.max_slots)
-			_add_line(vbox, "Req. Level: %d" % a.level)
+			vbox.add_child(PszStyle.detail_label("Rarity: %s" % a.get_rarity_string(), PszStyle.TEXT_HIGHLIGHT))
+			vbox.add_child(PszStyle.detail_label("DEF: %d-%d" % [a.defense_base, a.defense_max]))
+			vbox.add_child(PszStyle.detail_label("EVA: %d-%d" % [a.evasion_base, a.evasion_max]))
+			vbox.add_child(PszStyle.detail_label("Unit Slots: %d" % a.max_slots))
+			vbox.add_child(PszStyle.detail_label("Req. Level: %d" % a.level))
 			var resists: Array = []
 			if a.resist_fire > 0: resists.append("Fire %d" % a.resist_fire)
 			if a.resist_ice > 0: resists.append("Ice %d" % a.resist_ice)
@@ -463,66 +462,42 @@ func _refresh_detail() -> void:
 			if a.resist_light > 0: resists.append("Lgt %d" % a.resist_light)
 			if a.resist_dark > 0: resists.append("Drk %d" % a.resist_dark)
 			if not resists.is_empty():
-				_add_line(vbox, "Resist: %s" % ", ".join(PackedStringArray(resists)))
+				vbox.add_child(PszStyle.detail_label("Resist: %s" % ", ".join(PackedStringArray(resists))))
 	elif cat == "unit":
 		var u = UnitRegistry.get_unit(item_id)
 		if u:
-			_add_line(vbox, "Rarity: %s" % ("*".repeat(int(u.rarity))), ThemeColors.TEXT_HIGHLIGHT)
-			_add_line(vbox, "Category: %s" % u.category)
-			_add_line(vbox, "Effect: %s" % u.effect, ThemeColors.EQUIPPABLE)
+			vbox.add_child(PszStyle.detail_label("Rarity: %s" % ("*".repeat(int(u.rarity))), PszStyle.TEXT_HIGHLIGHT))
+			vbox.add_child(PszStyle.detail_label("Category: %s" % u.category))
+			vbox.add_child(PszStyle.detail_label("Effect: %s" % u.effect, PszStyle.TEXT_SUCCESS))
 
 	# Price info
-	var sep := Label.new()
-	sep.text = ""
-	vbox.add_child(sep)
+	vbox.add_child(PszStyle.detail_label(""))
 	if _tab == Tab.SELL:
-		var sell_label := Label.new()
-		sell_label.text = "Sell: %d M" % int(item.get("sell_price", 0))
-		sell_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-		vbox.add_child(sell_label)
-		var qty_label := Label.new()
-		qty_label.text = "Owned: %d" % int(item.get("quantity", 0))
-		vbox.add_child(qty_label)
+		vbox.add_child(PszStyle.detail_label("Sell: %d M" % int(item.get("sell_price", 0)), PszStyle.TEXT_HIGHLIGHT))
+		vbox.add_child(PszStyle.detail_label("Owned: %d" % int(item.get("quantity", 0))))
 	else:
-		var cost_label := Label.new()
-		cost_label.text = "Buy: %d M" % int(item.get("cost", 0))
-		cost_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-		vbox.add_child(cost_label)
-		var sell_label := Label.new()
-		sell_label.text = "Sell: %d M" % int(item.get("sell_price", 0))
-		sell_label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-		vbox.add_child(sell_label)
+		vbox.add_child(PszStyle.detail_label("Buy: %d M" % int(item.get("cost", 0)), PszStyle.TEXT_HIGHLIGHT))
+		vbox.add_child(PszStyle.detail_label("Sell: %d M" % int(item.get("sell_price", 0)), PszStyle.TEXT_MUTED))
 
 		# Equippability status
 		if cat in ["weapon", "armor"]:
 			var equip_check: Dictionary = _check_equippability(item_id, cat)
-			var equip_status := Label.new()
 			if equip_check.get("can_equip", true):
-				equip_status.text = "Can equip"
-				equip_status.add_theme_color_override("font_color", ThemeColors.EQUIPPABLE)
+				vbox.add_child(PszStyle.detail_label("Can equip", PszStyle.TEXT_SUCCESS))
 			else:
 				var reason: String = str(equip_check.get("reason", ""))
 				if reason == "class":
-					equip_status.text = "Cannot equip: class"
+					vbox.add_child(PszStyle.detail_label("Cannot equip: class", PszStyle.TEXT_DANGER))
 				elif reason == "level":
-					equip_status.text = "Cannot equip: Lv.%d required" % int(equip_check.get("req_level", 1))
+					vbox.add_child(PszStyle.detail_label("Cannot equip: Lv.%d required" % int(equip_check.get("req_level", 1)), PszStyle.TEXT_DANGER))
 				else:
-					equip_status.text = "Cannot equip"
-				equip_status.add_theme_color_override("font_color", ThemeColors.DANGER)
-			vbox.add_child(equip_status)
+					vbox.add_child(PszStyle.detail_label("Cannot equip", PszStyle.TEXT_DANGER))
 
 	detail_panel.add_child(vbox)
 
 
-func _add_line(parent: VBoxContainer, text: String, color: Color = ThemeColors.TEXT_PRIMARY) -> void:
-	var label := Label.new()
-	label.text = text
-	label.add_theme_color_override("font_color", color)
-	parent.add_child(label)
-
-
-func _get_meseta_str() -> String:
+func _get_meseta() -> int:
 	var character = CharacterManager.get_active_character()
 	if character:
-		return str(int(character.get("meseta", 0)))
-	return "0"
+		return int(character.get("meseta", 0))
+	return 0

--- a/scripts/2d/shops/weapon_shop.gd
+++ b/scripts/2d/shops/weapon_shop.gd
@@ -8,6 +8,7 @@ const TAB_COUNT := 4
 
 var _tab: int = Tab.WEAPONS
 var _selected_index: int = 0
+var _confirming: bool = false
 
 var _weapons: Array = []
 var _armors: Array = []
@@ -218,11 +219,35 @@ func _check_equippability(item_id: String, cat: String) -> Dictionary:
 	return {"can_equip": true, "reason": ""}
 
 
+func _cancel_confirm() -> void:
+	_confirming = false
+	_update_hint()
+	_refresh_display()
+
+
+func _ask_confirm() -> void:
+	var list := _get_current_list()
+	if list.is_empty() or _selected_index >= list.size():
+		return
+	var item: Dictionary = list[_selected_index]
+	if _tab == Tab.SELL:
+		var sell_price: int = int(item.get("sell_price", 0))
+		hint_label.text = "Sell %s for %d M? [Enter] Yes  [Esc] No" % [str(item.get("name", "???")), sell_price]
+	else:
+		var cost: int = int(item.get("cost", 0))
+		hint_label.text = "Buy %s for %d M? [Enter] Yes  [Esc] No" % [str(item.get("name", "???")), cost]
+	_confirming = true
+
+
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
-		SceneManager.pop_scene()
+		if _confirming:
+			_cancel_confirm()
+		else:
+			SceneManager.pop_scene()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_left"):
+		_confirming = false
 		_tab = wrapi(_tab - 1, 0, TAB_COUNT)
 		_selected_index = 0
 		if _tab == Tab.SELL:
@@ -231,6 +256,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_right"):
+		_confirming = false
 		_tab = wrapi(_tab + 1, 0, TAB_COUNT)
 		_selected_index = 0
 		if _tab == Tab.SELL:
@@ -239,18 +265,26 @@ func _unhandled_input(event: InputEvent) -> void:
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_up"):
+		_confirming = false
 		_selected_index = wrapi(_selected_index - 1, 0, maxi(_get_current_list().size(), 1))
+		_update_hint()
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_down"):
+		_confirming = false
 		_selected_index = wrapi(_selected_index + 1, 0, maxi(_get_current_list().size(), 1))
+		_update_hint()
 		_refresh_display()
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("ui_accept"):
-		if _tab == Tab.SELL:
-			_sell_selected()
+		if _confirming:
+			_confirming = false
+			if _tab == Tab.SELL:
+				_sell_selected()
+			else:
+				_buy_selected()
 		else:
-			_buy_selected()
+			_ask_confirm()
 		get_viewport().set_input_as_handled()
 
 

--- a/scripts/2d/status.gd
+++ b/scripts/2d/status.gd
@@ -118,30 +118,16 @@ func _refresh_stats() -> void:
 	vbox.add_child(PszStyle.create_section_header("Base Stats"))
 
 	var stats: Dictionary = character.get("stats", {})
-	var stat_order := ["hp", "pp", "atk", "def", "acc", "eva", "tech"]
-	var stat_names := ["HP", "PP", "ATK", "DEF", "ACC", "EVA", "TECH"]
+	var stat_order := ["atk", "def", "acc", "eva", "tech"]
+	var stat_names := ["ATK", "DEF", "ACC", "EVA", "TECH"]
 
 	for i in range(stat_order.size()):
 		var key: String = stat_order[i]
 		var value: int = int(stats.get(key, 0))
 		vbox.add_child(PszStyle.create_pill(stat_names[i], false, str(value)))
 
-	# Equipment bonuses
-	var equip_bonuses := _calculate_equipment_bonuses(character)
-	var has_bonuses := false
-	for key in equip_bonuses:
-		if int(equip_bonuses[key]) != 0:
-			has_bonuses = true
-			break
-
-	if has_bonuses:
-		vbox.add_child(PszStyle.create_section_header("Equipment Bonus"))
-		for key in equip_bonuses:
-			if int(equip_bonuses[key]) != 0:
-				vbox.add_child(PszStyle.create_pill(key.to_upper(), false,
-					"+%d" % int(equip_bonuses[key]), PszStyle.TEXT_SUCCESS))
-
 	# Effective stats
+	var equip_bonuses := _calculate_equipment_bonuses(character)
 	vbox.add_child(PszStyle.create_section_header("Effective"))
 	for i in range(stat_order.size()):
 		var key: String = stat_order[i]

--- a/scripts/2d/status.gd
+++ b/scripts/2d/status.gd
@@ -56,30 +56,23 @@ func _refresh_info() -> void:
 	var exp_progress: Dictionary = CharacterManager.get_exp_progress()
 	var current_exp: int = int(exp_progress.get("current", 0))
 	var needed_exp: int = int(exp_progress.get("needed", 1))
-	var exp_percent: float = float(exp_progress.get("percent", 0.0))
-	var exp_filled := int(exp_percent / 100.0 * 20)
-	vbox.add_child(PszStyle.create_pill(
-		"EXP %s %d/%d" % ["█".repeat(exp_filled) + "░".repeat(20 - exp_filled), current_exp, needed_exp],
-		false))
+	var exp_ratio: float = clampf(float(exp_progress.get("percent", 0.0)) / 100.0, 0.0, 1.0)
+	vbox.add_child(PszStyle.create_bar("EXP", exp_ratio, "%d/%d" % [current_exp, needed_exp],
+		Color(0.30, 0.55, 0.85)))
 
-	# HP
+	# HP bar
 	var hp: int = int(character.get("hp", 0))
 	var max_hp: int = int(character.get("max_hp", 1))
 	var hp_ratio := clampf(float(hp) / float(max_hp), 0.0, 1.0)
-	var hp_filled := int(hp_ratio * 20)
-	var hp_color := PszStyle.TEXT_DANGER if hp_ratio < 0.25 else Color.TRANSPARENT
-	vbox.add_child(PszStyle.create_pill(
-		"HP  %s %d/%d" % ["█".repeat(hp_filled) + "░".repeat(20 - hp_filled), hp, max_hp],
-		false, "", hp_color))
+	var hp_fill_color := Color(0.80, 0.20, 0.20) if hp_ratio < 0.25 else Color(0.20, 0.70, 0.30)
+	vbox.add_child(PszStyle.create_bar("HP", hp_ratio, "%d/%d" % [hp, max_hp], hp_fill_color))
 
-	# PP
+	# PP bar
 	var pp: int = int(character.get("pp", 0))
 	var max_pp: int = int(character.get("max_pp", 1))
 	var pp_ratio := clampf(float(pp) / float(max_pp), 0.0, 1.0)
-	var pp_filled := int(pp_ratio * 20)
-	vbox.add_child(PszStyle.create_pill(
-		"PP  %s %d/%d" % ["█".repeat(pp_filled) + "░".repeat(20 - pp_filled), pp, max_pp],
-		false))
+	vbox.add_child(PszStyle.create_bar("PP", pp_ratio, "%d/%d" % [pp, max_pp],
+		Color(0.30, 0.50, 0.80)))
 
 	# Meseta
 	vbox.add_child(PszStyle.create_pill("Meseta", false, "%d" % int(character.get("meseta", 0)), PszStyle.TEXT_MESETA))

--- a/scripts/2d/status.gd
+++ b/scripts/2d/status.gd
@@ -8,8 +8,9 @@ extends Control
 
 
 func _ready() -> void:
-	title_label.text = "CHARACTER STATUS"
-	hint_label.text = "[ESC] Back"
+	PszStyle.style_menu(title_label, hint_label, [content_panel, stats_panel])
+	title_label.text = "Character Status"
+	hint_label.text = "Esc: Back"
 	_refresh_display()
 
 
@@ -32,100 +33,77 @@ func _refresh_info() -> void:
 	if character == null:
 		return
 
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
-	vbox.add_theme_constant_override("separation", 4)
-
-	var name_label := Label.new()
-	name_label.text = "── %s ──" % str(character.get("name", "???"))
-	name_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(name_label)
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
 	var class_id: String = str(character.get("class_id", "???"))
 	var class_data = ClassRegistry.get_class_data(class_id)
 	var class_name_str: String = class_data.name if class_data else class_id
 
-	var class_label := Label.new()
-	class_label.text = "Class: %s" % class_name_str
-	vbox.add_child(class_label)
+	# Character header
+	vbox.add_child(PszStyle.create_section_header(str(character.get("name", "???"))))
+	vbox.add_child(PszStyle.create_pill("Class: %s" % class_name_str, false))
 
 	var level: int = int(character.get("level", 1))
-	var level_label := Label.new()
-	level_label.text = "Level: %d" % level
-	vbox.add_child(level_label)
+	vbox.add_child(PszStyle.create_pill("Level: %d" % level, false))
 
 	# EXP bar
 	var exp_progress: Dictionary = CharacterManager.get_exp_progress()
-	var exp_label := Label.new()
 	var current_exp: int = int(exp_progress.get("current", 0))
 	var needed_exp: int = int(exp_progress.get("needed", 1))
 	var exp_percent: float = float(exp_progress.get("percent", 0.0))
 	var exp_filled := int(exp_percent / 100.0 * 20)
-	exp_label.text = "EXP %s %d/%d" % [
-		"█".repeat(exp_filled) + "░".repeat(20 - exp_filled),
-		current_exp, needed_exp
-	]
-	vbox.add_child(exp_label)
+	vbox.add_child(PszStyle.create_pill(
+		"EXP %s %d/%d" % ["█".repeat(exp_filled) + "░".repeat(20 - exp_filled), current_exp, needed_exp],
+		false))
 
 	# HP
 	var hp: int = int(character.get("hp", 0))
 	var max_hp: int = int(character.get("max_hp", 1))
 	var hp_ratio := clampf(float(hp) / float(max_hp), 0.0, 1.0)
 	var hp_filled := int(hp_ratio * 20)
-	var hp_label := Label.new()
-	hp_label.text = "HP  %s %d/%d" % [
-		"█".repeat(hp_filled) + "░".repeat(20 - hp_filled), hp, max_hp
-	]
-	if hp_ratio < 0.25:
-		hp_label.add_theme_color_override("font_color", ThemeColors.DANGER)
-	vbox.add_child(hp_label)
+	var hp_color := PszStyle.TEXT_DANGER if hp_ratio < 0.25 else Color.TRANSPARENT
+	vbox.add_child(PszStyle.create_pill(
+		"HP  %s %d/%d" % ["█".repeat(hp_filled) + "░".repeat(20 - hp_filled), hp, max_hp],
+		false, "", hp_color))
 
 	# PP
 	var pp: int = int(character.get("pp", 0))
 	var max_pp: int = int(character.get("max_pp", 1))
 	var pp_ratio := clampf(float(pp) / float(max_pp), 0.0, 1.0)
 	var pp_filled := int(pp_ratio * 20)
-	var pp_label := Label.new()
-	pp_label.text = "PP  %s %d/%d" % [
-		"█".repeat(pp_filled) + "░".repeat(20 - pp_filled), pp, max_pp
-	]
-	vbox.add_child(pp_label)
+	vbox.add_child(PszStyle.create_pill(
+		"PP  %s %d/%d" % ["█".repeat(pp_filled) + "░".repeat(20 - pp_filled), pp, max_pp],
+		false))
 
 	# Meseta
-	var meseta_label := Label.new()
-	meseta_label.text = "Meseta: %d" % int(character.get("meseta", 0))
-	meseta_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(meseta_label)
+	vbox.add_child(PszStyle.create_pill("Meseta", false, "%d" % int(character.get("meseta", 0)), PszStyle.TEXT_MESETA))
 
 	# Equipment section
-	var sep := Label.new()
-	sep.text = ""
-	vbox.add_child(sep)
-
-	var equip_header := Label.new()
-	equip_header.text = "── EQUIPMENT ──"
-	equip_header.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(equip_header)
+	vbox.add_child(PszStyle.create_section_header("Equipment"))
 
 	var equipment: Dictionary = character.get("equipment", {})
 	var slots := ["weapon", "frame", "mag", "unit1", "unit2", "unit3", "unit4"]
 	var slot_names := ["Weapon", "Frame", "Mag", "Unit 1", "Unit 2", "Unit 3", "Unit 4"]
 	for i in range(slots.size()):
-		var slot_label := Label.new()
 		var item_id: String = str(equipment.get(slots[i], ""))
 		if item_id.is_empty():
-			slot_label.text = "  %-8s [Empty]" % slot_names[i]
-			slot_label.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
+			vbox.add_child(PszStyle.create_pill(slot_names[i], false, "[Empty]", PszStyle.TEXT_MUTED))
 		else:
 			var item_name := _get_item_name(slots[i], item_id)
-			# Show grind level for weapons
 			if slots[i] == "weapon":
 				var grind: int = int(character.get("weapon_grinds", {}).get(item_id, 0))
 				if grind > 0:
 					item_name += " +%d" % grind
-			slot_label.text = "  %-8s %s" % [slot_names[i], item_name]
-		vbox.add_child(slot_label)
+			vbox.add_child(PszStyle.create_pill(slot_names[i], false, item_name))
 
-	content_panel.add_child(vbox)
+	scroll.add_child(vbox)
+	content_panel.add_child(scroll)
 
 
 func _refresh_stats() -> void:
@@ -136,13 +114,15 @@ func _refresh_stats() -> void:
 	if character == null:
 		return
 
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
-	vbox.add_theme_constant_override("separation", 4)
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.add_theme_constant_override("separation", 3)
 
-	var header := Label.new()
-	header.text = "── STATS ──"
-	header.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(header)
+	vbox.add_child(PszStyle.create_section_header("Base Stats"))
 
 	var stats: Dictionary = character.get("stats", {})
 	var stat_order := ["hp", "pp", "atk", "def", "acc", "eva", "tech"]
@@ -151,48 +131,33 @@ func _refresh_stats() -> void:
 	for i in range(stat_order.size()):
 		var key: String = stat_order[i]
 		var value: int = int(stats.get(key, 0))
-		var label := Label.new()
-		label.text = "  %-6s %d" % [stat_names[i], value]
-		vbox.add_child(label)
+		vbox.add_child(PszStyle.create_pill(stat_names[i], false, str(value)))
 
 	# Equipment bonuses
 	var equip_bonuses := _calculate_equipment_bonuses(character)
-	if not equip_bonuses.is_empty():
-		var sep := Label.new()
-		sep.text = ""
-		vbox.add_child(sep)
+	var has_bonuses := false
+	for key in equip_bonuses:
+		if int(equip_bonuses[key]) != 0:
+			has_bonuses = true
+			break
 
-		var bonus_header := Label.new()
-		bonus_header.text = "── EQUIP BONUS ──"
-		bonus_header.add_theme_color_override("font_color", ThemeColors.HEADER)
-		vbox.add_child(bonus_header)
-
+	if has_bonuses:
+		vbox.add_child(PszStyle.create_section_header("Equipment Bonus"))
 		for key in equip_bonuses:
 			if int(equip_bonuses[key]) != 0:
-				var label := Label.new()
-				label.text = "  %-6s +%d" % [key.to_upper(), int(equip_bonuses[key])]
-				label.add_theme_color_override("font_color", ThemeColors.EQUIPPABLE)
-				vbox.add_child(label)
+				vbox.add_child(PszStyle.create_pill(key.to_upper(), false,
+					"+%d" % int(equip_bonuses[key]), PszStyle.TEXT_SUCCESS))
 
 	# Effective stats
-	var sep2 := Label.new()
-	sep2.text = ""
-	vbox.add_child(sep2)
-
-	var eff_header := Label.new()
-	eff_header.text = "── EFFECTIVE ──"
-	eff_header.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-	vbox.add_child(eff_header)
-
+	vbox.add_child(PszStyle.create_section_header("Effective"))
 	for i in range(stat_order.size()):
 		var key: String = stat_order[i]
 		var base: int = int(stats.get(key, 0))
 		var bonus: int = int(equip_bonuses.get(key, 0))
-		var label := Label.new()
-		label.text = "  %-6s %d" % [stat_names[i], base + bonus]
-		vbox.add_child(label)
+		vbox.add_child(PszStyle.create_pill(stat_names[i], false, str(base + bonus), PszStyle.TEXT_HIGHLIGHT))
 
-	stats_panel.add_child(vbox)
+	scroll.add_child(vbox)
+	stats_panel.add_child(scroll)
 
 
 func _calculate_equipment_bonuses(character: Dictionary) -> Dictionary:

--- a/scripts/2d/storage.gd
+++ b/scripts/2d/storage.gd
@@ -5,12 +5,16 @@ const CATEGORY_ORDER := ["Weapon", "Armor", "Unit", "Mag", "Disk", "Consumable",
 
 enum Tab { ITEMS, MESETA }
 
+const TAB_NAMES := ["Store Items", "Store Meseta"]
+
 var _tab: int = Tab.ITEMS
 var _selected_side: int = 0  # 0 = inventory, 1 = storage (items tab)
 var _selected_index: int = 0
 var _meseta_action: int = 0  # 0 = deposit, 1 = withdraw (meseta tab)
 var _inventory_items: Array = []
 var _storage_items: Array = []
+
+var _mode_bar: HBoxContainer
 
 @onready var title_label: Label = $Panel/VBox/TitleLabel
 @onready var mode_label: Label = $Panel/VBox/ModeBar/ModeLabel
@@ -20,7 +24,9 @@ var _storage_items: Array = []
 
 
 func _ready() -> void:
-	title_label.text = "STORAGE"
+	_mode_bar = mode_label.get_parent()
+	PszStyle.style_menu(title_label, hint_label, [inventory_panel, storage_panel])
+	title_label.text = "Storage"
 	_load_items()
 	_refresh_display()
 
@@ -169,13 +175,15 @@ func _move_item() -> void:
 
 
 func _refresh_display() -> void:
-	# Mode bar
+	# Tab bar
+	for child in _mode_bar.get_children():
+		child.queue_free()
+	_mode_bar.add_child(PszStyle.create_tab_bar(TAB_NAMES, _tab))
+
 	if _tab == Tab.ITEMS:
-		mode_label.text = "[◄ STORE ITEMS ►]    STORE MESETA"
-		hint_label.text = "[←/→] Switch Tab  [TAB] Switch Panel  [↑/↓] Select  [ENTER] Move  [ESC] Back"
+		hint_label.text = "Left/Right: Switch Tab  TAB: Switch Panel  Up/Down: Select  Enter: Move  Esc: Back"
 	else:
-		mode_label.text = "   STORE ITEMS    [◄ STORE MESETA ►]"
-		hint_label.text = "[←/→] Switch Tab  [↑/↓] Select  [ENTER] Transfer 100M  [ESC] Back"
+		hint_label.text = "Left/Right: Switch Tab  Up/Down: Select  Enter: Transfer 100M  Esc: Back"
 
 	_refresh_items_panel(inventory_panel, _inventory_items, "INVENTORY (%d/40)" % Inventory.get_total_slots(), 0)
 	_refresh_items_panel(storage_panel, _storage_items, "STORAGE (%d)" % _storage_items.size(), 1)
@@ -185,56 +193,38 @@ func _refresh_items_panel(panel: PanelContainer, items: Array, header_text: Stri
 	for child in panel.get_children():
 		child.queue_free()
 
-	var labels_ref: Array = []
 	var scroll := ScrollContainer.new()
 	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	var vbox := VBoxContainer.new()
 	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	vbox.add_theme_constant_override("separation", 2)
+	vbox.add_theme_constant_override("separation", 3)
+
+	var pills_ref: Array = []
 
 	# Header
-	var header := Label.new()
 	if _tab == Tab.MESETA:
 		var character = CharacterManager.get_active_character()
 		if side == 0:
 			var char_meseta: int = int(character.get("meseta", 0)) if character else 0
-			header.text = "── WALLET: %d M ──" % char_meseta
+			vbox.add_child(PszStyle.create_section_header("WALLET: %d M" % char_meseta))
 		else:
-			header.text = "── BANK: %d M ──" % GameState.stored_meseta
-		header.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
+			vbox.add_child(PszStyle.create_section_header("BANK: %d M" % GameState.stored_meseta))
 	else:
-		header.text = "── %s ──" % header_text
-		if _selected_side == side:
-			header.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-		else:
-			header.add_theme_color_override("font_color", ThemeColors.HEADER)
-	vbox.add_child(header)
+		var header_color := PszStyle.TEXT_HIGHLIGHT if _selected_side == side else PszStyle.TITLE_BG
+		vbox.add_child(PszStyle.create_section_header(header_text))
 
 	if _tab == Tab.MESETA:
 		# Meseta mode: show deposit/withdraw options
 		if side == 0:
-			var dep_label := Label.new()
-			if _meseta_action == 0:
-				dep_label.text = "> Deposit 100 M"
-				dep_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			else:
-				dep_label.text = "  Deposit 100 M"
-			vbox.add_child(dep_label)
+			var pill := PszStyle.create_pill("Deposit 100 M", _meseta_action == 0)
+			vbox.add_child(pill)
 		else:
-			var wit_label := Label.new()
-			if _meseta_action == 1:
-				wit_label.text = "> Withdraw 100 M"
-				wit_label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			else:
-				wit_label.text = "  Withdraw 100 M"
-			vbox.add_child(wit_label)
+			var pill := PszStyle.create_pill("Withdraw 100 M", _meseta_action == 1)
+			vbox.add_child(pill)
 	elif items.is_empty():
-		var empty := Label.new()
-		empty.text = "  (Empty)"
-		empty.add_theme_color_override("font_color", ThemeColors.TEXT_SECONDARY)
-		vbox.add_child(empty)
+		vbox.add_child(PszStyle.create_pill("(Empty)", false, "", PszStyle.TEXT_MUTED))
 	else:
 		var character = CharacterManager.get_active_character()
 		var class_type_race := ""
@@ -261,10 +251,7 @@ func _refresh_items_panel(panel: PanelContainer, items: Array, header_text: Stri
 			var cat: String = _get_item_category(item_id)
 			if cat != current_category:
 				current_category = cat
-				var cat_label := Label.new()
-				cat_label.text = "── %s ──" % cat
-				cat_label.add_theme_color_override("font_color", ThemeColors.HEADER)
-				vbox.add_child(cat_label)
+				vbox.add_child(PszStyle.create_section_header(cat))
 
 			var weapon = WeaponRegistry.get_weapon(item_id)
 			if weapon == null and is_unresolved:
@@ -273,7 +260,6 @@ func _refresh_items_panel(panel: PanelContainer, items: Array, header_text: Stri
 			if armor_data == null and is_unresolved:
 				armor_data = ArmorRegistry.get_armor(norm_id)
 
-			var label := Label.new()
 			var item_name: String = str(item.get("name", item_id))
 			if is_unresolved:
 				if weapon:
@@ -291,40 +277,38 @@ func _refresh_items_panel(panel: PanelContainer, items: Array, header_text: Stri
 
 			var suffix := ""
 			if weapon:
-				suffix = "%s %s [%s]" % [grind_tag, weapon.get_rarity_string(), weapon.get_weapon_type_name()]
+				suffix = "%s %s" % [grind_tag, weapon.get_rarity_string()]
 			elif armor_data:
-				suffix = " %s [%s]" % [armor_data.get_rarity_string(), armor_data.get_type_name()]
+				suffix = " %s" % armor_data.get_rarity_string()
 
-			if qty > 1:
-				label.text = "%-18s x%d%s%s" % [item_name, qty, equip_tag, suffix]
-			else:
-				label.text = "%s%s%s" % [item_name, equip_tag, suffix]
+			var display_name := item_name + equip_tag + suffix
+			var right_text := "x%d" % qty if qty > 1 else ""
 
-			if _selected_side == side and i == _selected_index:
-				label.text = "> " + label.text
-				label.add_theme_color_override("font_color", ThemeColors.TEXT_HIGHLIGHT)
-			else:
-				label.text = "  " + label.text
-				if is_unresolved:
-					label.add_theme_color_override("font_color", ThemeColors.RESTRICT_ID)
-				elif weapon and not class_type_race.is_empty():
-					if not weapon.can_be_used_by(class_type_race):
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-					elif char_level < weapon.level:
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-				elif armor_data and not class_type_race.is_empty():
-					if not armor_data.can_be_used_by(class_type_race):
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_CLASS)
-					elif char_level < armor_data.level:
-						label.add_theme_color_override("font_color", ThemeColors.RESTRICT_LEVEL)
-			vbox.add_child(label)
-			labels_ref.append(label)
+			# Determine text color based on equippability
+			var text_color := Color.TRANSPARENT
+			if is_unresolved:
+				text_color = PszStyle.TEXT_DANGER
+			elif weapon and not class_type_race.is_empty():
+				if not weapon.can_be_used_by(class_type_race):
+					text_color = PszStyle.TEXT_DANGER
+				elif char_level < weapon.level:
+					text_color = PszStyle.TEXT_WARNING
+			elif armor_data and not class_type_race.is_empty():
+				if not armor_data.can_be_used_by(class_type_race):
+					text_color = PszStyle.TEXT_DANGER
+				elif char_level < armor_data.level:
+					text_color = PszStyle.TEXT_WARNING
+
+			var is_selected: bool = _selected_side == side and i == _selected_index
+			var pill := PszStyle.create_pill(display_name, is_selected, right_text, text_color)
+			vbox.add_child(pill)
+			pills_ref.append(pill)
 
 	scroll.add_child(vbox)
 	panel.add_child(scroll)
 
-	if _tab == Tab.ITEMS and _selected_side == side and _selected_index >= 0 and _selected_index < labels_ref.size():
-		scroll.ensure_control_visible.call_deferred(labels_ref[_selected_index])
+	if _tab == Tab.ITEMS and _selected_side == side and _selected_index >= 0 and _selected_index < pills_ref.size():
+		scroll.ensure_control_visible.call_deferred(pills_ref[_selected_index])
 
 
 func _get_item_category(item_id: String) -> String:

--- a/scripts/3d/city/city_menu.gd
+++ b/scripts/3d/city/city_menu.gd
@@ -11,6 +11,7 @@ const BASE_MENU_ITEMS := [
 	"Return to Title",
 ]
 
+@onready var title_label: Label = $CenterPanel/VBox/TitleLabel
 @onready var menu_list = $CenterPanel/VBox/MenuList
 @onready var hint_label: Label = $HintLabel
 @onready var feedback_label: Label = $CenterPanel/VBox/FeedbackLabel
@@ -19,8 +20,14 @@ var _menu_items: Array = []
 
 
 func _ready() -> void:
+	# PSZ title bar styling
+	title_label.add_theme_stylebox_override("normal", PszStyle.title_style())
+	title_label.add_theme_color_override("font_color", PszStyle.TEXT_WHITE)
+	title_label.add_theme_font_size_override("font_size", PszStyle.FONT_TITLE)
+	title_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+
 	_build_menu()
-	hint_label.text = "[↑/↓] Navigate  [ENTER] Select  [ESC] Resume"
+	hint_label.text = "Up/Down: Navigate  Enter: Select  Esc: Resume"
 
 
 func _build_menu() -> void:

--- a/scripts/3d/field/field_hud.gd
+++ b/scripts/3d/field/field_hud.gd
@@ -123,16 +123,16 @@ func _auto_show_log() -> void:
 # ── Stats Panel (top-left) ───────────────────────────────────────────────────
 
 class _StatsPanel extends Control:
-	const PANEL_W := 190.0
-	const PANEL_H := 62.0
-	const BAR_H := 12.0
-	const FONT_SIZE_MAIN := 12
-	const FONT_SIZE_SMALL := 10
-	const FONT_SIZE_BAR := 9
+	const PANEL_W := 170.0
+	const PANEL_H := 56.0
+	const BAR_H := 10.0
+	const FONT_SIZE_MAIN := 11
+	const FONT_SIZE_SMALL := 9
+	const FONT_SIZE_BAR := 8
 
-	# PSZ palette
-	const BG_BLUE := Color(0.66, 0.80, 0.91)       # Pale icy blue
-	const BORDER_BLUE := Color(0.48, 0.63, 0.75)    # Blue border
+	# PSZ palette — semi-transparent for single-screen
+	const BG_BLUE := Color(0.66, 0.80, 0.91, 0.6)   # Pale icy blue, translucent
+	const BORDER_BLUE := Color(0.48, 0.63, 0.75, 0.5)
 	const TEXT_DARK := Color(0.1, 0.1, 0.17)         # Near-black text
 	const TEXT_LIGHT := Color(0.23, 0.29, 0.35)      # Secondary text
 	const HP_COLOR := Color(0.27, 0.73, 0.27)        # Green HP fill
@@ -247,17 +247,17 @@ class _StatsPanel extends Control:
 # ── Action Log (bottom-left, fixed box with scroll) ─────────────────────────
 
 class _QuestLogPanel extends Control:
-	const PANEL_W := 220.0
-	const PANEL_H := 180.0
-	const PAD := 5.0
-	const FONT_SIZE := 10
+	const PANEL_W := 180.0
+	const PANEL_H := 120.0
+	const PAD := 4.0
+	const FONT_SIZE := 9
 
-	# PSZ palette — light blue panel with white content area
-	const BG_COLOR := Color(0.66, 0.80, 0.91)        # Pale icy blue
-	const BORDER_COLOR := Color(0.48, 0.63, 0.75)     # Blue border
-	const HEADER_BG := Color(0.16, 0.16, 0.22)        # Dark navy header
-	const HEADER_TEXT := Color(1.0, 1.0, 1.0)          # White header text
-	const CONTENT_BG := Color(1.0, 1.0, 1.0, 0.85)    # White content area
+	# PSZ palette — semi-transparent for single-screen
+	const BG_COLOR := Color(0.66, 0.80, 0.91, 0.5)   # Pale icy blue, translucent
+	const BORDER_COLOR := Color(0.48, 0.63, 0.75, 0.4)
+	const HEADER_BG := Color(0.16, 0.16, 0.22, 0.7)   # Dark navy header
+	const HEADER_TEXT := Color(1.0, 1.0, 1.0, 0.9)
+	const CONTENT_BG := Color(1.0, 1.0, 1.0, 0.6)     # White content area, translucent
 	const TEXT_COLOR := Color(0.1, 0.1, 0.17)          # Dark text
 	const ITEM_COLOR := Color(0.53, 0.33, 0.13)        # Brown/orange items
 	const MESETA_COLOR := Color(0.53, 0.4, 0.0)        # Dark gold
@@ -417,23 +417,23 @@ class _ActionPalette extends Control:
 	## PSO-style action palette: I (swap), J/K/L (action slots).
 	## I centered above, J/L raised, K lower (diamond-ish layout).
 
-	const PILL_BG := Color(1.0, 1.0, 1.0, 0.85)
-	const PILL_BORDER := Color(0.59, 0.71, 0.82, 0.4)
-	const KEY_BG := Color(0.16, 0.24, 0.31, 0.7)
+	const PILL_BG := Color(1.0, 1.0, 1.0, 0.5)
+	const PILL_BORDER := Color(0.59, 0.71, 0.82, 0.3)
+	const KEY_BG := Color(0.16, 0.24, 0.31, 0.5)
 	const KEY_TEXT := Color(1.0, 1.0, 1.0)
 	const LABEL_TEXT := Color(0.1, 0.1, 0.17)
 	const LABEL_LIGHT := Color(0.23, 0.29, 0.35)
-	const FONT_SIZE_KEY := 9
-	const FONT_SIZE_LABEL := 11
-	const FONT_SIZE_SMALL := 9
+	const FONT_SIZE_KEY := 8
+	const FONT_SIZE_LABEL := 10
+	const FONT_SIZE_SMALL := 8
 
 	# Layout constants
-	const PILL_W := 52.0
-	const PILL_H := 34.0
-	const SWAP_W := 46.0
-	const SWAP_H := 20.0
-	const GAP := 6.0
-	const RAISED := 14.0  # J and L raised above K
+	const PILL_W := 44.0
+	const PILL_H := 28.0
+	const SWAP_W := 40.0
+	const SWAP_H := 18.0
+	const GAP := 4.0
+	const RAISED := 10.0  # J and L raised above K
 
 	var _bg_pill: StyleBoxFlat
 	var _bg_swap: StyleBoxFlat

--- a/scripts/3d/field/field_hud.gd
+++ b/scripts/3d/field/field_hud.gd
@@ -7,6 +7,7 @@ const MARGIN := 12.0
 
 var _stats_panel: Control
 var _quest_log: Control
+var _action_palette: Control
 var _log_visible: bool = false
 var _hidden_for_overlay: bool = false
 
@@ -32,6 +33,9 @@ func _ready() -> void:
 
 	_quest_log = _QuestLogPanel.new()
 	add_child(_quest_log)
+
+	_action_palette = _ActionPalette.new()
+	add_child(_action_palette)
 
 	GameState.hp_changed.connect(_on_stats_changed)
 	GameState.max_hp_changed.connect(_on_stats_changed)
@@ -71,7 +75,10 @@ func _toggle_log() -> void:
 
 
 func _is_in_quest() -> bool:
-	return SessionManager.has_accepted_quest() or not SessionManager.get_quest_objectives().is_empty()
+	if SessionManager.has_accepted_quest():
+		return true
+	var session: Dictionary = SessionManager.get_session()
+	return not session.is_empty() and str(session.get("type", "")) == "quest"
 
 
 ## Hide all HUD elements when a menu/shop/dialog is open.
@@ -402,3 +409,120 @@ class _QuestLogPanel extends Control:
 	func _scroll_to_bottom() -> void:
 		await get_tree().process_frame
 		_scroll.scroll_vertical = int(_scroll.get_v_scroll_bar().max_value)
+
+
+# ── Action Palette (bottom-right) ────────────────────────────────────────────
+
+class _ActionPalette extends Control:
+	## PSO-style action palette: I (swap), J/K/L (action slots).
+	## I centered above, J/L raised, K lower (diamond-ish layout).
+
+	const PILL_BG := Color(1.0, 1.0, 1.0, 0.85)
+	const PILL_BORDER := Color(0.59, 0.71, 0.82, 0.4)
+	const KEY_BG := Color(0.16, 0.24, 0.31, 0.7)
+	const KEY_TEXT := Color(1.0, 1.0, 1.0)
+	const LABEL_TEXT := Color(0.1, 0.1, 0.17)
+	const LABEL_LIGHT := Color(0.23, 0.29, 0.35)
+	const FONT_SIZE_KEY := 9
+	const FONT_SIZE_LABEL := 11
+	const FONT_SIZE_SMALL := 9
+
+	# Layout constants
+	const PILL_W := 52.0
+	const PILL_H := 34.0
+	const SWAP_W := 46.0
+	const SWAP_H := 20.0
+	const GAP := 6.0
+	const RAISED := 14.0  # J and L raised above K
+
+	var _bg_pill: StyleBoxFlat
+	var _bg_swap: StyleBoxFlat
+
+	# Action slot data
+	var _slots: Array = [
+		{"key": "J", "label": "Atk"},
+		{"key": "K", "label": "Foie"},
+		{"key": "L", "label": "Mate"},
+	]
+	var _palette_index: int = 1
+	var _palette_count: int = 6
+
+	func _ready() -> void:
+		mouse_filter = MOUSE_FILTER_IGNORE
+
+		# Total size: 3 pills + 2 gaps wide, swap pill + gap + tallest pill high
+		var total_w: float = PILL_W * 3 + GAP * 2
+		var total_h: float = SWAP_H + 2.0 + PILL_H + RAISED
+		custom_minimum_size = Vector2(total_w, total_h)
+		size = Vector2(total_w, total_h)
+
+		# Anchor bottom-right
+		anchor_left = 1.0
+		anchor_right = 1.0
+		anchor_top = 1.0
+		anchor_bottom = 1.0
+		offset_left = -total_w - MARGIN
+		offset_right = -MARGIN
+		offset_top = -total_h - MARGIN
+		offset_bottom = -MARGIN
+
+		# Pill style
+		_bg_pill = StyleBoxFlat.new()
+		_bg_pill.bg_color = PILL_BG
+		_bg_pill.border_color = PILL_BORDER
+		_bg_pill.set_border_width_all(1)
+		_bg_pill.set_corner_radius_all(8)
+
+		# Swap pill style (smaller)
+		_bg_swap = StyleBoxFlat.new()
+		_bg_swap.bg_color = PILL_BG
+		_bg_swap.border_color = PILL_BORDER
+		_bg_swap.set_border_width_all(1)
+		_bg_swap.set_corner_radius_all(8)
+
+	func _draw() -> void:
+		var font := ThemeDB.fallback_font
+		var total_w: float = size.x
+
+		# I — palette swap, centered above JKL
+		var swap_x: float = (total_w - SWAP_W) * 0.5
+		var swap_y: float = 0.0
+		draw_style_box(_bg_swap, Rect2(swap_x, swap_y, SWAP_W, SWAP_H))
+
+		# "I" key badge
+		var key_rect := Rect2(swap_x + 6, swap_y + 4, 16, 13)
+		draw_rect(key_rect, KEY_BG)
+		draw_string(font, Vector2(swap_x + 10, swap_y + 14), "I",
+			HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_KEY, KEY_TEXT)
+
+		# Palette number
+		var pn_text := "%d/%d" % [_palette_index, _palette_count]
+		draw_string(font, Vector2(swap_x + 26, swap_y + 14), pn_text,
+			HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL, LABEL_LIGHT)
+
+		# JKL row — bottom-aligned, J and L raised
+		var row_y: float = SWAP_H + 2.0
+		for i in range(3):
+			var slot: Dictionary = _slots[i]
+			var px: float = i * (PILL_W + GAP)
+			var py: float = row_y + (0.0 if slot["key"] == "K" else 0.0)
+			# J and L are raised (lower py = higher on screen)
+			if slot["key"] != "K":
+				py = row_y
+			else:
+				py = row_y + RAISED
+
+			draw_style_box(_bg_pill, Rect2(px, py, PILL_W, PILL_H))
+
+			# Key badge
+			var kx: float = px + (PILL_W - 16) * 0.5
+			var ky: float = py + 5
+			draw_rect(Rect2(kx, ky, 16, 13), KEY_BG)
+			draw_string(font, Vector2(kx + 4, ky + 10), slot["key"],
+				HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_KEY, KEY_TEXT)
+
+			# Action label
+			var lbl: String = slot["label"]
+			var lbl_w: float = font.get_string_size(lbl, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_LABEL).x
+			draw_string(font, Vector2(px + (PILL_W - lbl_w) * 0.5, py + PILL_H - 5),
+				lbl, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_LABEL, LABEL_TEXT)

--- a/scripts/3d/field/field_hud.gd
+++ b/scripts/3d/field/field_hud.gd
@@ -1,12 +1,14 @@
 extends CanvasLayer
 ## Field HUD — shows player stats (HP/PP bars, level, name) top-left,
-## meseta below, action log bottom-left, and hosts the room minimap (always visible).
+## quest log docked left (toggleable, only when quest active),
+## and hosts the room minimap (always visible).
 
 const MARGIN := 12.0
 
 var _stats_panel: Control
-var _meseta_label: Control
 var _quest_log: Control
+var _log_visible: bool = false
+var _hidden_for_overlay: bool = false
 
 # Cached character info (static for session)
 var _char_name: String = ""
@@ -16,6 +18,7 @@ var _char_level: int = 1
 func _ready() -> void:
 	layer = 99
 	name = "FieldHud"
+	process_mode = Node.PROCESS_MODE_ALWAYS
 
 	var ch = CharacterManager.get_active_character()
 	if ch:
@@ -27,9 +30,6 @@ func _ready() -> void:
 	_stats_panel.char_level = _char_level
 	add_child(_stats_panel)
 
-	_meseta_label = _MesetaLabel.new()
-	add_child(_meseta_label)
-
 	_quest_log = _QuestLogPanel.new()
 	add_child(_quest_log)
 
@@ -37,58 +37,129 @@ func _ready() -> void:
 	GameState.max_hp_changed.connect(_on_stats_changed)
 	GameState.mp_changed.connect(_on_stats_changed)
 	GameState.max_mp_changed.connect(_on_stats_changed)
-	GameState.meseta_changed.connect(_on_meseta_changed)
+
+	# Auto-show log if we're in a quest session
+	if _is_in_quest():
+		_log_visible = true
+		_quest_log.visible = true
+	else:
+		_quest_log.visible = false
+
+
+func _process(_delta: float) -> void:
+	# Hide HUD when an overlay (shop, menu, dialog) is open
+	var has_overlay: bool = not SceneManager._overlay_stack.is_empty()
+	if has_overlay and not _hidden_for_overlay:
+		_hidden_for_overlay = true
+		hide_for_menu()
+	elif not has_overlay and _hidden_for_overlay:
+		_hidden_for_overlay = false
+		restore_after_menu()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	# Toggle log with backtick (`) key
+	if event is InputEventKey and event.pressed and not event.echo:
+		if event.keycode == KEY_QUOTELEFT:
+			_toggle_log()
+			get_viewport().set_input_as_handled()
+
+
+func _toggle_log() -> void:
+	_log_visible = not _log_visible
+	_quest_log.visible = _log_visible
+
+
+func _is_in_quest() -> bool:
+	return SessionManager.has_accepted_quest() or not SessionManager.get_quest_objectives().is_empty()
+
+
+## Hide all HUD elements when a menu/shop/dialog is open.
+func hide_for_menu() -> void:
+	for child in get_children():
+		if child is Control:
+			child.visible = false
+
+
+## Restore HUD visibility after menu closes.
+func restore_after_menu() -> void:
+	for child in get_children():
+		if child is Control:
+			child.visible = true
+	# Log respects its own toggle state
+	_quest_log.visible = _log_visible
 
 
 func _on_stats_changed(_value: int) -> void:
 	_stats_panel.queue_redraw()
 
 
-func _on_meseta_changed(_value: int) -> void:
-	_meseta_label.queue_redraw()
-
-
 ## Log companion speech to the action log.
 func log_speech(speaker: String, text: String) -> void:
 	_quest_log.add_speech_entry(speaker, text)
+	_auto_show_log()
 
 
 ## Log an arbitrary entry to the action log.
 func log_entry(text: String, color: Color = Color(0.85, 0.85, 0.85)) -> void:
 	_quest_log.add_entry(text, color)
+	_auto_show_log()
+
+
+## Auto-show log when a new entry arrives during a quest.
+func _auto_show_log() -> void:
+	if not _log_visible:
+		_log_visible = true
+		_quest_log.visible = true
 
 
 # ── Stats Panel (top-left) ───────────────────────────────────────────────────
 
 class _StatsPanel extends Control:
-	const PANEL_W := 220.0
-	const PANEL_H := 72.0
-	const BAR_W := 120.0
-	const BAR_H := 8.0
-	const FONT_SIZE_MAIN := 13
-	const FONT_SIZE_SMALL := 11
+	const PANEL_W := 190.0
+	const PANEL_H := 62.0
+	const BAR_H := 12.0
+	const FONT_SIZE_MAIN := 12
+	const FONT_SIZE_SMALL := 10
+	const FONT_SIZE_BAR := 9
 
-	const BG_COLOR := Color(0.08, 0.08, 0.15, 0.8)
-	const BORDER_COLOR := Color(0.4, 0.4, 0.5, 0.5)
-	const HP_GREEN := Color(0.2, 0.9, 0.2)
+	# PSZ palette
+	const BG_BLUE := Color(0.66, 0.80, 0.91)       # Pale icy blue
+	const BORDER_BLUE := Color(0.48, 0.63, 0.75)    # Blue border
+	const TEXT_DARK := Color(0.1, 0.1, 0.17)         # Near-black text
+	const TEXT_LIGHT := Color(0.23, 0.29, 0.35)      # Secondary text
+	const HP_COLOR := Color(0.27, 0.73, 0.27)        # Green HP fill
+	const HP_COLOR_TOP := Color(0.4, 0.87, 0.4)      # HP gradient top
+	const HP_BG := Color(0.85, 0.91, 0.85)           # HP bar background
 	const HP_YELLOW := Color(0.9, 0.9, 0.2)
 	const HP_RED := Color(0.9, 0.2, 0.2)
-	const PP_COLOR := Color(0.3, 0.7, 1.0)
-	const BAR_BG := Color(0.15, 0.15, 0.2)
-	const LABEL_GREEN := Color(0.5, 1.0, 0.5)
-	const LABEL_CYAN := Color(0.5, 0.9, 1.0)
-	const STAR_YELLOW := Color(1.0, 0.9, 0.3)
-	const NAME_WHITE := Color(1.0, 1.0, 1.0, 0.9)
-	const VALUE_WHITE := Color(0.9, 0.9, 0.9)
+	const PP_COLOR := Color(0.2, 0.53, 0.93)         # Blue PP fill
+	const PP_COLOR_TOP := Color(0.4, 0.6, 1.0)       # PP gradient top
+	const PP_BG := Color(0.85, 0.85, 0.94)           # PP bar background
+	const HP_LABEL := Color(0.2, 0.53, 0.2)          # Dark green
+	const PP_LABEL := Color(0.2, 0.4, 0.73)          # Dark blue
+	const BAR_VALUE := Color(1.0, 1.0, 1.0)          # White value on bar
+	const MAX_VALUE := Color(0.1, 0.1, 0.17)         # Dark max value at end
 
 	var char_name: String = ""
 	var char_level: int = 1
+	var _bg_style: StyleBoxFlat
 
 	func _ready() -> void:
 		mouse_filter = MOUSE_FILTER_IGNORE
 		position = Vector2(MARGIN, MARGIN)
 		size = Vector2(PANEL_W, PANEL_H)
 		custom_minimum_size = size
+
+		# Rounded panel background
+		_bg_style = StyleBoxFlat.new()
+		_bg_style.bg_color = BG_BLUE
+		_bg_style.border_color = BORDER_BLUE
+		_bg_style.set_border_width_all(2)
+		_bg_style.corner_radius_top_left = 4
+		_bg_style.corner_radius_top_right = 16
+		_bg_style.corner_radius_bottom_right = 10
+		_bg_style.corner_radius_bottom_left = 12
 
 	func _draw() -> void:
 		var font := ThemeDB.fallback_font
@@ -97,51 +168,51 @@ class _StatsPanel extends Control:
 		var pp: int = GameState.mp
 		var max_pp: int = GameState.max_mp
 
-		# Background
-		var rect := Rect2(Vector2.ZERO, Vector2(PANEL_W, PANEL_H))
-		draw_rect(rect, BG_COLOR)
-		# Border
-		draw_rect(rect, BORDER_COLOR, false, 1.0)
+		# Panel background — rounded with asymmetric corners
+		draw_style_box(_bg_style, Rect2(Vector2.ZERO, Vector2(PANEL_W, PANEL_H)))
 
-		var pad := 8.0
-		var y := pad + 12.0  # baseline for first line
+		# Scanline overlay (clipped to panel area)
+		for sy in range(2, int(PANEL_H) - 2, 4):
+			draw_rect(Rect2(2, sy + 2, PANEL_W - 4, 2), Color(0.47, 0.63, 0.78, 0.08))
 
-		# Line 1: ★Lv N              Name
-		var lv_text := "Lv %d" % char_level
-		draw_string(font, Vector2(pad, y), "\u2605", HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_MAIN, STAR_YELLOW)
-		var star_w: float = font.get_string_size("\u2605", HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_MAIN).x
-		draw_string(font, Vector2(pad + star_w, y), lv_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_MAIN, STAR_YELLOW)
-		var name_w: float = font.get_string_size(char_name, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_MAIN).x
-		draw_string(font, Vector2(PANEL_W - pad - name_w, y), char_name, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_MAIN, NAME_WHITE)
+		var pad := 10.0
+		var y := 14.0
 
-		y += 18.0
+		# Player name + level
+		draw_string(font, Vector2(pad, y), char_name, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_MAIN, TEXT_DARK)
+		var lv_text := "Lv. %d" % char_level
+		var lv_w: float = font.get_string_size(lv_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL).x
+		draw_string(font, Vector2(PANEL_W - pad - lv_w, y), lv_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL, TEXT_LIGHT)
 
-		# Line 2: HP bar
+		# Separator line
+		y += 4.0
+		draw_line(Vector2(pad, y), Vector2(PANEL_W - pad, y), Color(0.47, 0.63, 0.78, 0.3), 1.0)
+
+		y += 14.0
 		_draw_stat_bar(font, Vector2(pad, y), "HP", hp, max_hp, true)
-
-		y += 16.0
-
-		# Line 3: PP bar
+		y += 14.0
 		_draw_stat_bar(font, Vector2(pad, y), "PP", pp, max_pp, false)
 
 	func _draw_stat_bar(font: Font, pos: Vector2, label: String, current: int, maximum: int, is_hp: bool) -> void:
-		var label_color: Color = LABEL_GREEN if is_hp else LABEL_CYAN
+		var label_color: Color = HP_LABEL if is_hp else PP_LABEL
 		draw_string(font, pos, label, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL, label_color)
 
 		var label_w: float = font.get_string_size(label, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL).x
-		var bar_x: float = pos.x + label_w + 6.0
-		var bar_y: float = pos.y - BAR_H  # bars draw downward from top
+		var bar_x: float = pos.x + label_w + 4.0
+		var bar_y: float = pos.y - BAR_H + 1.0
+		var bar_w: float = PANEL_W - bar_x - 30.0  # leave room for max value
 
-		# Bar background
-		draw_rect(Rect2(bar_x, bar_y, BAR_W, BAR_H), BAR_BG)
+		# Bar background (rounded)
+		var bar_bg: Color = HP_BG if is_hp else PP_BG
+		draw_rect(Rect2(bar_x, bar_y, bar_w, BAR_H), bar_bg)
 
 		# Bar fill
 		var pct: float = float(current) / float(maximum) if maximum > 0 else 0.0
-		var fill_w: float = BAR_W * clampf(pct, 0.0, 1.0)
+		var fill_w: float = bar_w * clampf(pct, 0.0, 1.0)
 		var fill_color: Color
 		if is_hp:
 			if pct > 0.5:
-				fill_color = HP_GREEN
+				fill_color = HP_COLOR
 			elif pct > 0.25:
 				fill_color = HP_YELLOW
 			else:
@@ -150,61 +221,42 @@ class _StatsPanel extends Control:
 			fill_color = PP_COLOR
 		if fill_w > 0:
 			draw_rect(Rect2(bar_x, bar_y, fill_w, BAR_H), fill_color)
+			# Top gradient highlight
+			var top_color: Color = HP_COLOR_TOP if is_hp else PP_COLOR_TOP
+			draw_rect(Rect2(bar_x, bar_y, fill_w, BAR_H / 2), Color(top_color, 0.3))
 
-		# Numeric value right-aligned
-		var val_text := "%d/%d" % [current, maximum]
-		var val_w: float = font.get_string_size(val_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL).x
-		draw_string(font, Vector2(PANEL_W - 8.0 - val_w, pos.y), val_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_SMALL, VALUE_WHITE)
+		# Current value centered on bar
+		var cur_text := str(current)
+		var cur_w: float = font.get_string_size(cur_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_BAR).x
+		var cur_x: float = bar_x + (bar_w - cur_w) * 0.5
+		draw_string(font, Vector2(cur_x, pos.y - 1), cur_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_BAR, BAR_VALUE)
 
-
-# ── Meseta Label (below stats) ───────────────────────────────────────────────
-
-class _MesetaLabel extends Control:
-	const FONT_SIZE := 12
-	const MESETA_COLOR := Color(1.0, 0.85, 0.3)
-
-	func _ready() -> void:
-		mouse_filter = MOUSE_FILTER_IGNORE
-		position = Vector2(MARGIN, MARGIN + 72.0 + 4.0)
-		size = Vector2(220, 20)
-		custom_minimum_size = size
-
-	func _draw() -> void:
-		var font := ThemeDB.fallback_font
-		var meseta: int = GameState.meseta
-		var text := "M %s" % _format_meseta(meseta)
-		draw_string(font, Vector2(8.0, 14.0), text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE, MESETA_COLOR)
-
-	func _format_meseta(value: int) -> String:
-		var s := str(value)
-		if s.length() <= 3:
-			return s
-		var result := ""
-		var count := 0
-		for i in range(s.length() - 1, -1, -1):
-			if count > 0 and count % 3 == 0:
-				result = "," + result
-			result = s[i] + result
-			count += 1
-		return result
+		# Max value at right end of bar
+		var max_text := str(maximum)
+		var max_w: float = font.get_string_size(max_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_BAR).x
+		draw_string(font, Vector2(PANEL_W - 8.0 - max_w, pos.y - 1), max_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_BAR, MAX_VALUE)
 
 
 # ── Action Log (bottom-left, fixed box with scroll) ─────────────────────────
 
 class _QuestLogPanel extends Control:
-	const PANEL_W := 300.0
-	const PANEL_H := 150.0
-	const PAD := 6.0
-	const FONT_SIZE := 11
+	const PANEL_W := 220.0
+	const PANEL_H := 180.0
+	const PAD := 5.0
+	const FONT_SIZE := 10
 
-	const BG_COLOR := Color(0.08, 0.08, 0.15, 0.55)
-	const BORDER_COLOR := Color(0.4, 0.4, 0.5, 0.3)
-	const TEXT_COLOR := Color(0.85, 0.85, 0.85)
-	const ITEM_COLOR := Color(1.0, 0.85, 0.2)
-	const MESETA_COLOR := Color(1.0, 0.75, 0.1)
-	const QUEST_COLOR := Color(0.4, 0.8, 1.0)
-	const SPEECH_COLOR := Color(0.85, 0.85, 0.85)
-	const COMPLETE_COLOR := Color(0.3, 1.0, 0.3)
+	# PSZ palette — light blue panel with white content area
+	const BG_COLOR := Color(0.66, 0.80, 0.91)        # Pale icy blue
+	const BORDER_COLOR := Color(0.48, 0.63, 0.75)     # Blue border
+	const HEADER_BG := Color(0.16, 0.16, 0.22)        # Dark navy header
+	const HEADER_TEXT := Color(1.0, 1.0, 1.0)          # White header text
+	const CONTENT_BG := Color(1.0, 1.0, 1.0, 0.85)    # White content area
+	const TEXT_COLOR := Color(0.1, 0.1, 0.17)          # Dark text
+	const ITEM_COLOR := Color(0.53, 0.33, 0.13)        # Brown/orange items
+	const MESETA_COLOR := Color(0.53, 0.4, 0.0)        # Dark gold
+	const QUEST_COLOR := Color(0.17, 0.33, 0.6)        # Dark blue
+	const SPEECH_COLOR := Color(0.2, 0.2, 0.3)         # Dark gray
+	const COMPLETE_COLOR := Color(0.13, 0.53, 0.13)    # Dark green
 
 	var _scroll: ScrollContainer
 	var _vbox: VBoxContainer
@@ -214,27 +266,64 @@ class _QuestLogPanel extends Control:
 	func _ready() -> void:
 		mouse_filter = MOUSE_FILTER_IGNORE
 
-		# Fixed position: bottom-left
+		# Bottom-left corner
 		set_anchors_preset(Control.PRESET_BOTTOM_LEFT)
-		position = Vector2(MARGIN, 0)
 		offset_left = MARGIN
 		offset_bottom = -MARGIN
 		offset_top = -MARGIN - PANEL_H
 		offset_right = MARGIN + PANEL_W
 		size = Vector2(PANEL_W, PANEL_H)
 
-		# Background panel
+		# Background panel — PSZ blue
 		_panel_bg = PanelContainer.new()
 		_panel_bg.mouse_filter = MOUSE_FILTER_IGNORE
 		_panel_bg.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 		var style := StyleBoxFlat.new()
 		style.bg_color = BG_COLOR
 		style.border_color = BORDER_COLOR
-		style.set_border_width_all(1)
-		style.set_corner_radius_all(4)
+		style.set_border_width_all(2)
+		style.set_corner_radius_all(6)
 		style.set_content_margin_all(PAD)
 		_panel_bg.add_theme_stylebox_override("panel", style)
 		add_child(_panel_bg)
+
+		# Outer VBox: header label + scroll content
+		var outer_vbox := VBoxContainer.new()
+		outer_vbox.mouse_filter = MOUSE_FILTER_IGNORE
+		outer_vbox.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		outer_vbox.add_theme_constant_override("separation", 2)
+		_panel_bg.add_child(outer_vbox)
+
+		# "Log" header label
+		var header := Label.new()
+		header.text = "Log"
+		header.add_theme_font_size_override("font_size", 10)
+		header.add_theme_color_override("font_color", HEADER_TEXT)
+		header.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+		header.mouse_filter = MOUSE_FILTER_IGNORE
+		var header_panel := PanelContainer.new()
+		header_panel.mouse_filter = MOUSE_FILTER_IGNORE
+		var header_style := StyleBoxFlat.new()
+		header_style.bg_color = HEADER_BG
+		header_style.set_corner_radius_all(4)
+		header_style.content_margin_left = 8.0
+		header_style.content_margin_right = 8.0
+		header_style.content_margin_top = 2.0
+		header_style.content_margin_bottom = 2.0
+		header_panel.add_theme_stylebox_override("panel", header_style)
+		header_panel.add_child(header)
+		outer_vbox.add_child(header_panel)
+
+		# White content area
+		var content_panel := PanelContainer.new()
+		content_panel.mouse_filter = MOUSE_FILTER_IGNORE
+		content_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		var content_style := StyleBoxFlat.new()
+		content_style.bg_color = CONTENT_BG
+		content_style.set_corner_radius_all(3)
+		content_style.set_content_margin_all(4.0)
+		content_panel.add_theme_stylebox_override("panel", content_style)
+		outer_vbox.add_child(content_panel)
 
 		# ScrollContainer — auto-scrolls to bottom
 		_scroll = ScrollContainer.new()
@@ -242,7 +331,7 @@ class _QuestLogPanel extends Control:
 		_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 		_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_SHOW_NEVER
 		_scroll.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		_panel_bg.add_child(_scroll)
+		content_panel.add_child(_scroll)
 
 		# VBoxContainer holds the label entries
 		_vbox = VBoxContainer.new()

--- a/scripts/3d/field/field_pause_menu.gd
+++ b/scripts/3d/field/field_pause_menu.gd
@@ -4,16 +4,23 @@ extends CanvasLayer
 
 signal closed()
 
-const BG_COLOR := Color(0.0, 0.0, 0.0, 0.6)
-const PANEL_COLOR := Color(0.1, 0.1, 0.18, 0.95)
-const BORDER_COLOR := Color(0.4, 0.45, 0.6, 0.7)
-const TITLE_COLOR := Color(0.8, 0.85, 1.0)
-const ITEM_COLOR := Color(0.9, 0.9, 0.9)
-const SELECTED_COLOR := Color(1.0, 0.9, 0.3)
-const SEPARATOR_COLOR := Color(0.4, 0.4, 0.5, 0.4)
-const HINT_COLOR := Color(0.6, 0.6, 0.7)
-const FONT_SIZE_TITLE := 18
-const FONT_SIZE_ITEM := 15
+# PSZ palette
+const BG_COLOR := Color(0.0, 0.0, 0.0, 0.5)
+const PANEL_COLOR := Color(0.66, 0.80, 0.91)        # Pale icy blue
+const BORDER_COLOR := Color(0.48, 0.63, 0.75)       # Blue border
+const TITLE_BG := Color(0.16, 0.16, 0.22)           # Dark navy title bar
+const TITLE_COLOR := Color(1.0, 1.0, 1.0)           # White title text
+const ITEM_COLOR := Color(0.1, 0.1, 0.17)           # Dark text
+const ITEM_BG := Color(1.0, 1.0, 1.0, 0.85)         # White pill row
+const SELECTED_BG_A := Color(0.94, 0.63, 0.13)      # Orange gradient start
+const SELECTED_BG_B := Color(0.97, 0.78, 0.25)      # Orange gradient end
+const SELECTED_BORDER := Color(0.82, 0.5, 0.06)     # Orange border
+const SEPARATOR_COLOR := Color(0.48, 0.63, 0.75, 0.5)
+const HINT_COLOR := Color(0.1, 0.1, 0.17)
+const HINT_BG := Color(1.0, 1.0, 1.0, 0.7)
+const SCANLINE_COLOR := Color(0.47, 0.63, 0.78, 0.08)
+const FONT_SIZE_TITLE := 16
+const FONT_SIZE_ITEM := 14
 const FONT_SIZE_HINT := 11
 
 const MENU_ITEMS := [
@@ -46,8 +53,8 @@ func _ready() -> void:
 
 	_panel = Control.new()
 	_panel.set_anchors_and_offsets_preset(Control.PRESET_CENTER)
-	_panel.size = Vector2(240, 244)
-	_panel.position = Vector2(-120, -122)
+	_panel.size = Vector2(260, 270)
+	_panel.position = Vector2(-130, -135)
 	add_child(_panel)
 
 	_panel.draw.connect(_draw_panel)
@@ -60,12 +67,23 @@ func open() -> void:
 	_feedback_text = ""
 	get_tree().paused = true
 	_panel.queue_redraw()
+	_set_field_hud_visible(false)
 
 
 func close() -> void:
 	visible = false
 	get_tree().paused = false
+	_set_field_hud_visible(true)
 	closed.emit()
+
+
+func _set_field_hud_visible(show: bool) -> void:
+	var hud := get_parent().get_node_or_null("FieldHud")
+	if hud and hud.has_method("hide_for_menu") and hud.has_method("restore_after_menu"):
+		if show:
+			hud.restore_after_menu()
+		else:
+			hud.hide_for_menu()
 
 
 func _process(delta: float) -> void:
@@ -129,37 +147,62 @@ func _activate_item() -> void:
 
 func _draw_panel() -> void:
 	var font := ThemeDB.fallback_font
+	var pw: float = _panel.size.x
+	var ph: float = _panel.size.y
 	var rect := Rect2(Vector2.ZERO, _panel.size)
-	_panel.draw_rect(rect, PANEL_COLOR)
-	_panel.draw_rect(rect, BORDER_COLOR, false, 1.5)
+	var pad := 12.0
 
-	var pad := 16.0
-	var y := pad + 18.0
-	_panel.draw_string(font, Vector2(pad, y), "PAUSED",
+	# Panel background — pale icy blue
+	_panel.draw_rect(rect, PANEL_COLOR)
+	_panel.draw_rect(rect, BORDER_COLOR, false, 2.0)
+
+	# Scanline overlay
+	for sy in range(0, int(ph), 4):
+		_panel.draw_rect(Rect2(0, sy + 2, pw, 2), SCANLINE_COLOR)
+
+	# Title bar — dark navy
+	var title_h := 32.0
+	_panel.draw_rect(Rect2(0, 0, pw, title_h), TITLE_BG)
+	_panel.draw_string(font, Vector2(pad, 22.0), "Menu",
 		HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_TITLE, TITLE_COLOR)
 
-	y += 30.0
+	var y := title_h + 10.0
+	var item_h := 26.0
 	for i in range(MENU_ITEMS.size()):
 		var item: String = MENU_ITEMS[i]
 		if item.begins_with("────"):
 			_panel.draw_line(
-				Vector2(pad, y - 6.0), Vector2(_panel.size.x - pad, y - 6.0),
+				Vector2(pad, y + 2.0), Vector2(pw - pad, y + 2.0),
 				SEPARATOR_COLOR, 1.0)
-			y += 12.0
+			y += 8.0
 			continue
-		var color: Color = SELECTED_COLOR if i == _selected else ITEM_COLOR
-		var prefix := "> " if i == _selected else "  "
-		_panel.draw_string(font, Vector2(pad, y), prefix + item,
-			HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_ITEM, color)
-		y += 24.0
+
+		var item_rect := Rect2(pad - 2.0, y, pw - (pad - 2.0) * 2, item_h - 3.0)
+		if i == _selected:
+			# Orange selected pill
+			_panel.draw_rect(item_rect, SELECTED_BG_A)
+			# Gradient effect — lighter right half
+			_panel.draw_rect(Rect2(item_rect.position.x + item_rect.size.x * 0.5,
+				item_rect.position.y, item_rect.size.x * 0.5, item_rect.size.y), SELECTED_BG_B)
+			_panel.draw_rect(item_rect, SELECTED_BORDER, false, 2.0)
+		else:
+			# White pill
+			_panel.draw_rect(item_rect, ITEM_BG)
+			_panel.draw_rect(item_rect, Color(0.59, 0.71, 0.82, 0.4), false, 1.0)
+
+		_panel.draw_string(font, Vector2(pad + 8.0, y + 17.0), item,
+			HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_ITEM, ITEM_COLOR)
+		y += item_h
 
 	# Feedback text
 	if not _feedback_text.is_empty():
-		_panel.draw_string(font, Vector2(pad, _panel.size.y - 12.0), _feedback_text,
-			HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_ITEM, SELECTED_COLOR)
+		_panel.draw_string(font, Vector2(pad, ph - 28.0), _feedback_text,
+			HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_ITEM, Color(0.13, 0.53, 0.13))
 
-	# Hint at bottom
-	var hint := "[ESC] Resume"
+	# Hint bar at bottom
+	var hint := "Select from the Menu."
+	var hint_rect := Rect2(pad - 2.0, ph - 24.0, pw - (pad - 2.0) * 2, 20.0)
+	_panel.draw_rect(hint_rect, HINT_BG)
 	var hint_w: float = font.get_string_size(hint, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_HINT).x
-	_panel.draw_string(font, Vector2(_panel.size.x - pad - hint_w, _panel.size.y - 12.0), hint,
+	_panel.draw_string(font, Vector2((pw - hint_w) * 0.5, ph - 10.0), hint,
 		HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE_HINT, HINT_COLOR)

--- a/scripts/3d/field/room_minimap.gd
+++ b/scripts/3d/field/room_minimap.gd
@@ -7,7 +7,12 @@ extends Control
 ## position tracking, matching the web PreviewMinimap approach.
 
 const DISPLAY_SIZE := 180.0
-const BG_COLOR := Color(0.1, 0.1, 0.18, 0.85)
+const PANEL_PAD := 8.0  # padding around map inside blue panel
+# PSZ palette
+const PANEL_BG := Color(0.66, 0.80, 0.91)           # Pale icy blue
+const PANEL_BORDER := Color(0.48, 0.63, 0.75)       # Blue border
+const SCANLINE_COLOR := Color(0.47, 0.63, 0.78, 0.08)
+const BG_COLOR := Color(0.08, 0.15, 0.23, 0.85)     # Dark map background
 const FLOOR_COLOR := Color(0.16, 0.16, 0.31)
 const BOUNDARY_COLOR := Color(1.0, 1.0, 1.0, 0.6)
 const PLAYER_COLOR := Color(0.0, 1.0, 0.0)
@@ -15,6 +20,9 @@ const GATE_OPEN := Color(0.27, 1.0, 0.27)
 const GATE_LOCKED := Color(1.0, 0.3, 0.3)
 const GATE_EXIT := Color(0.29, 0.62, 1.0)
 const GATE_WALL := Color(0.4, 0.4, 0.4)
+const KEY_LABEL_COLOR := Color(0.1, 0.1, 0.17)      # Dark text
+const KEY_BG_ACTIVE := Color(0.8, 0.53, 0.27)       # Orange for collected
+const KEY_BG_INACTIVE := Color(0.59, 0.71, 0.82, 0.4)  # Light gray
 
 var _floor_triangles: Array = []   # Array[PackedVector2Array] — 3 verts each
 var _boundary_lines: Array = []    # Array[[Vector2, Vector2]]
@@ -42,18 +50,20 @@ func setup(stage_id: String, area_folder: String, portal_data: Dictionary,
 		map_root: Node3D, rotation_deg: int = 0, entry_edge: String = "") -> void:
 	_rotation_deg = rotation_deg
 	mouse_filter = MOUSE_FILTER_IGNORE
-	custom_minimum_size = Vector2(DISPLAY_SIZE, DISPLAY_SIZE)
-	size = Vector2(DISPLAY_SIZE, DISPLAY_SIZE)
+	var total_w: float = DISPLAY_SIZE + PANEL_PAD * 2 + 30  # extra for key column
+	var total_h: float = DISPLAY_SIZE + PANEL_PAD * 2
+	custom_minimum_size = Vector2(total_w, total_h)
+	size = Vector2(total_w, total_h)
 
 	# Anchor top-right with margin
 	anchor_left = 1.0
 	anchor_right = 1.0
 	anchor_top = 0.0
 	anchor_bottom = 0.0
-	offset_left = -DISPLAY_SIZE - 20
-	offset_right = -20
-	offset_top = 20
-	offset_bottom = 20 + DISPLAY_SIZE
+	offset_left = -total_w - 12
+	offset_right = -12
+	offset_top = 12
+	offset_bottom = 12 + total_h
 
 	# Load SVG text (not as texture — we need to parse geometry)
 	var subfolder: String = "%s_%s" % [area_folder, stage_id[3]] if stage_id.length() >= 4 else area_folder
@@ -134,25 +144,59 @@ func update_player(global_pos: Vector3, facing_rad: float, map_root: Node3D) -> 
 # ── Drawing ──────────────────────────────────────────────────────────────────
 
 func _draw() -> void:
-	# Background
-	draw_rect(Rect2(Vector2.ZERO, Vector2(DISPLAY_SIZE, DISPLAY_SIZE)), BG_COLOR)
+	var font := ThemeDB.fallback_font
+	var total_w: float = size.x
+	var total_h: float = size.y
+
+	# Blue panel background
+	var panel_rect := Rect2(Vector2.ZERO, Vector2(total_w, total_h))
+	draw_rect(panel_rect, PANEL_BG)
+	draw_rect(panel_rect, PANEL_BORDER, false, 2.0)
+
+	# Scanlines on panel
+	for sy in range(0, int(total_h), 4):
+		draw_rect(Rect2(0, sy + 2, total_w, 2), SCANLINE_COLOR)
+
+	# Key indicators — left column inside panel
+	var key_x := PANEL_PAD
+	var key_y_start := PANEL_PAD
+	if _keys_total > 0:
+		# "Keys" label
+		draw_string(font, Vector2(key_x, key_y_start + 8.0), "Keys",
+			HORIZONTAL_ALIGNMENT_LEFT, -1, 8, KEY_LABEL_COLOR)
+		for ki in range(_keys_total):
+			var ky: float = key_y_start + 14.0 + ki * 22.0
+			var key_bg: Color = KEY_BG_ACTIVE if ki < _keys_collected else KEY_BG_INACTIVE
+			var key_rect := Rect2(key_x, ky, 18, 18)
+			draw_rect(key_rect, key_bg)
+			draw_rect(key_rect, Color(0, 0, 0, 0.15), false, 1.0)
+			var letter := char(65 + ki)  # A, B, C...
+			var letter_color: Color = Color(1, 1, 1) if ki < _keys_collected else KEY_LABEL_COLOR
+			draw_string(font, Vector2(key_x + 4, ky + 13), letter,
+				HORIZONTAL_ALIGNMENT_LEFT, -1, 10, letter_color)
+
+	# Map area offset — right of key column
+	var map_offset := Vector2(30 + PANEL_PAD, PANEL_PAD)
+
+	# Dark map background
+	draw_rect(Rect2(map_offset, Vector2(DISPLAY_SIZE, DISPLAY_SIZE)), BG_COLOR)
+	draw_rect(Rect2(map_offset, Vector2(DISPLAY_SIZE, DISPLAY_SIZE)), Color(0, 0, 0, 0.3), false, 1.0)
 
 	# Floor triangles
 	for tri in _floor_triangles:
 		var pts := PackedVector2Array()
 		for v in tri:
-			pts.append(_svg_to_display(v))
+			pts.append(_svg_to_display(v) + map_offset)
 		draw_polygon(pts, [FLOOR_COLOR])
 
 	# Boundary edges
 	for seg in _boundary_lines:
-		draw_line(_svg_to_display(seg[0]), _svg_to_display(seg[1]),
+		draw_line(_svg_to_display(seg[0]) + map_offset, _svg_to_display(seg[1]) + map_offset,
 			BOUNDARY_COLOR, 1.5)
 
 	# Gate markers
-	var font := ThemeDB.fallback_font
 	for gate in _gate_entries:
-		var c: Vector2 = _svg_to_display(gate["center"])
+		var c: Vector2 = _svg_to_display(gate["center"]) + map_offset
 		var d := 5.0
 		draw_polygon(PackedVector2Array([
 			c + Vector2(-d, -d), c + Vector2(d, -d),
@@ -167,21 +211,12 @@ func _draw() -> void:
 	if _has_player_tracking:
 		var fwd := _player_display_dir
 		var sz := 6.0
+		var pp := _player_display_pos + map_offset
 		draw_polygon(PackedVector2Array([
-			_player_display_pos + fwd * sz,
-			_player_display_pos + fwd.rotated(2.4) * sz * 0.6,
-			_player_display_pos + fwd.rotated(-2.4) * sz * 0.6,
+			pp + fwd * sz,
+			pp + fwd.rotated(2.4) * sz * 0.6,
+			pp + fwd.rotated(-2.4) * sz * 0.6,
 		]), [PLAYER_COLOR])
-
-	# Key counter below minimap
-	if _keys_total > 0:
-		var key_y := DISPLAY_SIZE + 6.0
-		var key_color := Color(1.0, 0.3, 0.3)
-		var val_color := Color(1.0, 1.0, 1.0) if _keys_collected < _keys_total else Color(0.3, 1.0, 0.3)
-		draw_string(font, Vector2(2.0, key_y + 11.0), "KEY", HORIZONTAL_ALIGNMENT_LEFT, -1, 11, key_color)
-		var key_text := "%d/%d" % [_keys_collected, _keys_total]
-		var tw: float = font.get_string_size(key_text, HORIZONTAL_ALIGNMENT_LEFT, -1, 12).x
-		draw_string(font, Vector2(DISPLAY_SIZE - tw - 2.0, key_y + 11.0), key_text, HORIZONTAL_ALIGNMENT_LEFT, -1, 12, val_color)
 
 
 func update_keys(collected: int, total: int) -> void:

--- a/scripts/3d/field/room_minimap.gd
+++ b/scripts/3d/field/room_minimap.gd
@@ -6,13 +6,13 @@ extends Control
 ## Uses embedded metadata from SVG (data-scale, data-offset-x/y) for player
 ## position tracking, matching the web PreviewMinimap approach.
 
-const DISPLAY_SIZE := 180.0
-const PANEL_PAD := 8.0  # padding around map inside blue panel
-# PSZ palette
-const PANEL_BG := Color(0.66, 0.80, 0.91)           # Pale icy blue
-const PANEL_BORDER := Color(0.48, 0.63, 0.75)       # Blue border
-const SCANLINE_COLOR := Color(0.47, 0.63, 0.78, 0.08)
-const BG_COLOR := Color(0.08, 0.15, 0.23, 0.85)     # Dark map background
+const DISPLAY_SIZE := 120.0
+const PANEL_PAD := 5.0  # padding around map inside blue panel
+# PSZ palette — semi-transparent for single-screen
+const PANEL_BG := Color(0.66, 0.80, 0.91, 0.5)     # Pale icy blue, translucent
+const PANEL_BORDER := Color(0.48, 0.63, 0.75, 0.4)
+const SCANLINE_COLOR := Color(0.47, 0.63, 0.78, 0.06)
+const BG_COLOR := Color(0.08, 0.15, 0.23, 0.7)      # Dark map background
 const FLOOR_COLOR := Color(0.16, 0.16, 0.31)
 const BOUNDARY_COLOR := Color(1.0, 1.0, 1.0, 0.6)
 const PLAYER_COLOR := Color(0.0, 1.0, 0.0)
@@ -20,9 +20,9 @@ const GATE_OPEN := Color(0.27, 1.0, 0.27)
 const GATE_LOCKED := Color(1.0, 0.3, 0.3)
 const GATE_EXIT := Color(0.29, 0.62, 1.0)
 const GATE_WALL := Color(0.4, 0.4, 0.4)
-const KEY_LABEL_COLOR := Color(0.1, 0.1, 0.17)      # Dark text
-const KEY_BG_ACTIVE := Color(0.8, 0.53, 0.27)       # Orange for collected
-const KEY_BG_INACTIVE := Color(0.59, 0.71, 0.82, 0.4)  # Light gray
+const KEY_LABEL_COLOR := Color(0.1, 0.1, 0.17, 0.8)
+const KEY_BG_ACTIVE := Color(0.8, 0.53, 0.27, 0.8)  # Orange for collected
+const KEY_BG_INACTIVE := Color(0.59, 0.71, 0.82, 0.3)
 
 var _floor_triangles: Array = []   # Array[PackedVector2Array] — 3 verts each
 var _boundary_lines: Array = []    # Array[[Vector2, Vector2]]
@@ -50,7 +50,7 @@ func setup(stage_id: String, area_folder: String, portal_data: Dictionary,
 		map_root: Node3D, rotation_deg: int = 0, entry_edge: String = "") -> void:
 	_rotation_deg = rotation_deg
 	mouse_filter = MOUSE_FILTER_IGNORE
-	var total_w: float = DISPLAY_SIZE + PANEL_PAD * 2 + 30  # extra for key column
+	var total_w: float = DISPLAY_SIZE + PANEL_PAD * 2 + 22  # extra for key column
 	var total_h: float = DISPLAY_SIZE + PANEL_PAD * 2
 	custom_minimum_size = Vector2(total_w, total_h)
 	size = Vector2(total_w, total_h)
@@ -161,22 +161,19 @@ func _draw() -> void:
 	var key_x := PANEL_PAD
 	var key_y_start := PANEL_PAD
 	if _keys_total > 0:
-		# "Keys" label
-		draw_string(font, Vector2(key_x, key_y_start + 8.0), "Keys",
-			HORIZONTAL_ALIGNMENT_LEFT, -1, 8, KEY_LABEL_COLOR)
 		for ki in range(_keys_total):
-			var ky: float = key_y_start + 14.0 + ki * 22.0
+			var ky: float = key_y_start + ki * 18.0
 			var key_bg: Color = KEY_BG_ACTIVE if ki < _keys_collected else KEY_BG_INACTIVE
-			var key_rect := Rect2(key_x, ky, 18, 18)
+			var key_rect := Rect2(key_x, ky, 14, 14)
 			draw_rect(key_rect, key_bg)
 			draw_rect(key_rect, Color(0, 0, 0, 0.15), false, 1.0)
 			var letter := char(65 + ki)  # A, B, C...
 			var letter_color: Color = Color(1, 1, 1) if ki < _keys_collected else KEY_LABEL_COLOR
-			draw_string(font, Vector2(key_x + 4, ky + 13), letter,
-				HORIZONTAL_ALIGNMENT_LEFT, -1, 10, letter_color)
+			draw_string(font, Vector2(key_x + 3, ky + 11), letter,
+				HORIZONTAL_ALIGNMENT_LEFT, -1, 9, letter_color)
 
 	# Map area offset — right of key column
-	var map_offset := Vector2(30 + PANEL_PAD, PANEL_PAD)
+	var map_offset := Vector2(22 + PANEL_PAD, PANEL_PAD)
 
 	# Dark map background
 	draw_rect(Rect2(map_offset, Vector2(DISPLAY_SIZE, DISPLAY_SIZE)), BG_COLOR)

--- a/scripts/3d/ui/hud.gd
+++ b/scripts/3d/ui/hud.gd
@@ -1,11 +1,9 @@
 extends CanvasLayer
-## Main HUD displaying player HP, PP, meseta, and interaction prompts.
+## Main HUD displaying player HP, PP, and interaction prompts.
 
 @onready var char_info_label: Label = $TopLeft/Panel/VBox/CharInfoLabel
 @onready var hp_bar = $TopLeft/Panel/VBox/HPBar
 @onready var pp_bar = $TopLeft/Panel/VBox/PPBar
-@onready var meseta_label: Label = $TopRight/MesetaPanel/HBox/MesetaLabel
-@onready var meseta_icon: Label = $TopRight/MesetaPanel/HBox/MesetaIcon
 @onready var interaction_prompt: PanelContainer = $BottomCenter/InteractionPrompt
 @onready var prompt_label: Label = $BottomCenter/InteractionPrompt/PromptLabel
 
@@ -16,24 +14,12 @@ func _ready() -> void:
 	GameState.max_hp_changed.connect(_on_max_hp_changed)
 	GameState.mp_changed.connect(_on_mp_changed)
 	GameState.max_mp_changed.connect(_on_max_mp_changed)
-	GameState.meseta_changed.connect(_on_meseta_changed)
 	CharacterManager.level_up.connect(_on_level_up)
-
-	# Style the meseta icon
-	var icon_settings := LabelSettings.new()
-	icon_settings.font_color = ThemeColors.MESETA_GOLD
-	icon_settings.font_size = 14
-	meseta_icon.label_settings = icon_settings
-
-	var meseta_settings := LabelSettings.new()
-	meseta_settings.font_color = ThemeColors.MESETA_GOLD
-	meseta_label.label_settings = meseta_settings
 
 	# Initialize display
 	_update_char_info()
 	_update_hp_display()
 	_update_mp_display()
-	_update_meseta_display()
 	hide_interaction_prompt()
 
 
@@ -45,11 +31,6 @@ func _update_hp_display() -> void:
 func _update_mp_display() -> void:
 	if pp_bar:
 		pp_bar.set_values(GameState.mp, GameState.max_mp)
-
-
-func _update_meseta_display() -> void:
-	if meseta_label:
-		meseta_label.text = str(GameState.meseta)
 
 
 func show_interaction_prompt(text: String) -> void:
@@ -77,10 +58,6 @@ func _on_mp_changed(_new_mp: int) -> void:
 
 func _on_max_mp_changed(_new_max_mp: int) -> void:
 	_update_mp_display()
-
-
-func _on_meseta_changed(_new_amount: int) -> void:
-	_update_meseta_display()
 
 
 func _on_level_up(_new_level: int) -> void:

--- a/scripts/ui/psz_style.gd
+++ b/scripts/ui/psz_style.gd
@@ -1,0 +1,233 @@
+class_name PszStyle
+## PSZ menu style utilities — pale icy blue palette with pill rows and tab buttons.
+
+# ── Panel Colors ──
+const BG := Color(0.66, 0.80, 0.91)
+const BG_BORDER := Color(0.48, 0.63, 0.75)
+const TITLE_BG := Color(0.16, 0.20, 0.28)
+const INNER_BG := Color(1.0, 1.0, 1.0, 0.3)
+const INNER_BORDER := Color(0.59, 0.71, 0.82, 0.4)
+const SCANLINE := Color(0.47, 0.63, 0.78, 0.08)
+
+# ── Pill / Tab Colors ──
+const PILL_BG := Color(1.0, 1.0, 1.0, 0.85)
+const PILL_BORDER := Color(0.59, 0.71, 0.82, 0.4)
+const SEL_BG := Color(0.94, 0.63, 0.13)
+const SEL_BORDER := Color(0.82, 0.5, 0.06)
+const HINT_BG := Color(1.0, 1.0, 1.0, 0.7)
+
+# ── Text Colors ──
+const TEXT := Color(0.1, 0.1, 0.17)
+const TEXT_WHITE := Color(1.0, 1.0, 1.0)
+const TEXT_LIGHT := Color(0.23, 0.29, 0.35)
+const TEXT_MUTED := Color(0.40, 0.45, 0.55)
+const TEXT_DANGER := Color(0.80, 0.20, 0.20)
+const TEXT_WARNING := Color(0.75, 0.50, 0.08)
+const TEXT_SUCCESS := Color(0.13, 0.53, 0.13)
+const TEXT_QUEST := Color(0.30, 0.38, 0.60)
+const TEXT_CLEAR := Color(0.20, 0.50, 0.25)
+const TEXT_HIGHLIGHT := Color(0.82, 0.45, 0.05)
+const TEXT_MESETA := Color(0.82, 0.58, 0.05)
+
+# ── Font Sizes ──
+const FONT_TITLE := 16
+const FONT_ITEM := 14
+const FONT_HINT := 13
+const FONT_DETAIL := 13
+const FONT_TAB := 12
+
+
+static func pill_style(selected: bool) -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	if selected:
+		s.bg_color = SEL_BG
+		s.border_color = SEL_BORDER
+		s.border_width_left = 2
+		s.border_width_top = 2
+		s.border_width_right = 2
+		s.border_width_bottom = 2
+	else:
+		s.bg_color = PILL_BG
+		s.border_color = PILL_BORDER
+		s.border_width_left = 1
+		s.border_width_top = 1
+		s.border_width_right = 1
+		s.border_width_bottom = 1
+	s.corner_radius_top_left = 3
+	s.corner_radius_top_right = 3
+	s.corner_radius_bottom_right = 3
+	s.corner_radius_bottom_left = 3
+	s.content_margin_left = 10.0
+	s.content_margin_right = 10.0
+	s.content_margin_top = 5.0
+	s.content_margin_bottom = 5.0
+	return s
+
+
+static func tab_style(active: bool) -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	if active:
+		s.bg_color = SEL_BG
+		s.border_color = SEL_BORDER
+		s.border_width_left = 2
+		s.border_width_top = 2
+		s.border_width_right = 2
+		s.border_width_bottom = 2
+	else:
+		s.bg_color = PILL_BG
+		s.border_color = PILL_BORDER
+		s.border_width_left = 1
+		s.border_width_top = 1
+		s.border_width_right = 1
+		s.border_width_bottom = 1
+	s.corner_radius_top_left = 4
+	s.corner_radius_top_right = 4
+	s.corner_radius_bottom_right = 4
+	s.corner_radius_bottom_left = 4
+	s.content_margin_left = 12.0
+	s.content_margin_right = 12.0
+	s.content_margin_top = 4.0
+	s.content_margin_bottom = 4.0
+	return s
+
+
+static func title_style() -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	s.bg_color = TITLE_BG
+	s.content_margin_left = 14.0
+	s.content_margin_right = 14.0
+	s.content_margin_top = 8.0
+	s.content_margin_bottom = 8.0
+	return s
+
+
+static func hint_style() -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	s.bg_color = HINT_BG
+	s.border_color = BG_BORDER
+	s.border_width_left = 1
+	s.border_width_top = 1
+	s.border_width_right = 1
+	s.border_width_bottom = 1
+	s.corner_radius_bottom_left = 12
+	s.corner_radius_bottom_right = 12
+	s.content_margin_left = 14.0
+	s.content_margin_right = 14.0
+	s.content_margin_top = 6.0
+	s.content_margin_bottom = 6.0
+	return s
+
+
+static func inner_panel_style() -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	s.bg_color = INNER_BG
+	s.border_color = INNER_BORDER
+	s.border_width_left = 1
+	s.border_width_top = 1
+	s.border_width_right = 1
+	s.border_width_bottom = 1
+	s.corner_radius_top_left = 6
+	s.corner_radius_top_right = 6
+	s.corner_radius_bottom_right = 6
+	s.corner_radius_bottom_left = 6
+	s.content_margin_left = 8.0
+	s.content_margin_top = 8.0
+	s.content_margin_right = 8.0
+	s.content_margin_bottom = 8.0
+	return s
+
+
+static func section_header_style() -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	s.bg_color = Color(0.48, 0.63, 0.75, 0.3)
+	s.corner_radius_top_left = 3
+	s.corner_radius_top_right = 3
+	s.corner_radius_bottom_right = 3
+	s.corner_radius_bottom_left = 3
+	s.content_margin_left = 10.0
+	s.content_margin_right = 10.0
+	s.content_margin_top = 3.0
+	s.content_margin_bottom = 3.0
+	return s
+
+
+static func create_pill(left_text: String, selected: bool, right_text: String = "", text_color := Color.TRANSPARENT) -> PanelContainer:
+	var pill := PanelContainer.new()
+	pill.add_theme_stylebox_override("panel", pill_style(selected))
+	pill.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var hbox := HBoxContainer.new()
+	var label := Label.new()
+	label.text = left_text
+	var color: Color = text_color if text_color.a > 0.0 else TEXT
+	label.add_theme_color_override("font_color", color)
+	label.add_theme_font_size_override("font_size", FONT_ITEM)
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	hbox.add_child(label)
+	if not right_text.is_empty():
+		var right := Label.new()
+		right.text = right_text
+		right.add_theme_color_override("font_color", TEXT_LIGHT if text_color.a == 0.0 else color)
+		right.add_theme_font_size_override("font_size", FONT_ITEM)
+		right.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+		hbox.add_child(right)
+	pill.add_child(hbox)
+	return pill
+
+
+static func create_section_header(text: String) -> PanelContainer:
+	var pill := PanelContainer.new()
+	pill.add_theme_stylebox_override("panel", section_header_style())
+	pill.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var label := Label.new()
+	label.text = text
+	label.add_theme_color_override("font_color", TITLE_BG)
+	label.add_theme_font_size_override("font_size", FONT_DETAIL)
+	pill.add_child(label)
+	return pill
+
+
+static func create_tab_bar(tab_names: Array, active_tab: int) -> HBoxContainer:
+	var hbox := HBoxContainer.new()
+	hbox.add_theme_constant_override("separation", 4)
+	for i in range(tab_names.size()):
+		var panel := PanelContainer.new()
+		panel.add_theme_stylebox_override("panel", tab_style(i == active_tab))
+		var label := Label.new()
+		label.text = str(tab_names[i])
+		label.add_theme_color_override("font_color", TEXT)
+		label.add_theme_font_size_override("font_size", FONT_TAB)
+		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		panel.add_child(label)
+		hbox.add_child(panel)
+	return hbox
+
+
+static func create_meseta_label(meseta: int) -> Label:
+	var label := Label.new()
+	label.text = "%d M" % meseta
+	label.add_theme_color_override("font_color", TEXT_MESETA)
+	label.add_theme_font_size_override("font_size", FONT_ITEM)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	return label
+
+
+static func detail_label(text: String, color := TEXT) -> Label:
+	var label := Label.new()
+	label.text = text
+	label.add_theme_color_override("font_color", color)
+	label.add_theme_font_size_override("font_size", FONT_DETAIL)
+	return label
+
+
+static func style_menu(p_title: Label, p_hint: Label, panels: Array = []) -> void:
+	p_title.add_theme_stylebox_override("normal", title_style())
+	p_title.add_theme_color_override("font_color", TEXT_WHITE)
+	p_title.add_theme_font_size_override("font_size", FONT_TITLE)
+	p_title.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	p_hint.add_theme_stylebox_override("normal", hint_style())
+	p_hint.add_theme_color_override("font_color", TEXT)
+	p_hint.add_theme_font_size_override("font_size", FONT_HINT)
+	for panel in panels:
+		if panel is PanelContainer:
+			panel.add_theme_stylebox_override("panel", inner_panel_style())

--- a/scripts/ui/psz_style.gd
+++ b/scripts/ui/psz_style.gd
@@ -212,6 +212,66 @@ static func create_meseta_label(meseta: int) -> Label:
 	return label
 
 
+## Create a labeled progress bar inside a pill row.
+## label_text: "HP", "PP", "EXP" etc.  ratio: 0.0-1.0.  value_text: "45/100".
+## fill_color: bar fill color.
+static func create_bar(label_text: String, ratio: float, value_text: String, fill_color: Color) -> PanelContainer:
+	var pill := PanelContainer.new()
+	pill.add_theme_stylebox_override("panel", pill_style(false))
+	pill.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var hbox := HBoxContainer.new()
+	hbox.add_theme_constant_override("separation", 8)
+
+	# Left label (HP, PP, EXP)
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.add_theme_color_override("font_color", TEXT)
+	lbl.add_theme_font_size_override("font_size", FONT_ITEM)
+	lbl.custom_minimum_size.x = 30
+	hbox.add_child(lbl)
+
+	# Bar background
+	var bar_bg := PanelContainer.new()
+	var bg_style := StyleBoxFlat.new()
+	bg_style.bg_color = Color(0.48, 0.63, 0.75, 0.3)
+	bg_style.corner_radius_top_left = 3
+	bg_style.corner_radius_top_right = 3
+	bg_style.corner_radius_bottom_right = 3
+	bg_style.corner_radius_bottom_left = 3
+	bar_bg.add_theme_stylebox_override("panel", bg_style)
+	bar_bg.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	bar_bg.custom_minimum_size.y = 16
+
+	# Bar fill (ColorRect clipped by bar_bg)
+	var fill := ColorRect.new()
+	fill.color = fill_color
+	fill.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	fill.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	# We use a container to clip the fill to ratio width
+	var fill_container := Control.new()
+	fill_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	fill_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	fill_container.clip_contents = true
+	fill.anchor_right = clampf(ratio, 0.0, 1.0)
+	fill.anchor_bottom = 1.0
+	fill_container.add_child(fill)
+	bar_bg.add_child(fill_container)
+
+	hbox.add_child(bar_bg)
+
+	# Right value text
+	var val_lbl := Label.new()
+	val_lbl.text = value_text
+	val_lbl.add_theme_color_override("font_color", TEXT_LIGHT)
+	val_lbl.add_theme_font_size_override("font_size", FONT_DETAIL)
+	val_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	hbox.add_child(val_lbl)
+
+	pill.add_child(hbox)
+	return pill
+
+
 static func detail_label(text: String, color := TEXT) -> Label:
 	var label := Label.new()
 	label.text = text

--- a/scripts/ui/psz_style.gd.uid
+++ b/scripts/ui/psz_style.gd.uid
@@ -1,0 +1,1 @@
+uid://dsuqp7s2fe566

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ const OfficeEditor = lazy(() => import('./office-editor/OfficeEditor'));
 const RetargetViewer = lazy(() => import('./retarget/RetargetViewer'));
 const RetargetTuner = lazy(() => import('./retarget/RetargetTuner'));
 const BasicWeaponPreview = lazy(() => import('./storybook/BasicWeaponPreview'));
+const MenuDesign = lazy(() => import('./storybook/MenuDesign'));
 
 function NavBar() {
   const location = useLocation();
@@ -91,6 +92,12 @@ function NavBar() {
       }}>
         Office
       </Link>
+      <Link to="/menu-design" style={{
+        color: isActive('/menu-design') ? '#fff' : '#888',
+        textDecoration: 'none',
+      }}>
+        Menus
+      </Link>
       <Link to="/retarget" style={{
         color: isActive('/retarget') ? '#fff' : '#888',
         textDecoration: 'none',
@@ -125,6 +132,7 @@ export default function App() {
             <Route path="/stage-editor" element={<StageEditor />} />
             <Route path="/svg-check" element={<SvgCheck />} />
             <Route path="/office-editor" element={<OfficeEditor />} />
+            <Route path="/menu-design" element={<MenuDesign />} />
             <Route path="/retarget" element={<RetargetViewer />} />
             <Route path="/retarget-tuner" element={<RetargetTuner />} />
           </Routes>

--- a/web/src/storybook/MenuDesign.tsx
+++ b/web/src/storybook/MenuDesign.tsx
@@ -204,33 +204,258 @@ function PauseMenu() {
   );
 }
 
-function HUD() {
+function HudHpPp() {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '400px' }}>
-      {/* Player HUD */}
+    <div style={{
+      background: C.bgLight, backgroundImage: SCANLINES,
+      border: `2px solid ${C.separator}`,
+      borderRadius: '4px 20px 12px 16px',
+      padding: '8px 14px', width: '230px',
+      filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.3))',
+    }}>
+      {/* Player name + level */}
       <div style={{
-        background: C.bgLight, backgroundImage: SCANLINES,
-        border: `2px solid ${C.separator}`, borderRadius: '8px',
-        padding: '10px 14px',
+        fontSize: '13px', fontWeight: 800, color: C.text,
+        marginBottom: '5px', fontStyle: 'italic',
+        borderBottom: '1px solid rgba(120,160,200,0.3)',
+        paddingBottom: '4px',
       }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px' }}>
-          <span style={{ fontSize: '14px', fontWeight: 700, color: C.text }}>HUmar Lv.42</span>
-          <span style={{ fontSize: '12px', fontWeight: 600, color: '#886600' }}>12,450 MST</span>
-        </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-          <StatBar label="HP" current={342} max={480} color={C.hp} bgColor={C.hpBg} />
-          <StatBar label="PP" current={86} max={120} color={C.pp} bgColor={C.ppBg} />
+        Kion
+        <span style={{
+          fontSize: '10px', fontWeight: 600, color: C.textLight,
+          marginLeft: '8px', fontStyle: 'normal',
+        }}>
+          Lv. 42
+        </span>
+      </div>
+
+      {/* HP bar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '3px' }}>
+        <span style={{ fontSize: '10px', fontWeight: 800, color: '#338833', width: '18px' }}>HP</span>
+        <div style={{
+          flex: 1, height: '14px', background: C.hpBg,
+          borderRadius: '7px', overflow: 'hidden',
+          border: '1px solid rgba(0,0,0,0.1)',
+          position: 'relative',
+        }}>
+          <div style={{
+            width: `${(342 / 480) * 100}%`, height: '100%',
+            background: 'linear-gradient(180deg, #66dd66 0%, #338833 100%)',
+            borderRadius: '7px',
+          }} />
+          <span style={{
+            position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+            fontSize: '9px', fontWeight: 700, color: '#fff',
+            textShadow: '0 1px 2px rgba(0,0,0,0.5)',
+          }}>342</span>
+          <span style={{
+            position: 'absolute', top: '50%', right: '6px', transform: 'translateY(-50%)',
+            fontSize: '9px', fontWeight: 700, color: C.text,
+          }}>480</span>
         </div>
       </div>
 
-      {/* Target */}
+      {/* PP bar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <span style={{ fontSize: '10px', fontWeight: 800, color: '#3366bb', width: '18px' }}>PP</span>
+        <div style={{
+          flex: 1, height: '14px', background: C.ppBg,
+          borderRadius: '7px', overflow: 'hidden',
+          border: '1px solid rgba(0,0,0,0.1)',
+          position: 'relative',
+        }}>
+          <div style={{
+            width: `${(86 / 120) * 100}%`, height: '100%',
+            background: 'linear-gradient(180deg, #6699ff 0%, #3355aa 100%)',
+            borderRadius: '7px',
+          }} />
+          <span style={{
+            position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+            fontSize: '9px', fontWeight: 700, color: '#fff',
+            textShadow: '0 1px 2px rgba(0,0,0,0.5)',
+          }}>86</span>
+          <span style={{
+            position: 'absolute', top: '50%', right: '6px', transform: 'translateY(-50%)',
+            fontSize: '9px', fontWeight: 700, color: C.text,
+          }}>120</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HudMinimap() {
+  return (
+    <div style={{
+      background: C.bgLight, backgroundImage: SCANLINES,
+      border: `2px solid ${C.separator}`, borderRadius: '20px 4px 4px 12px',
+      padding: '8px', width: '170px',
+      filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.3))',
+      display: 'flex', gap: '6px',
+    }}>
+      {/* Key indicators — inside panel, left of map */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <span style={{ fontSize: '8px', fontWeight: 700, color: C.textLight, textAlign: 'center' }}>Keys</span>
+        {['A', 'B'].map((key, i) => (
+          <div key={key} style={{
+            width: '18px', height: '18px', fontSize: '10px', fontWeight: 800,
+            background: i === 0 ? '#cc8844' : 'rgba(150,180,210,0.4)',
+            color: i === 0 ? C.textWhite : C.textLight,
+            borderRadius: '3px', border: '1px solid rgba(0,0,0,0.15)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}>
+            {key}
+          </div>
+        ))}
+      </div>
+
+      {/* Minimap grid */}
       <div style={{
-        background: C.bgLight, backgroundImage: SCANLINES,
-        border: `2px solid ${C.separator}`, borderRadius: '8px',
-        padding: '8px 14px', width: '220px',
+        flex: 1, aspectRatio: '1', background: 'rgba(20,40,60,0.7)',
+        borderRadius: '4px', border: '1px solid rgba(0,0,0,0.3)',
+        position: 'relative',
       }}>
-        <div style={{ fontSize: '13px', fontWeight: 700, color: C.rare, marginBottom: '4px' }}>Booma</div>
-        <StatBar label="HP" current={120} max={200} color="#cc4444" bgColor="#e8d0d0" />
+        {Array.from({ length: 25 }).map((_, i) => {
+          const row = Math.floor(i / 5);
+          const col = i % 5;
+          const isVisited = [6, 7, 8, 11, 12, 13, 16, 17, 18].includes(i);
+          const isCurrent = i === 12;
+          const isGate = i === 8 || i === 16;
+          return (
+            <div key={i} style={{
+              position: 'absolute',
+              left: `${col * 20 + 2}%`, top: `${row * 20 + 2}%`,
+              width: '16%', height: '16%',
+              background: isCurrent ? '#44cc44' : isGate ? '#cc8844' : isVisited ? 'rgba(100,160,220,0.5)' : 'rgba(60,80,100,0.3)',
+              borderRadius: '2px',
+              border: isCurrent ? '2px solid #88ff88' : '1px solid rgba(100,140,180,0.3)',
+            }} />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function HudActionPalette() {
+  // PSO-style: I to swap palette, J/K/L for the 3 action slots
+  const slots = [
+    { label: 'Atk', key: 'J' },
+    { label: 'Foie', key: 'K' },
+    { label: 'Mate', key: 'L' },
+  ];
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0px',
+      filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.3))',
+    }}>
+      {/* I — palette swap, centered above */}
+      <div style={{
+        background: C.itemBg, borderRadius: '8px',
+        padding: '4px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        display: 'flex', alignItems: 'center', gap: '6px',
+        marginBottom: '-2px', zIndex: 1,
+      }}>
+        <span style={{
+          fontSize: '9px', fontWeight: 700, color: C.textWhite,
+          background: 'rgba(40,60,80,0.7)', borderRadius: '6px',
+          padding: '1px 6px', lineHeight: '16px',
+        }}>I</span>
+        <span style={{ fontSize: '9px', fontWeight: 600, color: C.textLight }}>1/6</span>
+      </div>
+      {/* J K L — J and L raised, K lower (diamond-ish) */}
+      <div style={{ display: 'flex', gap: '6px', alignItems: 'flex-end' }}>
+        {slots.map((a) => (
+          <div key={a.key} style={{
+            background: C.itemBg, borderRadius: '8px',
+            padding: '6px 12px', border: '1px solid rgba(150,180,210,0.4)',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2px',
+            minWidth: '52px',
+            marginBottom: a.key === 'K' ? '0px' : '14px',
+          }}>
+            <span style={{
+              fontSize: '9px', fontWeight: 700, color: C.textWhite,
+              background: 'rgba(40,60,80,0.7)', borderRadius: '6px',
+              padding: '1px 6px', lineHeight: '16px',
+            }}>{a.key}</span>
+            <span style={{ fontSize: '11px', fontWeight: 600, color: C.text }}>{a.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HudActivityLog() {
+  const entries = [
+    { text: 'Picked up Monomate x2', color: C.text },
+    { text: 'Booma defeated!', color: C.rare },
+    { text: 'Obtained 120 Meseta', color: '#886600' },
+    { text: 'NPC: "The valley is dangerous. Be careful."', color: '#4466aa' },
+    { text: 'Picked up Photon Drop x1', color: '#8844cc' },
+    { text: 'Key A obtained!', color: '#cc8844' },
+  ];
+  return (
+    <div style={{
+      background: C.bgLight, backgroundImage: SCANLINES,
+      border: `2px solid ${C.separator}`, borderRadius: '8px',
+      padding: '4px', width: '320px',
+      filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.3))',
+    }}>
+      <div style={{
+        fontSize: '10px', fontWeight: 800, color: C.textWhite,
+        background: C.bgDark, backgroundImage: SCANLINES,
+        borderRadius: '4px 4px 0 0',
+        padding: '3px 8px',
+      }}>Log</div>
+      <div style={{
+        background: C.itemBg, borderRadius: '4px',
+        padding: '8px 10px', border: '1px solid rgba(150,180,210,0.4)',
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+          {entries.map((entry, i) => (
+            <div key={i} style={{
+              fontSize: '12px', color: entry.color,
+              opacity: 0.5 + (i / entries.length) * 0.5,
+            }}>
+              {entry.text}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HudFull() {
+  return (
+    <div style={{
+      width: '800px', height: '500px', position: 'relative',
+      background: 'rgba(30,50,70,0.3)', borderRadius: '8px',
+      border: '1px dashed rgba(100,140,180,0.3)',
+    }}>
+      {/* Top-left: HP/PP */}
+      <div style={{ position: 'absolute', top: '12px', left: '12px' }}>
+        <HudHpPp />
+      </div>
+      {/* Top-right: Minimap */}
+      <div style={{ position: 'absolute', top: '12px', right: '12px' }}>
+        <HudMinimap />
+      </div>
+      {/* Bottom-right: Action palette */}
+      <div style={{ position: 'absolute', bottom: '12px', right: '12px' }}>
+        <HudActionPalette />
+      </div>
+      {/* Bottom-left: Activity log */}
+      <div style={{ position: 'absolute', bottom: '12px', left: '12px' }}>
+        <HudActivityLog />
+      </div>
+      {/* Center label */}
+      <div style={{
+        position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+        fontSize: '14px', color: 'rgba(150,180,210,0.4)', fontStyle: 'italic',
+      }}>
+        gameplay area
       </div>
     </div>
   );
@@ -518,7 +743,11 @@ function GuildCounter() {
 // --- Main Page ---
 
 const MENU_DEMOS = [
-  { id: 'hud', label: 'HUD', component: HUD },
+  { id: 'hud-full', label: 'HUD (Full)', component: HudFull },
+  { id: 'hud-hp', label: 'HUD: HP/PP', component: HudHpPp },
+  { id: 'hud-map', label: 'HUD: Minimap', component: HudMinimap },
+  { id: 'hud-actions', label: 'HUD: Actions', component: HudActionPalette },
+  { id: 'hud-log', label: 'HUD: Log', component: HudActivityLog },
   { id: 'pause', label: 'Pause Menu', component: PauseMenu },
   { id: 'equipment', label: 'Equipment', component: EquipmentMenu },
   { id: 'inventory', label: 'Inventory', component: InventoryMenu },
@@ -528,7 +757,7 @@ const MENU_DEMOS = [
 ];
 
 export default function MenuDesign() {
-  const [activeMenu, setActiveMenu] = useState('pause');
+  const [activeMenu, setActiveMenu] = useState('hud-full');
   const ActiveComponent = MENU_DEMOS.find((m) => m.id === activeMenu)?.component || PauseMenu;
 
   return (

--- a/web/src/storybook/MenuDesign.tsx
+++ b/web/src/storybook/MenuDesign.tsx
@@ -740,6 +740,339 @@ function GuildCounter() {
   );
 }
 
+function ItemShop() {
+  const [tab, setTab] = useState(0);
+  const [sel, setSel] = useState(0);
+  const items = [
+    { name: 'Monomate', price: 50, desc: 'Restores a small amount of HP.' },
+    { name: 'Dimate', price: 300, desc: 'Restores a moderate amount of HP.' },
+    { name: 'Trimate', price: 2000, desc: 'Fully restores HP.' },
+    { name: 'Monofluid', price: 100, desc: 'Restores a small amount of PP.' },
+    { name: 'Difluid', price: 600, desc: 'Restores a moderate amount of PP.' },
+    { name: 'Telepipe', price: 350, desc: 'Warps back to the city from the field.' },
+    { name: 'Moon Atomizer', price: 500, desc: 'Revives a fallen ally.' },
+    { name: 'Star Atomizer', price: 5000, desc: 'Fully restores HP of all nearby allies.' },
+    { name: 'Sol Atomizer', price: 200, desc: 'Cures status effects for all nearby allies.' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Item Shop" width={380} hint={`Press ENTER to buy - ${items[sel].price} MST`}>
+        <TabBar tabs={['Buy', 'Sell']} active={tab} onSelect={setTab} />
+        {items.map((item, i) => (
+          <PillRow
+            key={item.name}
+            label={item.name}
+            rightText={`${item.price.toLocaleString()} MST`}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+        <Divider />
+        <div style={{
+          display: 'flex', justifyContent: 'space-between',
+          fontSize: '13px', color: C.text, padding: '2px 4px',
+        }}>
+          <span>Your Meseta:</span>
+          <span style={{ fontWeight: 700, color: '#886600' }}>12,450</span>
+        </div>
+      </Panel>
+
+      <Panel title="Item Info" width={260}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '4px' }}>
+            {items[sel].name}
+          </div>
+          <div style={{ fontSize: '12px', fontWeight: 600, color: '#886600', marginBottom: '8px' }}>
+            {items[sel].price.toLocaleString()} MST
+          </div>
+          <Divider />
+          <div style={{ fontSize: '13px', color: C.text, lineHeight: '1.5' }}>
+            {items[sel].desc}
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function StorageCounter() {
+  const [tab, setTab] = useState(0);
+  const [sel, setSel] = useState(0);
+  const stored = [
+    { name: 'Brand', type: 'Saber', rarity: 'common' },
+    { name: 'Varista', type: 'Handgun', rarity: 'common' },
+    { name: 'Photon Drop', type: 'Material', rarity: 'common' },
+    { name: 'Photon Drop', type: 'Material', rarity: 'common' },
+    { name: 'Grinder', type: 'Material', rarity: 'common' },
+    { name: 'Resist/Fire', type: 'Unit', rarity: 'common' },
+    { name: 'DB\'s Saber', type: 'Saber', rarity: 'rare' },
+    { name: 'Mag Cell', type: 'Material', rarity: 'rare' },
+  ];
+  const inventory = [
+    { name: 'Monomate', qty: 8 },
+    { name: 'Dimate', qty: 3 },
+    { name: 'Telepipe', qty: 4 },
+    { name: 'Saber', qty: 1 },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Storage" width={360} hint={tab === 0 ? 'Select item to withdraw.' : 'Select item to deposit.'}>
+        <TabBar tabs={['Withdraw', 'Deposit']} active={tab} onSelect={(i) => { setTab(i); setSel(0); }} />
+        <div style={{
+          fontSize: '11px', color: C.textLight, padding: '0 4px', marginBottom: '6px',
+        }}>
+          {tab === 0
+            ? <span>{stored.length}/200 stored</span>
+            : <span>{inventory.length}/40 items</span>
+          }
+        </div>
+        {(tab === 0 ? stored : inventory).map((item, i) => (
+          <PillRow
+            key={`${item.name}-${i}`}
+            label={item.name}
+            rightText={'type' in item ? item.type : `x${(item as any).qty}`}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+      </Panel>
+
+      <Panel title="Detail" width={240}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          {tab === 0 ? (
+            <>
+              <div style={{ fontSize: '15px', fontWeight: 700, color: stored[sel]?.rarity === 'rare' ? C.rare : C.text, marginBottom: '4px' }}>
+                {stored[sel]?.name}
+              </div>
+              <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+                {stored[sel]?.type}
+              </div>
+            </>
+          ) : (
+            <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '4px' }}>
+              {inventory[sel]?.name}
+            </div>
+          )}
+          <Divider />
+          <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
+            {[tab === 0 ? 'Withdraw' : 'Deposit', 'Cancel'].map((action) => (
+              <div key={action} style={{
+                flex: 1, padding: '7px', fontSize: '13px', fontWeight: 600,
+                background: C.itemBg, border: '1px solid rgba(150,180,210,0.4)',
+                borderRadius: '4px', color: C.text, cursor: 'pointer', textAlign: 'center',
+              }}>
+                {action}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function TekkerMenu() {
+  const [tab, setTab] = useState(0);
+  const [sel, setSel] = useState(0);
+
+  const unidentified = [
+    { name: '??? Saber', slots: '???' },
+    { name: '??? Sword', slots: '???' },
+    { name: '??? Handgun', slots: '???' },
+  ];
+  const grindable = [
+    { name: 'Saber', grind: '+0', maxGrind: '+9', cost: 100 },
+    { name: 'Brand', grind: '+3', maxGrind: '+12', cost: 300 },
+    { name: 'Buster', grind: '+1', maxGrind: '+15', cost: 500 },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Tekker" width={380} hint={tab === 0 ? 'Identify a mysterious weapon.' : 'Grind your weapon for ATK bonus.'}>
+        <TabBar tabs={['Identify', 'Grind']} active={tab} onSelect={(i) => { setTab(i); setSel(0); }} />
+        {tab === 0 ? (
+          <>
+            {unidentified.length === 0 ? (
+              <div style={{ padding: '16px', fontSize: '13px', color: C.textLight, textAlign: 'center' }}>
+                No unidentified weapons.
+              </div>
+            ) : (
+              unidentified.map((w, i) => (
+                <PillRow
+                  key={`${w.name}-${i}`}
+                  label={w.name}
+                  rightText={w.slots}
+                  selected={sel === i}
+                  onClick={() => setSel(i)}
+                />
+              ))
+            )}
+          </>
+        ) : (
+          <>
+            {grindable.map((w, i) => (
+              <PillRow
+                key={w.name}
+                label={w.name}
+                rightText={`${w.grind} / ${w.maxGrind}`}
+                selected={sel === i}
+                onClick={() => setSel(i)}
+              />
+            ))}
+            <Divider />
+            <div style={{
+              display: 'flex', justifyContent: 'space-between',
+              fontSize: '13px', color: C.text, padding: '2px 4px',
+            }}>
+              <span>Grind Cost:</span>
+              <span style={{ fontWeight: 700, color: '#886600' }}>{grindable[sel]?.cost.toLocaleString()} MST</span>
+            </div>
+          </>
+        )}
+      </Panel>
+
+      <Panel title="Detail" width={280}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          {tab === 0 ? (
+            <>
+              <div style={{ fontSize: '15px', fontWeight: 700, color: C.rare, marginBottom: '4px' }}>
+                {unidentified[sel]?.name}
+              </div>
+              <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+                Unidentified weapon
+              </div>
+              <Divider />
+              <div style={{ fontSize: '13px', color: C.text, lineHeight: '1.5' }}>
+                This weapon must be identified before it can be equipped. The Tekker will reveal its true stats and element.
+              </div>
+              <div style={{
+                marginTop: '10px', padding: '7px', fontSize: '13px', fontWeight: 600,
+                background: C.selectedGradient, border: '2px solid #d08010',
+                borderRadius: '4px', color: C.text, cursor: 'pointer', textAlign: 'center',
+              }}>
+                Identify (100 MST)
+              </div>
+            </>
+          ) : (
+            <>
+              <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '4px' }}>
+                {grindable[sel]?.name}
+              </div>
+              <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+                Current grind: {grindable[sel]?.grind}
+              </div>
+              <Divider />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '13px' }}>
+                {[
+                  ['ATK Bonus', `+${parseInt(grindable[sel]?.grind.replace('+', '') || '0') * 2}`],
+                  ['Max Grind', grindable[sel]?.maxGrind || ''],
+                  ['Success Rate', '90%'],
+                ].map(([k, v]) => (
+                  <div key={k} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span style={{ color: C.textLight }}>{k}</span>
+                    <span style={{ fontWeight: 700, color: C.text }}>{v}</span>
+                  </div>
+                ))}
+              </div>
+              <div style={{
+                marginTop: '10px', padding: '7px', fontSize: '13px', fontWeight: 600,
+                background: C.selectedGradient, border: '2px solid #d08010',
+                borderRadius: '4px', color: C.text, cursor: 'pointer', textAlign: 'center',
+              }}>
+                Grind ({grindable[sel]?.cost} MST)
+              </div>
+            </>
+          )}
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function QuestCounter() {
+  const [mode, setMode] = useState(0);
+  const [sel, setSel] = useState(0);
+  const quests = [
+    { name: 'Valley Patrol', area: 'Gurhacia Valley', diff: 'Normal', rank: 'C', reward: 500, desc: 'Patrol the valley and eliminate hostile creatures.' },
+    { name: 'Swamp Sweep', area: 'Ozette Wetlands', diff: 'Normal', rank: 'C', reward: 600, desc: 'Clear out the creatures infesting the wetlands.' },
+    { name: 'Forest Recon', area: 'Rioh Snowfield', diff: 'Hard', rank: 'B', reward: 1200, desc: 'Investigate unusual activity in the snowfield.' },
+    { name: 'Desert Storm', area: 'Makara Desert', diff: 'Hard', rank: 'B', reward: 1500, desc: 'A sandstorm has stirred up the desert creatures.' },
+    { name: 'Tower Ascent', area: 'Eternal Tower', diff: 'S. Hard', rank: 'A', reward: 5000, desc: 'Climb the tower and reach the summit.' },
+  ];
+  const difficulties = ['Normal', 'Hard', 'S. Hard'];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Quest Counter" width={420} hint="Select a quest to accept.">
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          marginBottom: '8px', padding: '0 4px',
+        }}>
+          <TabBar tabs={difficulties} active={mode} onSelect={(i) => { setMode(i); setSel(0); }} />
+        </div>
+        {quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard')).map((q, i) => (
+          <PillRow
+            key={q.name}
+            label={q.name}
+            rightText={`[${q.rank}]`}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+      </Panel>
+
+      <Panel title="Quest Info" width={280}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '2px' }}>
+            {quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard'))[sel]?.name}
+          </div>
+          <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+            {quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard'))[sel]?.area}
+          </div>
+          <Divider />
+          <div style={{ fontSize: '13px', color: C.text, lineHeight: '1.5', marginBottom: '8px' }}>
+            {quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard'))[sel]?.desc}
+          </div>
+          <Divider />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '13px' }}>
+            {[
+              ['Difficulty', quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard'))[sel]?.diff || ''],
+              ['Rank', quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard'))[sel]?.rank || ''],
+              ['Reward', `${(quests.filter((q) => q.diff === difficulties[mode] || (mode === 2 && q.diff === 'S. Hard'))[sel]?.reward || 0).toLocaleString()} MST`],
+            ].map(([k, v]) => (
+              <div key={k} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: C.textLight }}>{k}</span>
+                <span style={{ fontWeight: 700, color: C.text }}>{v}</span>
+              </div>
+            ))}
+          </div>
+          <div style={{
+            marginTop: '10px', padding: '7px', fontSize: '13px', fontWeight: 600,
+            background: C.selectedGradient, border: '2px solid #d08010',
+            borderRadius: '4px', color: C.text, cursor: 'pointer', textAlign: 'center',
+          }}>
+            Accept Quest
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
 // --- Main Page ---
 
 const MENU_DEMOS = [
@@ -751,9 +1084,12 @@ const MENU_DEMOS = [
   { id: 'pause', label: 'Pause Menu', component: PauseMenu },
   { id: 'equipment', label: 'Equipment', component: EquipmentMenu },
   { id: 'inventory', label: 'Inventory', component: InventoryMenu },
-  { id: 'shop', label: 'Weapon Shop', component: ShopMenu },
+  { id: 'weapon-shop', label: 'Weapon Shop', component: ShopMenu },
+  { id: 'item-shop', label: 'Item Shop', component: ItemShop },
+  { id: 'tekker', label: 'Tekker', component: TekkerMenu },
+  { id: 'storage', label: 'Storage', component: StorageCounter },
+  { id: 'quest', label: 'Quest Counter', component: QuestCounter },
   { id: 'status', label: 'Status', component: StatusScreen },
-  { id: 'guild', label: 'Guild Counter', component: GuildCounter },
 ];
 
 export default function MenuDesign() {

--- a/web/src/storybook/MenuDesign.tsx
+++ b/web/src/storybook/MenuDesign.tsx
@@ -1,0 +1,581 @@
+import { useState } from 'react';
+
+// PSZ color palette — pale icy blue with white items, black text
+const C = {
+  // Backgrounds
+  bgLight: '#a8cce8',       // Pale icy blue (main panel bg)
+  bgMid: '#8ab8d8',         // Slightly darker blue
+  bgDark: '#2a3448',        // Dark navy (title bar, dividers)
+  bgDarker: '#1e2838',      // Darker navy
+  // Items
+  itemBg: 'rgba(255,255,255,0.85)',  // White pill rows
+  itemBgHover: 'rgba(255,255,255,0.95)',
+  selectedGradient: 'linear-gradient(90deg, #f0a020 0%, #f8c840 100%)',  // Orange/yellow
+  // Text
+  text: '#1a1a2a',          // Near-black text
+  textLight: '#3a4a5a',     // Lighter for secondary info
+  textWhite: '#ffffff',      // White text on dark bg
+  textOnSelected: '#1a1a2a', // Black text on orange selection
+  // Accents
+  hintBg: 'rgba(255,255,255,0.7)',   // Hint bar background
+  hintBorder: '#8aa8c8',
+  separator: '#7aa0c0',     // Horizontal line separators
+  // HP/PP
+  hp: '#44bb44',
+  hpBg: '#d8e8d8',
+  pp: '#4488ee',
+  ppBg: '#d8d8f0',
+  // Rarity
+  rare: '#cc2222',
+  common: '#1a1a2a',
+};
+
+// Scanline overlay for that DS texture feel
+const SCANLINES = `repeating-linear-gradient(
+  0deg,
+  transparent,
+  transparent 2px,
+  rgba(120,160,200,0.08) 2px,
+  rgba(120,160,200,0.08) 4px
+)`;
+
+// --- Shared Components ---
+
+function Panel({ title, children, width, hint, style }: {
+  title?: string;
+  children: React.ReactNode;
+  width?: number | string;
+  hint?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div style={{
+      width: width || '100%',
+      display: 'flex', flexDirection: 'column',
+      filter: 'drop-shadow(0 2px 8px rgba(0,0,0,0.25))',
+      ...style,
+    }}>
+      {/* Title bar with diagonal cut */}
+      {title && (
+        <div style={{ position: 'relative', height: '36px', marginBottom: '-1px' }}>
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: C.bgDark,
+            clipPath: 'polygon(0 0, 85% 0, 80% 100%, 0 100%)',
+          }} />
+          {/* Dark stripe accent */}
+          <div style={{
+            position: 'absolute', top: 0, right: 0, bottom: 0, width: '30%',
+            background: `linear-gradient(135deg, transparent 30%, ${C.bgDarker} 30%, ${C.bgDarker} 35%, ${C.bgDark} 35%)`,
+          }} />
+          <div style={{
+            position: 'relative', padding: '6px 16px',
+            fontSize: '16px', fontWeight: 800, color: C.textWhite,
+            fontStyle: 'italic', letterSpacing: '0.5px',
+            textShadow: '1px 1px 0 rgba(0,0,0,0.5)',
+            zIndex: 1,
+          }}>
+            {title}
+          </div>
+        </div>
+      )}
+
+      {/* Main body */}
+      <div style={{
+        flex: 1,
+        background: C.bgLight,
+        backgroundImage: SCANLINES,
+        borderTop: `2px solid ${C.bgDark}`,
+        borderBottom: hint ? 'none' : `2px solid ${C.separator}`,
+        padding: '8px',
+      }}>
+        {children}
+      </div>
+
+      {/* Bottom hint bar */}
+      {hint && (
+        <div style={{
+          background: C.hintBg,
+          backgroundImage: SCANLINES,
+          border: `1px solid ${C.hintBorder}`,
+          borderRadius: '0 0 20px 20px',
+          padding: '8px 20px',
+          fontSize: '14px', color: C.text,
+          marginTop: '8px',
+          textAlign: 'center',
+        }}>
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PillRow({ label, selected, rightText, onClick }: {
+  label: string;
+  selected?: boolean;
+  rightText?: string;
+  onClick?: () => void;
+}) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '7px 14px', marginBottom: '3px',
+        background: selected ? C.selectedGradient : C.itemBg,
+        borderRadius: '3px',
+        border: selected ? '2px solid #d08010' : '1px solid rgba(150,180,210,0.4)',
+        cursor: 'pointer', fontSize: '14px', fontWeight: 600,
+        color: C.text,
+        transition: 'background 0.1s ease',
+      }}
+    >
+      <span>{label}</span>
+      {rightText && <span style={{ fontSize: '12px', color: C.textLight }}>{rightText}</span>}
+    </div>
+  );
+}
+
+function StatBar({ label, current, max, color, bgColor }: {
+  label: string; current: number; max: number; color: string; bgColor: string;
+}) {
+  const pct = Math.min(100, (current / max) * 100);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+      <span style={{ fontSize: '12px', color: C.text, width: '24px', fontWeight: 700 }}>{label}</span>
+      <div style={{
+        flex: 1, height: '12px', background: bgColor,
+        borderRadius: '6px', overflow: 'hidden', border: '1px solid rgba(0,0,0,0.15)',
+      }}>
+        <div style={{
+          width: `${pct}%`, height: '100%', background: color,
+          borderRadius: '6px',
+        }} />
+      </div>
+      <span style={{ fontSize: '11px', color: C.text, width: '65px', textAlign: 'right', fontWeight: 600 }}>
+        {current}/{max}
+      </span>
+    </div>
+  );
+}
+
+function TabBar({ tabs, active, onSelect }: {
+  tabs: string[]; active: number; onSelect: (i: number) => void;
+}) {
+  return (
+    <div style={{
+      display: 'flex', gap: '3px', marginBottom: '8px',
+    }}>
+      {tabs.map((tab, i) => (
+        <button
+          key={tab}
+          onClick={() => onSelect(i)}
+          style={{
+            padding: '5px 14px', fontSize: '12px', fontWeight: 700,
+            background: active === i ? C.selectedGradient : C.itemBg,
+            color: C.text,
+            border: active === i ? '2px solid #d08010' : '1px solid rgba(150,180,210,0.4)',
+            borderRadius: '4px', cursor: 'pointer',
+          }}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div style={{ height: '2px', background: C.separator, margin: '6px 0', opacity: 0.5 }} />;
+}
+
+// --- Menu Mockups ---
+
+function PauseMenu() {
+  const [sel, setSel] = useState(0);
+  const items = ['Equipment', 'Inventory', 'Techniques', 'Status', 'Options', 'Quit Mission'];
+  return (
+    <Panel title="Menu" width={320} hint="Select from the Menu.">
+      {items.map((item, i) => (
+        <PillRow key={item} label={item} selected={sel === i} onClick={() => setSel(i)} />
+      ))}
+    </Panel>
+  );
+}
+
+function HUD() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '400px' }}>
+      {/* Player HUD */}
+      <div style={{
+        background: C.bgLight, backgroundImage: SCANLINES,
+        border: `2px solid ${C.separator}`, borderRadius: '8px',
+        padding: '10px 14px',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px' }}>
+          <span style={{ fontSize: '14px', fontWeight: 700, color: C.text }}>HUmar Lv.42</span>
+          <span style={{ fontSize: '12px', fontWeight: 600, color: '#886600' }}>12,450 MST</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <StatBar label="HP" current={342} max={480} color={C.hp} bgColor={C.hpBg} />
+          <StatBar label="PP" current={86} max={120} color={C.pp} bgColor={C.ppBg} />
+        </div>
+      </div>
+
+      {/* Target */}
+      <div style={{
+        background: C.bgLight, backgroundImage: SCANLINES,
+        border: `2px solid ${C.separator}`, borderRadius: '8px',
+        padding: '8px 14px', width: '220px',
+      }}>
+        <div style={{ fontSize: '13px', fontWeight: 700, color: C.rare, marginBottom: '4px' }}>Booma</div>
+        <StatBar label="HP" current={120} max={200} color="#cc4444" bgColor="#e8d0d0" />
+      </div>
+    </div>
+  );
+}
+
+function EquipmentMenu() {
+  const [sel, setSel] = useState(0);
+  const slots = [
+    { slot: 'Weapon', item: 'Blade' },
+    { slot: 'Frame', item: 'Chef Apron' },
+    { slot: 'Mag', item: 'Mag' },
+    { slot: 'Unit 1', item: 'Ace/Power' },
+    { slot: 'Unit 2', item: 'Ace/HP' },
+    { slot: 'Unit 3', item: 'Ace/Hit' },
+    { slot: 'Unit 4', item: 'Ace/Guard' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Equipment" width={340} hint="Select equipment slot.">
+        {slots.map((s, i) => (
+          <PillRow
+            key={s.slot}
+            label={s.item}
+            rightText={s.slot}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+      </Panel>
+
+      <Panel title="Detail" width={280}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '4px' }}>
+            {slots[sel].item}
+          </div>
+          <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+            Saber-type weapon
+          </div>
+          <Divider />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '13px' }}>
+            {[['ATK', '40'], ['ATA', '35'], ['Grind', '+0'], ['Element', 'None']].map(([k, v]) => (
+              <div key={k} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: C.textLight }}>{k}</span>
+                <span style={{ fontWeight: 700, color: C.text }}>{v}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function ShopMenu() {
+  const [tab, setTab] = useState(0);
+  const [sel, setSel] = useState(0);
+  const weapons = [
+    { name: 'Saber', price: 100, type: 'Saber' },
+    { name: 'Brand', price: 350, type: 'Saber' },
+    { name: 'Buster', price: 800, type: 'Saber' },
+    { name: 'Dagger', price: 100, type: 'Dagger' },
+    { name: 'Knife', price: 350, type: 'Dagger' },
+    { name: 'Sword', price: 200, type: 'Sword' },
+    { name: 'Gigush', price: 550, type: 'Sword' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Weapon Shop" width={380} hint={`Press ENTER to buy - ${weapons[sel].price} MST`}>
+        <TabBar tabs={['Weapons', 'Armor', 'Units', 'Sell']} active={tab} onSelect={setTab} />
+        {weapons.map((w, i) => (
+          <PillRow
+            key={w.name}
+            label={w.name}
+            rightText={`${w.price.toLocaleString()} MST`}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+        <Divider />
+        <div style={{
+          display: 'flex', justifyContent: 'space-between',
+          fontSize: '13px', color: C.text, padding: '2px 4px',
+        }}>
+          <span>Your Meseta:</span>
+          <span style={{ fontWeight: 700, color: '#886600' }}>12,450</span>
+        </div>
+      </Panel>
+
+      <Panel title="Detail" width={280}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '4px' }}>
+            {weapons[sel].name}
+          </div>
+          <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+            {weapons[sel].type}-type
+          </div>
+          <Divider />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '13px' }}>
+            {[['ATK', '40'], ['ATA', '35'], ['Req. Level', '1']].map(([k, v]) => (
+              <div key={k} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: C.textLight }}>{k}</span>
+                <span style={{ fontWeight: 700, color: C.text }}>{v}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function InventoryMenu() {
+  const [sel, setSel] = useState(0);
+  const items = [
+    { name: 'Monomate', qty: 8 },
+    { name: 'Dimate', qty: 3 },
+    { name: 'Trimate', qty: 1 },
+    { name: 'Monofluid', qty: 5 },
+    { name: 'Difluid', qty: 2 },
+    { name: 'Telepipe', qty: 4 },
+    { name: 'Moon Atomizer', qty: 1 },
+    { name: 'Photon Drop', qty: 6 },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Inventory" width={360} hint="Select an item.">
+        <div style={{
+          display: 'flex', justifyContent: 'space-between',
+          fontSize: '12px', color: C.textLight, padding: '0 4px', marginBottom: '6px',
+        }}>
+          <span>{items.length}/40 items</span>
+          <span style={{ fontWeight: 600, color: '#886600' }}>12,450 MST</span>
+        </div>
+        {items.map((item, i) => (
+          <PillRow
+            key={item.name}
+            label={item.name}
+            rightText={`x${item.qty}`}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+      </Panel>
+
+      <Panel title="Item Info" width={260}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '8px' }}>
+            {items[sel].name}
+          </div>
+          <Divider />
+          <div style={{ fontSize: '13px', color: C.text, lineHeight: '1.5' }}>
+            Restores a small amount of HP. Basic healing item used by all hunters.
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
+          {['Use', 'Drop'].map((action) => (
+            <div key={action} style={{
+              flex: 1, padding: '7px', fontSize: '13px', fontWeight: 600,
+              background: C.itemBg, border: '1px solid rgba(150,180,210,0.4)',
+              borderRadius: '4px', color: C.text, cursor: 'pointer', textAlign: 'center',
+            }}>
+              {action}
+            </div>
+          ))}
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function StatusScreen() {
+  return (
+    <Panel title="Status" width={520}>
+      <div style={{ display: 'flex', gap: '16px' }}>
+        <div style={{ flex: 1 }}>
+          <div style={{
+            background: C.itemBg, borderRadius: '4px',
+            padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+            marginBottom: '8px',
+          }}>
+            <div style={{ fontSize: '16px', fontWeight: 700, color: C.text }}>Kion</div>
+            <div style={{ fontSize: '12px', color: C.textLight }}>HUmar — Lv. 42</div>
+          </div>
+          <div style={{
+            background: C.itemBg, borderRadius: '4px',
+            padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+          }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+              <StatBar label="HP" current={342} max={480} color={C.hp} bgColor={C.hpBg} />
+              <StatBar label="PP" current={86} max={120} color={C.pp} bgColor={C.ppBg} />
+            </div>
+            <Divider />
+            <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '4px' }}>EXP to next level</div>
+            <StatBar label="" current={14200} max={18500} color="#c09030" bgColor="#e8dcc8" />
+            <div style={{ fontSize: '10px', color: C.textLight, textAlign: 'right', marginTop: '2px' }}>
+              Next: 4,300
+            </div>
+          </div>
+        </div>
+
+        <div style={{ width: '200px' }}>
+          <div style={{
+            background: C.itemBg, borderRadius: '4px',
+            padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+          }}>
+            <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px', fontWeight: 700 }}>STATS</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '5px', fontSize: '13px' }}>
+              {[
+                ['ATK', '286'], ['DEF', '194'], ['ATA', '152'],
+                ['EVP', '98'], ['MST', '45'], ['LCK', '12'],
+              ].map(([k, v]) => (
+                <div key={k} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: C.textLight }}>{k}</span>
+                  <span style={{ fontWeight: 700, color: C.text }}>{v}</span>
+                </div>
+              ))}
+            </div>
+            <Divider />
+            <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '4px', fontWeight: 700 }}>PLAY TIME</div>
+            <div style={{ fontSize: '14px', fontWeight: 700, color: C.text }}>24:13:45</div>
+          </div>
+        </div>
+      </div>
+    </Panel>
+  );
+}
+
+function GuildCounter() {
+  const [sel, setSel] = useState(0);
+  const quests = [
+    { name: 'Valley Patrol', area: 'Gurhacia Valley', diff: 'Normal', rank: 'C' },
+    { name: 'Swamp Sweep', area: 'Ozette Wetlands', diff: 'Normal', rank: 'C' },
+    { name: 'Forest Recon', area: 'Rioh Snowfield', diff: 'Hard', rank: 'B' },
+    { name: 'Desert Storm', area: 'Makara Desert', diff: 'Hard', rank: 'B' },
+    { name: 'Tower Ascent', area: 'Eternal Tower', diff: 'Super Hard', rank: 'A' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Panel title="Guild Counter" width={420} hint="Select a quest.">
+        {quests.map((q, i) => (
+          <PillRow
+            key={q.name}
+            label={q.name}
+            rightText={`${q.diff} [${q.rank}]`}
+            selected={sel === i}
+            onClick={() => setSel(i)}
+          />
+        ))}
+      </Panel>
+
+      <Panel title="Quest Info" width={280}>
+        <div style={{
+          background: C.itemBg, borderRadius: '4px',
+          padding: '10px 12px', border: '1px solid rgba(150,180,210,0.4)',
+        }}>
+          <div style={{ fontSize: '15px', fontWeight: 700, color: C.text, marginBottom: '2px' }}>
+            {quests[sel].name}
+          </div>
+          <div style={{ fontSize: '11px', color: C.textLight, marginBottom: '8px' }}>
+            {quests[sel].area} — {quests[sel].diff}
+          </div>
+          <Divider />
+          <div style={{ fontSize: '13px', color: C.text, lineHeight: '1.5' }}>
+            Patrol the area and eliminate any hostile creatures. Report back to the guild upon completion.
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+// --- Main Page ---
+
+const MENU_DEMOS = [
+  { id: 'hud', label: 'HUD', component: HUD },
+  { id: 'pause', label: 'Pause Menu', component: PauseMenu },
+  { id: 'equipment', label: 'Equipment', component: EquipmentMenu },
+  { id: 'inventory', label: 'Inventory', component: InventoryMenu },
+  { id: 'shop', label: 'Weapon Shop', component: ShopMenu },
+  { id: 'status', label: 'Status', component: StatusScreen },
+  { id: 'guild', label: 'Guild Counter', component: GuildCounter },
+];
+
+export default function MenuDesign() {
+  const [activeMenu, setActiveMenu] = useState('pause');
+  const ActiveComponent = MENU_DEMOS.find((m) => m.id === activeMenu)?.component || PauseMenu;
+
+  return (
+    <div style={{
+      width: '100%', height: '100%',
+      background: `linear-gradient(180deg, #b8d8f0 0%, #88b8e0 40%, #a0c8e8 100%)`,
+      backgroundImage: `${SCANLINES}, linear-gradient(180deg, #b8d8f0 0%, #88b8e0 40%, #a0c8e8 100%)`,
+      color: C.text, display: 'flex', overflow: 'hidden',
+      fontFamily: "'Segoe UI', 'Helvetica Neue', Arial, sans-serif",
+    }}>
+      {/* Sidebar (dev only — not part of game UI) */}
+      <div style={{
+        width: '150px', flexShrink: 0,
+        background: 'rgba(30,40,60,0.9)',
+        padding: '12px', display: 'flex', flexDirection: 'column', gap: '3px',
+      }}>
+        <div style={{
+          fontSize: '10px', color: '#8899aa', marginBottom: '8px',
+          textTransform: 'uppercase', letterSpacing: '1px',
+        }}>
+          Menu Designs
+        </div>
+        {MENU_DEMOS.map((demo) => (
+          <button
+            key={demo.id}
+            onClick={() => setActiveMenu(demo.id)}
+            style={{
+              display: 'block', width: '100%', padding: '7px 10px',
+              background: activeMenu === demo.id ? 'rgba(240,160,30,0.2)' : 'transparent',
+              border: activeMenu === demo.id ? '1px solid #f0a020' : '1px solid transparent',
+              borderRadius: '4px', cursor: 'pointer', textAlign: 'left',
+              fontSize: '12px',
+              color: activeMenu === demo.id ? '#f8c840' : '#aabbcc',
+            }}
+          >
+            {demo.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Preview area */}
+      <div style={{
+        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: '32px',
+      }}>
+        <ActiveComponent />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **PszStyle utility** (`scripts/ui/psz_style.gd`): Shared class with PSZ color constants and factory methods for pill rows, tab bars, section headers, progress bars, and menu styling
- **All 2D shop menus restyled**: Item shop, weapon shop, tekker, storage, guild counter — icy blue panels, white pill rows, orange selection, dark navy title bars
- **City menu, status, equipment, inventory restyled**: Same PSZ palette with pill rows and section headers
- **City ESC menu and field pause menu**: PSZ-styled overlays
- **Field HUD**: PSZ pale blue palette, semi-transparent panels, HP/PP bars, minimap, action palette, quest log toggle
- **Shop confirmations**: Buy/sell now prompts "Are you sure?" before completing transactions
- **Inventory sorting**: Items grouped by category (weapons, armor, items), weapons sorted by type then rarity
- **Weapon shop sorting**: Weapons grouped by type with section headers, sorted by rarity ascending
- **Status screen**: Visual progress bars for EXP/HP/PP, simplified stats panel (base + effective only)
- **Web mockups page**: MenuDesign.tsx reference for PSZ DS-style UI

## Test plan
- [ ] Verify all shop menus display correctly with PSZ styling
- [ ] Confirm buy/sell confirmation prompts work in item shop and weapon shop
- [ ] Check inventory sorting order (weapons by type/rarity, armor by rarity)
- [ ] Verify status screen bars render correctly for EXP, HP, PP
- [ ] Test city ESC menu and field pause menu styling
- [ ] Verify HUD elements are semi-transparent and don't obscure gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)