### PR TITLE
feat(combat): miss-early fumbles the swing — mashing breaks its own combo

### DIFF
--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -157,6 +157,7 @@ var _is_special_attack: bool = false  # True when current attack carries weapon 
 var _is_just_attack: bool = false  # Current swing was chained via the just window
 var _queued_combo: int = ComboQueue.NONE  # Next-step queue (one slot, no re-roll)
 var _queued_combo_special: bool = false  # Queued step is a strong attack
+var _combo_fumbled: bool = false  # Miss-early press locked out this swing's chain
 var _attack_anim_length: float = 0.0  # Current attack animation duration
 var _attack_anim_elapsed: float = 0.0  # Time since attack animation started
 var _attack_step_ended: bool = false  # Step-end fired (animation_finished vs length safety net — exactly one wins)
@@ -1351,16 +1352,20 @@ func _attack_frac() -> float:
 	return clampf(_attack_anim_elapsed / _attack_anim_length, 0.0, 1.0)
 
 
-## Three-tier chain press (#155, spec /mechanics/combos): miss-early is a
-## clear NO-OP (not buffered), the just window queues with a damage bonus,
-## the normal window queues standard. The queued step fires at swing end
-## (_attack_step_finished) — never mid-swing (#377 commitment).
+## Three-tier chain press (#155, spec /mechanics/combos): miss-early FUMBLES
+## the swing (locks out chaining until the next step — a no-op alone let
+## mashing ride the wide accept window; Rozalin's #459 playtest), the just
+## window queues with a damage bonus, the normal window queues standard. The
+## queued step fires at swing end (_attack_step_finished) — never mid-swing
+## (#377 commitment).
 func _try_queue_combo(special: bool) -> void:
 	var max_combo: int = int(CombatManager.get_weapon_type_config(_get_equipped_weapon_type()).get("combo_steps", 3))
 	if combo_state <= 0 or combo_state >= max_combo:
 		return  # technique cast or finisher — nothing to chain
 	if _queued_combo != ComboQueue.NONE:
 		return  # one queue slot — a second press can't re-roll the tier
+	if _combo_fumbled:
+		return  # a miss-early press already fumbled this swing — chain is dead
 	var t: Dictionary = CombatManager.get_combo_timing(_get_equipped_weapon_type(), combo_state)
 	if t.is_empty():
 		return
@@ -1373,7 +1378,12 @@ func _try_queue_combo(special: bool) -> void:
 		_queued_combo = ComboQueue.NORMAL
 		_queued_combo_special = special
 		_combo_ring_flash(Color(1.0, 0.8, 0.2) if special else Color(0.2, 1.0, 0.4))
-	# else: miss-early — deliberately not buffered; the player reads the swing
+	else:
+		# Miss-early — the press fumbles the REST of this swing: nothing is
+		# buffered and later presses in the same swing are ignored, so the
+		# combo breaks at swing end. Mashing defeats itself.
+		_combo_fumbled = true
+		_combo_ring_flash(Color(0.75, 0.3, 0.3))  # Muted red — fumbled press
 
 
 ## Single step-end point: fires the queued step or breaks the combo. Reached
@@ -2007,6 +2017,7 @@ func _play_attack_animation(attack_num: int) -> void:
 	_attack_step_ended = false
 	_attack_anim_elapsed = 0.0
 	_attack_anim_length = 0.0
+	_combo_fumbled = false  # each step gets a clean chain attempt
 
 	if _is_special_attack:
 		# Pause before attack — player is exposed during wind-up
@@ -2307,6 +2318,7 @@ func transition_to(new_state: PlayerState) -> void:
 		_queued_combo = ComboQueue.NONE
 		_queued_combo_special = false
 		_is_just_attack = false
+		_combo_fumbled = false
 
 	match new_state:
 		PlayerState.IDLE:

--- a/scripts/autoloads/autopilot.gd
+++ b/scripts/autoloads/autopilot.gd
@@ -2267,22 +2267,48 @@ func _combo_probe_run(p) -> void:
 		return
 	var just_mid: float = (float(t.just_start) + float(t.just_end)) / 2.0
 
