### PR TITLE
chore(assets): republish pack — s01a_ic1 minimap update

### DIFF
--- a/asset_tree.txt
+++ b/asset_tree.txt
@@ -156,6 +156,7 @@ assets/enemies/wolf/m_012.png
 assets/enemies/wolf/wolf.glb
 assets/fonts/JetBrainsMono-Bold.ttf
 assets/fonts/JetBrainsMono-Regular.ttf
+assets/fonts/OFL.txt
 assets/hud/Anti.png
 assets/hud/Barta.png
 assets/hud/Deband.png

--- a/assets_manifest.json
+++ b/assets_manifest.json
@@ -1,16 +1,16 @@
 {
-  "version": "0.38.27",
+  "version": "dev",
   "godot_version": "4.5",
   "pack": {
-    "sha256": "f33c0075a4669500661443cfb469866f8b643af06556cc69291a0864e2061f1d",
-    "size": 330777488,
+    "sha256": "d115abcf4c917c819cec282978ee010fa52cb17561699822bdc37ff300652d08",
+    "size": 330484164,
     "urls": [
-      "https://pck.psz.onl/f33c0075a4669500661443cfb469866f8b643af06556cc69291a0864e2061f1d.pck"
+      "https://pck.psz.onl/d115abcf4c917c819cec282978ee010fa52cb17561699822bdc37ff300652d08.pck"
     ]
   },
   "sidecar": {
     "urls": [
-      "https://pck.psz.onl/f33c0075a4669500661443cfb469866f8b643af06556cc69291a0864e2061f1d.sidecar.json"
+      "https://pck.psz.onl/d115abcf4c917c819cec282978ee010fa52cb17561699822bdc37ff300652d08.sidecar.json"
     ]
   }
 }


### PR DESCRIPTION
## What this is

The pack republish that lands the updated **s01a_ic1 minimap** (from #481, PR that added the new SVG + rotations) into shipped builds. Deferred earlier because the 330MB rsync kept dropping on a tethered connection — went through cleanly now.

## What changed

- **`assets_manifest.json`** → points at the new DO pack `d115abcf…` (was `f33c0075…`) + matching sidecar on `pck.psz.onl`.
- **`asset_tree.txt`** → one incidental add (`assets/fonts/OFL.txt`, a license file the tree scan now records as in the pack). The minimap SVG *paths* were already tracked (only their content changed, which the tree doesn't diff).

The minimap SVGs themselves are **gitignored pack-only assets**, so the visual change doesn't appear in this diff — it ships inside the pack, and this manifest bump is the mechanism. It's already been live on disk (dev-from-source) and on R2 (web tools) since #481.

## Verification

- Pack + sidecar uploaded to the droplet; **`GDPC` magic verified** served over HTTPS.
- Sidecar consistent with the manifest (`version: dev`, sha `d115abcf`, size 330484164) — `verify-assets` will pass.
- Built from disk with the new minimap present (base SVG `data-scale="5.217391"`), `importer="keep"` so the raw SVG ships in the pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)