### PR TITLE
fix(shaders): texture seams — mirror folds + waterfall scroll

### DIFF
--- a/scripts/3d/field/texture_fix_shader.gdshader
+++ b/scripts/3d/field/texture_fix_shader.gdshader
@@ -12,14 +12,18 @@ uniform vec2 uv_scroll = vec2(0.0, 0.0);
 // 0 = alpha scissor (opaque), 1 = alpha blend (transparent)
 uniform int alpha_mode = 0;
 
-float apply_wrap(float coord, int mode) {
+float apply_wrap(float coord, int mode, float half_texel) {
 	if (mode == 2) {
 		// Clamp
 		return clamp(coord, 0.0, 1.0);
 	} else if (mode == 1) {
 		// Mirror: 0→1 normal, 1→2 flipped, 2→3 normal, etc.
 		float t = mod(coord, 2.0);
-		return t <= 1.0 ? t : 2.0 - t;
+		float r = t <= 1.0 ? t : 2.0 - t;
+		// Half-texel inset at the fold so linear filtering doesn't bleed across
+		// the repeat wrap and paint a 1px seam (matches hardware MIRRORED_REPEAT,
+		// which doubles the edge texel at the fold).
+		return clamp(r, half_texel, 1.0 - half_texel);
 	}
 	// Repeat (default)
 	return fract(coord);
@@ -27,8 +31,9 @@ float apply_wrap(float coord, int mode) {
 
 void fragment() {
 	vec2 uv = UV * uv_scale.xy + uv_offset.xy + uv_scroll * TIME;
-	uv.x = apply_wrap(uv.x, wrap_s);
-	uv.y = apply_wrap(uv.y, wrap_t);
+	vec2 half_texel = 0.5 / vec2(textureSize(albedo_texture, 0));
+	uv.x = apply_wrap(uv.x, wrap_s, half_texel.x);
+	uv.y = apply_wrap(uv.y, wrap_t, half_texel.y);
 	vec4 tex = texture(albedo_texture, uv);
 	// Use vertex color for RGB tint only — Three.js ignores vertex alpha for
 	// transparency, and GLB meshes often have COLOR.a=0 which would hide geometry.

--- a/scripts/3d/field/waterfall_shader.gdshader
+++ b/scripts/3d/field/waterfall_shader.gdshader
@@ -8,9 +8,16 @@ uniform vec3 uv_offset = vec3(0.0, 0.0, 0.0);
 uniform vec2 uv_scroll = vec2(0.0, 0.0);
 
 void fragment() {
-	vec2 uv = UV * uv_scale.xy + uv_offset.xy + uv_scroll * TIME;
-	uv = fract(uv);
-	vec4 tex = texture(albedo_texture, uv);
+	// Keep the SAMPLED uv in [0,1) (offsetY + uv_scroll*TIME accumulate large,
+	// and fract preserves float precision), but derive the mip from the
+	// CONTINUOUS coord. Plain texture() after fract() spikes the UV derivative
+	// at every wrap — the GPU then snaps to a coarse mip right there, painting
+	// a dark seam where the scroll wraps (the horizontal tile seam) and dotted
+	// lines at the U edges. textureGrad feeds the real continuous derivatives,
+	// so wrapping stays seamless with mipmaps.
+	vec2 uv_cont = UV * uv_scale.xy + uv_offset.xy + uv_scroll * TIME;
+	vec2 uv = fract(uv_cont);
+	vec4 tex = textureGrad(albedo_texture, uv, dFdx(uv_cont), dFdy(uv_cont));
 	ALBEDO = tex.rgb * COLOR.rgb * albedo_color.rgb;
 	ALPHA = tex.a * albedo_color.a;
 }

--- a/scripts/3d/shaders/mirror_repeat.gdshader
+++ b/scripts/3d/shaders/mirror_repeat.gdshader
@@ -9,15 +9,21 @@ uniform bool emission_enabled = false;
 uniform vec3 emission_color : source_color = vec3(0.0);
 uniform float emission_energy = 1.0;
 
-float mirror_coord(float c) {
+float mirror_coord(float c, float half_texel) {
 	float m = mod(c, 2.0);
-	return m < 1.0 ? m : 2.0 - m;
+	float r = m < 1.0 ? m : 2.0 - m;
+	// Half-texel inset at the mirror fold: without it, linear filtering samples
+	// across the repeat wrap right at the seam and paints a 1px line of the
+	// opposite edge (the "off by a pixel" seam). Clamping to texel-center range
+	// makes the fold double the edge texel, like hardware MIRRORED_REPEAT.
+	return clamp(r, half_texel, 1.0 - half_texel);
 }
 
 void fragment() {
 	vec2 uv = UV * uv_scale + uv_offset;
-	if (mirror_x) uv.x = mirror_coord(uv.x);
-	if (mirror_y) uv.y = mirror_coord(uv.y);
+	vec2 half_texel = 0.5 / vec2(textureSize(albedo_texture, 0));
+	if (mirror_x) uv.x = mirror_coord(uv.x, half_texel.x);
+	if (mirror_y) uv.y = mirror_coord(uv.y, half_texel.y);
 	vec4 tex = texture(albedo_texture, uv);
 	ALBEDO = tex.rgb;
 	if (emission_enabled) {

--- a/scripts/3d/shaders/mirror_repeat_alpha.gdshader
+++ b/scripts/3d/shaders/mirror_repeat_alpha.gdshader
@@ -8,15 +8,21 @@ uniform vec2 uv_offset = vec2(0.0, 0.0);
 uniform bool mirror_x = true;
 uniform bool mirror_y = true;
 
-float mirror_coord(float c) {
+float mirror_coord(float c, float half_texel) {
 	float m = mod(c, 2.0);
-	return m < 1.0 ? m : 2.0 - m;
+	float r = m < 1.0 ? m : 2.0 - m;
+	// Half-texel inset at the mirror fold: without it, linear filtering samples
+	// across the repeat wrap right at the seam and paints a 1px line of the
+	// opposite edge (the "off by a pixel" seam). Clamping to texel-center range
+	// makes the fold double the edge texel, like hardware MIRRORED_REPEAT.
+	return clamp(r, half_texel, 1.0 - half_texel);
 }
 
 void fragment() {
 	vec2 uv = UV * uv_scale + uv_offset;
-	if (mirror_x) uv.x = mirror_coord(uv.x);
-	if (mirror_y) uv.y = mirror_coord(uv.y);
+	vec2 half_texel = 0.5 / vec2(textureSize(albedo_texture, 0));
+	if (mirror_x) uv.x = mirror_coord(uv.x, half_texel.x);
+	if (mirror_y) uv.y = mirror_coord(uv.y, half_texel.y);
 	vec4 tex = texture(albedo_texture, uv);
 	ALBEDO = tex.rgb;
 	ALPHA = tex.a;


### PR DESCRIPTION
Two shader texture-seam fixes from playtesting, verified together in a field run (mirrored walls/warps + s01b_nb2 waterfall).

## 1. Mirror-fold 1px seam (`mirror_repeat`, `mirror_repeat_alpha`, `texture_fix_shader`)

The manual mirror folds the UV with a triangle wave then samples a `repeat_enable` texture with linear filtering — right at each fold the filter straddles the repeat wrap and blends the opposite edge in, a 1px seam. **Fix:** inset the mirrored coord by half a texel at the fold (`clamp(r, half_texel, 1 - half_texel)`, `half_texel = 0.5 / textureSize`), so the fold doubles the edge texel like hardware `MIRRORED_REPEAT`. No effect on repeat/clamp modes or mid-tile texels. *Confirmed in-game: dirt-path stray pixel gone, mirrored walls clean.*

## 2. Waterfall scroll seam + dotted edges (`waterfall_shader`)

The waterfall scrolls its UV then `uv = fract(uv)` before sampling. `texture()` derives the mip from that coord's derivative, which spikes at every wrap → the GPU snaps to a coarse mip at the wrap, painting a dark line where the scroll wraps (moving horizontal seam) and dotted U-edges, both exaggerated by the additive blend. **Fix:** keep `fract` for the sampled coord (precision — offset/scroll accumulate large) but sample with `textureGrad`, feeding the *continuous* coord's derivatives so wrapping stays seamless through mipmaps. *Confirmed fixed in s01b_nb2 (shared waterfall texture across the s01b rooms).*

## Verification

All four shaders parse clean loaded headless; both fixes eyeballed on the real renderer (kion's playtest — mirror "much better", waterfall "fixed"). `--headless` can't GPU-compile shaders so CI/sanity can't confirm pixels; visual confirmation is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)