-	# Case 1: miss-early press queues nothing (unbuffered no-op).
+	# Case 1: miss-early press FUMBLES the swing — nothing queued, later
+	# presses inside the accept window are locked out, and the swing ending
+	# un-queued breaks the combo: mashing defeats itself (Rozalin's #459
+	# playtest fix).
 	print("[sanity] checkpoint: combo probe — swing 1, miss-early press")
 	p._start_attack()
-	p._start_attack()  # frac ≈ 0 — miss-early
-	if p._queued_combo != p.ComboQueue.NONE:
-		print("[sanity] FAIL: combo probe — miss-early press queued a chain (#155)")
+	p._start_attack()  # frac ≈ 0 — miss-early → fumble
+	if p._queued_combo != p.ComboQueue.NONE or not p._combo_fumbled:
+		print("[sanity] FAIL: combo probe — miss-early press did not fumble the swing (#155)")
 		_after(QUIT_GRACE, func() -> void: get_tree().quit(1))
 		return
-	print("[sanity] checkpoint: combo probe — miss-early was a no-op")
+	print("[sanity] checkpoint: combo probe — miss-early fumbled the swing")
+	var in_fwindow := await _combo_await(func() -> bool:
+		return p.get_state() != states["ATTACKING"] or p._attack_frac() >= just_mid)
+	if not in_fwindow or p.get_state() != states["ATTACKING"]:
+		print("[sanity] FAIL: combo probe — fumbled swing ended before the accept window was reached")
+		_after(QUIT_GRACE, func() -> void: get_tree().quit(1))
+		return
+	p._start_attack()  # inside the window, but fumbled — must be ignored
+	if p._queued_combo != p.ComboQueue.NONE:
+		print("[sanity] FAIL: combo probe — press after a fumble queued a chain (mash lockout broken)")
+		_after(QUIT_GRACE, func() -> void: get_tree().quit(1))
+		return
+	var fumble_broke := await _combo_await(func() -> bool: return p.get_state() == states["IDLE"])
+	if not fumble_broke or p.combo_state != 0:
+		print("[sanity] FAIL: combo probe — fumbled swing did not break the combo to IDLE")
+		_after(QUIT_GRACE, func() -> void: get_tree().quit(1))
+		return
+	print("[sanity] checkpoint: combo probe — fumbled swing broke to IDLE")
+	_combo_probe_chain_phase(p, states, just_mid)
 
-	# Case 2: press inside the just window → queues JUST, fires step 2 with
-	# the just flag at swing end.
+
+## Clean-combo half of the probe: a just-window press queues JUST, fires
+## step 2 with the just flag at swing end, and the un-queued swing 2 breaks
+## back to IDLE.
+func _combo_probe_chain_phase(p, states: Dictionary, just_mid: float) -> void:
+	print("[sanity] checkpoint: combo probe — swing 1 (clean), just-window press")
+	p._start_attack()
 	var in_window := await _combo_await(func() -> bool:
 		return p.get_state() != states["ATTACKING"] or p._attack_frac() >= just_mid)
 	if not in_window or p.get_state() != states["ATTACKING"]:
-		print("[sanity] FAIL: combo probe — swing ended before the just window was reached")
+		print("[sanity] FAIL: combo probe — clean swing ended before the just window was reached")
 		_after(QUIT_GRACE, func() -> void: get_tree().quit(1))
 		return
 	p._start_attack()

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -34,6 +34,7 @@ func _run_tests_combat() -> void:
 	test_action_commitment()
 	test_combo_three_tier()
 	test_combo_chain_lifecycle()
+	test_combo_miss_early_fumble()
 	test_element_status()
 	test_combat_math()
 	test_combat_drops()
@@ -5141,14 +5142,16 @@ func test_combo_three_tier() -> void:
 
 	var pl = PlayerScript.new()
 
-	# miss-early: press before just_start is a clear no-op — NOT buffered.
+	# miss-early: press before just_start queues nothing (it FUMBLES the
+	# swing — the lockout itself is pinned in test_combo_miss_early_fumble).
 	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
 	pl.set("combo_state", 1)
 	pl.set("_attack_anim_length", 1.0)
 	pl.set("_attack_anim_elapsed", 0.3)  # < 0.45
 	pl._try_queue_combo(false)
 	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NONE),
