### PR TITLE
Fix Android export JAVA_HOME expansion in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Configure Godot Android settings
         run: |
           mkdir -p ~/.config/godot
-          cat > ~/.config/godot/editor_settings-4.tres << 'SETTINGS'
+          cat > ~/.config/godot/editor_settings-4.tres << SETTINGS
           [gd_resource type="EditorSettings" format=3]
           [resource]
           export/android/android_sdk_path = "/usr/local/lib/android/sdk"
-          export/android/java_sdk_path = "$JAVA_HOME"
-          export/android/debug_keystore = "~/.android/debug.keystore"
+          export/android/java_sdk_path = "${JAVA_HOME}"
+          export/android/debug_keystore = "${HOME}/.android/debug.keystore"
           export/android/debug_keystore_user = "androiddebugkey"
           export/android/debug_keystore_pass = "android"
           SETTINGS


### PR DESCRIPTION
## Summary
- The heredoc delimiter in the release workflow was single-quoted (`'SETTINGS'`), which prevented shell variable expansion
- `$JAVA_HOME` and `~/.android` were written literally into the Godot editor settings file instead of their actual paths
- Godot failed with "Invalid Java SDK path in Editor Settings. Missing 'bin' directory!"
- Fixed by removing quotes from the heredoc delimiter and using `${JAVA_HOME}` / `${HOME}`

## Test plan
- [ ] CI passes
- [ ] Merge to main triggers release workflow
- [ ] Android APK export step succeeds (no Java SDK path error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)