### PR TITLE
fix(hud): key count shows keys in hand, decrements on use

### DIFF
--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -962,12 +962,21 @@ func _setup_key_hud(cells: Array) -> void:
 			_total_keys_in_field += 1
 		if not str(cell.get("key_drop", "")).is_empty():
 			_total_keys_in_field += 1
+	# Refresh the held-key count live on pickup AND on gate-consume.
+	if not Inventory.keys_changed.is_connected(_on_keys_changed):
+		Inventory.keys_changed.connect(_on_keys_changed)
+	_update_key_hud()
+
+
+func _on_keys_changed(_total: int) -> void:
 	_update_key_hud()
 
 
 func _update_key_hud() -> void:
+	# Show keys IN HAND (Inventory), not cumulative pickups — the count must
+	# drop as gates consume keys. _keys_collected stays the respawn guard.
 	if _room_minimap and _total_keys_in_field > 0:
-		_room_minimap.update_keys(_keys_collected.size(), _total_keys_in_field)
+		_room_minimap.update_keys(Inventory.get_total_keys(), _total_keys_in_field)
 
 
 ## Check if a cell has living enemies (from quest data or saved state).

--- a/scripts/autoloads/inventory.gd
+++ b/scripts/autoloads/inventory.gd
@@ -37,6 +37,9 @@ var _instance_counter: int = 0
 signal item_added(item_id: String, quantity: int, total: int)
 signal item_removed(item_id: String, quantity: int, remaining: int)
 signal inventory_full()
+## Emitted whenever the held-key total changes (pickup or gate consume) so the
+## field key HUD can track keys IN HAND, not cumulative pickups.
+signal keys_changed(total: int)
 
 
 ## Extract base item ID from an instance ID (e.g., "ein_saber#3" → "ein_saber")
@@ -630,6 +633,7 @@ func clear_inventory() -> void:
 func add_key(key_id: String) -> void:
 	_keys[key_id] = int(_keys.get(key_id, 0)) + 1
 	print("[Inventory] Key collected: ", key_id)
+	keys_changed.emit(get_total_keys())
 
 
 ## Check if a key is held
@@ -642,6 +646,15 @@ func get_key_count(key_id: String) -> int:
 	return int(_keys.get(key_id, 0))
 
 
+## Total keys currently held across all key IDs — the count the field HUD
+## shows (decrements as gates consume keys).
+func get_total_keys() -> int:
+	var total := 0
+	for k in _keys:
+		total += int(_keys[k])
+	return total
+
+
 ## Remove a key (consumed when opening a gate)
 func remove_key(key_id: String) -> void:
 	if _keys.has(key_id):
@@ -650,6 +663,7 @@ func remove_key(key_id: String) -> void:
 			_keys.erase(key_id)
 		else:
 			_keys[key_id] = remaining
+		keys_changed.emit(get_total_keys())
 
 
 ## Get display name prefix for a photon element

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -57,6 +57,7 @@ func _run_tests_core() -> void:
 	test_registries()
 	test_inventory()
 	test_inventory_capacity()
+	test_key_hud_count()
 	test_character_creation()
 	test_equipment()
 	test_palette_momentary_swap()
@@ -427,6 +428,29 @@ func test_inventory() -> void:
 	assert_gt(info2.max_stack, 1, "Monomate is stackable")
 
 	Inventory.clear_inventory()
+	print("")
+
+
+# Held-key count for the field HUD (playtest: keys must decrement on use, not
+# just accumulate). get_total_keys tracks keys IN HAND; keys_changed fires on
+# both pickup (add_key) and gate-consume (remove_key) so the HUD refreshes.
+func test_key_hud_count() -> void:
+	print("── Held-key count + keys_changed signal ──")
+	while Inventory.get_total_keys() > 0:
+		Inventory.remove_key(Inventory._keys.keys()[0])
+	var events: Array = []
+	var cb := func(total: int): events.append(total)
+	Inventory.keys_changed.connect(cb)
+	Inventory.add_key("key_2_3")
+	assert_eq(Inventory.get_total_keys(), 1, "pickup → 1 key in hand")
+	Inventory.add_key("key_4_1")
+	assert_eq(Inventory.get_total_keys(), 2, "second distinct key → 2 in hand")
+	Inventory.remove_key("key_2_3")
+	assert_eq(Inventory.get_total_keys(), 1, "using a key drops the held count")
+	Inventory.remove_key("key_4_1")
+	assert_eq(Inventory.get_total_keys(), 0, "using the last key drops to 0 (playtest fix)")
+	assert_eq(events, [1, 2, 1, 0], "keys_changed emits the new total on every add/remove")
+	Inventory.keys_changed.disconnect(cb)
 	print("")
 
 


### PR DESCRIPTION
## What this is

Playtest fix (item 2 of 3 from today's notes): the top-right key count never went down — it should read 1 after picking up a key and drop to 0 when a gate consumes it.

## Root cause

Two problems stacked: the HUD drew the field controller's `_keys_collected` dict `.size()` — which is the **cumulative pickup / respawn guard** and never shrinks — and `_update_key_hud()` only fired on cell load, so even consuming a key at a gate (`Inventory.remove_key`) left the number stale.

## Fix

- The HUD now sources **`Inventory.get_total_keys()`** — keys actually in hand.
- New **`Inventory.keys_changed`** signal, emitted from `add_key` (pickup) and `remove_key` (gate consume); the field controller connects it to `_update_key_hud`, so the count refreshes live on both.
- `_keys_collected` stays exactly as-is — it's still the per-cell respawn guard, just no longer the display source.

## Verification

`test_key_hud_count` pins `get_total_keys()` and the `keys_changed` payload across pickup/consume (`[1, 2, 1, 0]`). Suite **2140 passed, 0 failed**; code-health clean.

⚠️ **Local sanity pending** — the dev machine is in a live playtest session (manifest-swap would race it). I'll run the sandboxed 27-check sanity before merge; CI's test-runner + spec build cover the automated gates meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)