### PR TITLE
Animate guild-counter textures: scrolling water + pillar (s00e_sa2)

### DIFF
--- a/data/stage_configs/global-texture-fixes.json
+++ b/data/stage_configs/global-texture-fixes.json
@@ -231,6 +231,26 @@
     "wrapS": "mirror",
     "wrapT": "mirror"
   },
+  "s00e_sa2_m_s00_0_bwat00.png#1": {
+    "offsetX": 0,
+    "offsetY": 0,
+    "repeatX": 1,
+    "repeatY": 1,
+    "scrollX": 0,
+    "scrollY": -0.12,
+    "wrapS": "repeat",
+    "wrapT": "repeat"
+  },
+  "s00e_sa2_m_s00_0_hasira.png#1": {
+    "offsetX": 0,
+    "offsetY": 0,
+    "repeatX": 1,
+    "repeatY": 1,
+    "scrollX": 0,
+    "scrollY": 0.13,
+    "wrapS": "repeat",
+    "wrapT": "repeat"
+  },
   "s01_0_bri2.png#1": {
     "offsetX": 0,
     "offsetY": 1,


### PR DESCRIPTION
## What this is

First config output from the new `#/texture-anim` tool (#483) — two animated materials on the merged counter+teleport model, tuned in the tool:

- **`s00e_sa2_m_s00_0_bwat00`** (water) scrolls down — `scrollY -0.12`
- **`s00e_sa2_m_s00_0_hasira`** (pillar) scrolls up — `scrollY 0.13`

`city_area_base` loads these from `global-texture-fixes.json` and drives them through the waterfall shader (`uv += uv_scroll * TIME`). Keys use the Godot-extracted filename + `#1`, matching `_find_global_fix_for_material`'s lookup.

## Notes

- **Additive** — only the two new keys; existing entries are byte-identical (verified: diff is 20 insertions, nothing else).
- Valid JSON (round-tripped). Data-only, no `.gd`/scene change — CI's spec/build covers it. I can run the sandboxed sanity (it passes through the counter scene) before merge if you want the extra check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)