-		"miss-early press queues nothing (unbuffered no-op)")
+		"miss-early press queues nothing (fumble, not buffered)")
+	pl.set("_combo_fumbled", false)  # fresh swing for the tier asserts below
 
 	# just window: [0.45, 0.60) queues a JUST chain.
 	pl.set("_attack_anim_elapsed", 0.5)
@@ -5187,23 +5190,34 @@ func test_combo_three_tier() -> void:
 
 # Second half of the #155 contract: the chain lifecycle — normal-window
 # chains, the finisher's structural no-window, the un-queued break to IDLE,
+# Off-tree player parked mid-swing — shared setup for the combo tests.
+func _combo_swing_player(pl_script, step: int, elapsed: float):
+	var pl = pl_script.new()
+	pl.set("current_state", pl_script.PlayerState.ATTACKING)
+	pl.set("combo_state", step)
+	pl.set("_attack_anim_length", 1.0)
+	pl.set("_attack_anim_elapsed", elapsed)
+	return pl
+
+
+# Fire the step-end point (resetting the exactly-once guard first).
+func _combo_step_end(pl) -> void:
+	pl.set("_attack_step_ended", false)
+	pl._attack_step_finished()
+
+
 # damage interrupts clearing the queue, and the special-chain flag.
 func test_combo_chain_lifecycle() -> void:
 	print("── Combo chain lifecycle (#155) ──")
 	const PlayerScript := preload("res://scripts/3d/player/player.gd")
-	var pl = PlayerScript.new()
 
 	# normal window: [0.60, 1.0] queues a NORMAL chain; firing clears the just flag.
-	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
-	pl.set("combo_state", 2)
+	var pl = _combo_swing_player(PlayerScript, 2, 0.8)
 	pl.set("_is_just_attack", true)  # as if step 2 was a just chain
-	pl.set("_attack_anim_elapsed", 0.8)
-	pl.set("_attack_anim_length", 1.0)
 	pl._try_queue_combo(false)
 	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NORMAL),
 		"press in [just_end, 1.0] queues a normal chain")
-	pl.set("_attack_step_ended", false)
-	pl._attack_step_finished()
+	_combo_step_end(pl)
 	assert_eq(int(pl.get("combo_state")), 3, "normal chain fires → step 3 (finisher)")
 	assert_true(not bool(pl.get("_is_just_attack")), "normal chain clears the just flag")
 	var atk3: Dictionary = pl._get_attack_damage()
@@ -5213,8 +5227,7 @@ func test_combo_chain_lifecycle() -> void:
 	pl.set("_attack_anim_elapsed", 0.7)
 	pl._try_queue_combo(false)
 	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NONE), "finisher press queues nothing")
-	pl.set("_attack_step_ended", false)
-	pl._attack_step_finished()
+	_combo_step_end(pl)
 	assert_eq(int(pl.get("current_state")), int(PlayerScript.PlayerState.IDLE), "finisher end returns to IDLE")
 	assert_eq(int(pl.get("combo_state")), 0, "combo resets after the finisher")
 
@@ -5222,20 +5235,22 @@ func test_combo_chain_lifecycle() -> void:
 	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
 	pl.set("combo_state", 1)
 	pl.set("_queued_combo", PlayerScript.ComboQueue.NONE)
-	pl.set("_attack_step_ended", false)
-	pl._attack_step_finished()
+	_combo_step_end(pl)
 	assert_eq(int(pl.get("current_state")), int(PlayerScript.PlayerState.IDLE),
 		"swing ending un-queued breaks the combo to IDLE (no grace window)")
 
-	# Damage interrupt clears the queue (via transition_to, with #428):
-	# the queued follow-up must never fire after a DAMAGED recovery.
+	# Damage interrupt clears the queue AND the fumble flag (via
+	# transition_to, with #428): the queued follow-up must never fire after
+	# a DAMAGED recovery, and a fumble must not leak into the next combo.
 	GameState.set_hp(GameState.max_hp)
 	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
 	pl.set("combo_state", 1)
 	pl.set("_queued_combo", PlayerScript.ComboQueue.JUST)
+	pl.set("_combo_fumbled", true)
 	pl.take_damage(15)
 	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NONE),
 		"damage interrupt clears the combo queue (#155/#428)")
+	assert_true(not bool(pl.get("_combo_fumbled")), "ATTACKING exit clears the fumble flag")
 	GameState.set_hp(GameState.max_hp)
 
 	# Special chain: strong-attack press queues with the special flag. (The
@@ -5251,6 +5266,51 @@ func test_combo_chain_lifecycle() -> void:
 	assert_true(bool(pl.get("_queued_combo_special")), "strong-attack press queues a special chain")
 	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NORMAL),
 		"special press in the normal window queues a NORMAL-tier chain")
+
+	pl.free()
+	print("")
+
+
+# Miss-early FUMBLES the swing (spec /mechanics/combos): a plain no-op let
+# mashing ride the wide accept window and chain anyway (Rozalin's #459
+# playtest) — the fumble locks out chaining for the rest of the swing so
+# mash breaks its own combo. Per swing: the next step starts clean.
+func test_combo_miss_early_fumble() -> void:
+	print("── Combo miss-early fumble ──")
+	const PlayerScript := preload("res://scripts/3d/player/player.gd")
+	# Park mid-swing at 0.3 — before saber's just_start (0.45): miss-early.
+	var pl = _combo_swing_player(PlayerScript, 1, 0.3)
+	pl._try_queue_combo(false)
+	assert_true(bool(pl.get("_combo_fumbled")), "miss-early press fumbles the swing")
+	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NONE),
+		"fumbling press queues nothing")
+
+	# Mash: presses inside the accept window are now locked out.
+	pl.set("_attack_anim_elapsed", 0.5)  # just window
+	pl._try_queue_combo(false)
+	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NONE),
+		"just-window press after a fumble is ignored")
+	pl.set("_attack_anim_elapsed", 0.8)  # normal window
+	pl._try_queue_combo(true)
+	assert_eq(int(pl.get("_queued_combo")), int(PlayerScript.ComboQueue.NONE),
+		"normal-window press after a fumble is ignored (strong too)")
+
+	# The fumbled swing ends un-queued → combo breaks.
+	_combo_step_end(pl)
+	assert_eq(int(pl.get("current_state")), int(PlayerScript.PlayerState.IDLE),
+		"fumbled swing breaks the combo at swing end")
+
+	# Per-swing lockout: firing the next step resets the flag (synthetic
+	# fumbled+queued state — unreachable in play, but pins the reset path).
+	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
+	pl.set("combo_state", 1)
+	pl.set("_combo_fumbled", true)
+	pl.set("_queued_combo", PlayerScript.ComboQueue.NORMAL)
+	_combo_step_end(pl)
+	assert_eq(int(pl.get("combo_state")), 2, "queued chain fires into step 2")
+	assert_true(not bool(pl.get("_combo_fumbled")), "next step starts with a clean chain attempt")
+	# (Damage-interrupt clearing of the flag is pinned in
+	# test_combo_chain_lifecycle's interrupt block.)
 
 	pl.free()
 	print("")

--- a/spec/src/pages/mechanics/combos.astro
+++ b/spec/src/pages/mechanics/combos.astro
@@ -18,7 +18,7 @@ import Concept from '../../layouts/Concept.astro';
   <table>
     <thead><tr><th>Tier</th><th>Window (fraction of swing)</th><th>On attack press (MUST)</th></tr></thead>
     <tbody>
-      <tr><td><strong>miss-early</strong></td><td><code>[0, just_start)</code></td><td>Clear no-op — the press is <strong>NOT buffered</strong> and does not advance the combo. The player has to read the swing.</td></tr>
+      <tr><td><strong>miss-early</strong></td><td><code>[0, just_start)</code></td><td><strong>Fumble</strong> — the press is <strong>NOT buffered</strong>, does not advance the combo, and <strong>locks out chaining for the remainder of this swing</strong>: every later press in the same swing <strong>MUST</strong> be ignored, so the swing ends un-queued and the combo breaks. Muted-red flash on the fumbling press.</td></tr>
       <tr><td><strong>just-attack</strong></td><td><code>[just_start, just_end)</code></td><td>Queue the next step with the <strong>just bonus</strong>: damage × <code>just_damage_mult</code> on the queued swing, distinct bright-green flash.</td></tr>
       <tr><td><strong>normal</strong></td><td><code>[just_end, 1.0]</code></td><td>Queue the next step (standard damage, green/yellow flash).</td></tr>
       <tr><td><strong>too-late</strong></td><td>after animation end</td><td>Unreachable as a press — the swing ending un-queued has already broken the combo and returned to IDLE.</td></tr>
@@ -27,6 +27,7 @@ import Concept from '../../layouts/Concept.astro';
   <ul>
     <li>The window fractions <strong>MUST</strong> come from data (<code>WeaponComboConfig</code> resources, <code>data/combo_configs/</code>), indexed by the step being chained <em>from</em> — per-motion tuning, not code constants. Defaults: just <code>[0.55, 0.70)</code>, normal <code>[0.70, 1.0]</code>; Saber (fast) is tuned to <code>[0.45, 0.60)</code>/<code>[0.60, 1.0]</code> per #155.</li>
     <li>The just window sits <strong>earlier</strong> than the normal window so precision is rewarded but "waiting = better" can't be farmed.</li>
+    <li><em>Why miss-early fumbles instead of being merely ignored:</em> the accept window spans nearly half the swing, so with an ignore-only miss-early, mashing always lands a press inside the window and chains anyway (Rozalin's #459 playtest — "can still be advanced by spamming"). The fumble makes mashing break its own combo. The lockout is <strong>per swing</strong>: the fumble flag <strong>MUST</strong> reset when the next step starts (each step is a clean chain attempt) and on any exit from ATTACKING.</li>
     <li>A queued step <strong>MUST fire at swing end</strong> (via <code>animation_finished</code> or, for looping animations that never emit it, the elapsed-length safety net — the mechgun-root fix generalizes to every step). Exactly one of the two paths fires per step (<code>_attack_step_ended</code> guard).</li>
     <li>The swing ending with nothing queued <strong>MUST</strong> break the combo: reset to step 0, deactivate the hitbox, return to IDLE (red flash when mid-chain). There is no post-animation grace window.</li>
     <li>Only one queue slot: a second press while queued is a no-op — it <strong>MUST NOT</strong> upgrade normal→just or re-roll the tier.</li>
@@ -40,7 +41,7 @@ import Concept from '../../layouts/Concept.astro';
   <p>Windows are runtime-computed from the animation fraction — PSO:BB's motion files carry no timing events (see <a href="https://github.com/kion-dgl/psobb-re">psobb-re</a>, combo-timing investigation). Motion frame counts from <code>plymotion-profile.tsv</code> inform per-weapon tuning (e.g. Saber A1 = 19 frames → wider windows; finishers A3 = 59–80 frames → no window). The in-repo starting values are feel-tuning defaults, expected to move via playtest.</p>
 
   <h2>Feedback</h2>
-  <p>Queue-time flash by tier (bright green = just, green = normal chain, yellow = special chain, red = chain broken), drawn by the combo ring and gated on the <strong>Combo Timing</strong> debug toggle exactly as before. The PSO:BB chain sounds (<code>SE_PL_CHAIN1/2/HIT</code>) are <strong>not in the pack yet</strong> — audio cues land as a follow-up with the next pack republish.</p>
+  <p>Queue-time flash by tier (bright green = just, green = normal chain, yellow = special chain, muted red = fumbled press, red = chain broken), drawn by the combo ring and gated on the <strong>Combo Timing</strong> debug toggle exactly as before. The PSO:BB chain sounds (<code>SE_PL_CHAIN1/2/HIT</code>) are <strong>not in the pack yet</strong> — audio cues land as a follow-up with the next pack republish.</p>
 
   <h2>Combo-timing debug overlay</h2>
   <p>The <strong>Combo Timing</strong> debug toggle (<code>DebugConfig.show_combo_timing</code>, default <strong>OFF</strong>, toggled from the field start menu) draws the at-feet timing ring, now visualizing the fraction windows: visible from <code>just_start</code> to animation end, bright green inside the just window, normal green in the rest, shrinking toward the swing's end. When the toggle is <strong>OFF</strong> it <strong>MUST</strong> hide <em>every</em> timing ring — both the combo ring (<code>_combo_ring</code>) <em>and</em> the element-tinted heavy/special-attack charge ring (<code>_charge_ring</code>); #415 fixed the charge ring leak. The heavy attack's rising particles and model glow are permanent attack VFX, <strong>not</strong> timing rings, and are unaffected by the toggle.</p>
@@ -51,7 +52,7 @@ import Concept from '../../layouts/Concept.astro';
     <li><code>scripts/autoloads/combat_manager.gd</code> — <code>get_combo_timing(weapon_type, from_step)</code> / <code>get_combo_just_mult(weapon_type)</code> resolve the resource (default config for untuned types).</li>
     <li><code>scripts/3d/player/player.gd</code> (Player) — <code>_try_queue_combo</code> (tier check on press), <code>_attack_step_finished</code> (single fire point at swing end), <code>_handle_attack_state</code> (elapsed tracking + safety net), <code>_get_attack_damage</code> (just bonus). <code>_start_attack</code>/<code>_start_strong_attack</code> route ATTACKING-state presses into the queue.</li>
   </ul>
-  <p>Status: <strong>implemented (#155)</strong> — <code>test_combo_three_tier</code> pins the tiers, queue semantics, just bonus, and finisher; <code>test_mechgun_final_step_no_root</code> pins the safety net; the <code>PSZ_AUTOPILOT_COMBO=1</code> probe drives a live just-chain end-to-end.</p>
+  <p>Status: <strong>implemented (#155)</strong> — <code>test_combo_three_tier</code> pins the tiers, queue semantics, just bonus, and finisher; <code>test_combo_miss_early_fumble</code> pins the fumble lockout; <code>test_mechgun_final_step_no_root</code> pins the safety net; the <code>PSZ_AUTOPILOT_COMBO=1</code> probe drives a live fumble + just-chain end-to-end.</p>
 
   <p>These attacks are the ATTACKING state of the <a href="/states/player-state">Player State Machine</a>.</p>
 


### PR DESCRIPTION
## What this is

The follow-up from Rozalin's #459/#474 device test:

> Normal Attack and Heavy Attack combo can still be advanced by spamming so the miss-early part still needs to be adjusted.

The root cause: a miss-early press was merely **ignored**, and the accept window spans nearly half the swing — so mashing always landed a press inside the window and chained anyway. Miss-early had no teeth.

## The fumble

A press in `[0, just_start)` now **fumbles the swing**: nothing is buffered, and every later press in the same swing is ignored — the swing ends un-queued and the combo breaks. Mashing defeats itself; a deliberate single press per swing is the only way to sustain a chain. The fumbling press gets a muted-red ring flash (debug-toggle-gated like the other tier feedback).

Scope rules (spec'd in `/mechanics/combos`):
- The lockout is **per swing** — the next step (or next fresh combo) starts with a clean chain attempt.
- Any exit from ATTACKING clears the flag alongside the queue (the #428 block in `transition_to`).
- A press after a successful queue is still the harmless no-op it was (the queue can't be re-rolled), so post-queue mashing doesn't retro-fumble a secured chain — but the *next* swing's first early press will.

## Verification (two layers)

- **Unit**: `test_combo_miss_early_fumble` — fumble on early press, just/normal-window presses locked out (strong too), break at swing end, per-step reset; interrupt clearing pinned in `test_combo_chain_lifecycle`'s damage block. Suite on macOS after rebasing onto merged #474: **2095 passed, 0 failed**; code-health ratchet clean.
- **Autopilot**: the `PSZ_AUTOPILOT_COMBO=1` probe now runs a fumble phase first (miss-early press → fumble flag, post-fumble window press ignored, break to IDLE) before the clean just-chain sequence. Needs a box run before merge.

## Needs device test

The feel question for Rozalin: with fumble on, does mashing now visibly break the combo, and does deliberate timing still feel fair? If the punishment feels too harsh, the softer alternative is a cooldown (fumble eats e.g. 0.2s instead of the whole swing) — one-line change, but let's feel this version first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
