### PR TITLE
Fix #477: big-rig enemies wedge in ATTACKING (freeze until hit)

### DIFF
--- a/scripts/3d/enemies/enemy_base.gd
+++ b/scripts/3d/enemies/enemy_base.gd
@@ -44,6 +44,14 @@ const HURT_DURATION: float = 0.3
 ## Animation state tracking
 var is_attacking: bool = false
 var current_anim: String = ""
+## Resolved (full) name of the attack animation in flight — attack end is
+## detected against this, never by parsing a suffix out of the finished
+## signal (big rigs name the clip atk1/atckwat and used to wedge ATTACKING
+## until a hit forced HURT — #477, spec /states/enemies).
+var _attack_anim: String = ""
+## Ticks down when no attack animation resolved at all (armadillo has none).
+var _attack_fallback_timer: float = 0.0
+const ATTACK_FALLBACK_DURATION: float = 0.8
 
 ## Stuck detection — try perpendicular direction when blocked
 var _stuck_time: float = 0.0
@@ -508,11 +516,22 @@ func _process_chasing(_delta: float) -> void:
 		_face_direction(direction)
 
 
-func _process_attacking(_delta: float) -> void:
+func _process_attacking(delta: float) -> void:
 	velocity.x = 0
 	velocity.z = 0
 
-	# Wait for attack animation to finish, then loaf off
+	# Attack end: the resolved animation finished (signal path or the
+	# watchdog below), or the fallback duration elapsed when no attack
+	# animation resolved. Never wait on a damage event to recover (#477).
+	if is_attacking:
+		if _attack_anim.is_empty():
+			_attack_fallback_timer -= delta
+			if _attack_fallback_timer <= 0.0:
+				is_attacking = false
+		elif animation_player and not animation_player.is_playing():
+			is_attacking = false
+			_attack_anim = ""
+
 	if not is_attacking:
 		_start_loafing()
 
@@ -584,7 +603,10 @@ func _start_attack() -> void:
 		return
 
 	is_attacking = true
-	_play_animation("atk", true)  # Force play attack animation
+	_attack_anim = _play_animation("atk", true)  # Force play attack animation
+	if _attack_anim.is_empty():
+		# Rig has no resolvable attack clip — end the attack on a timer.
+		_attack_fallback_timer = ATTACK_FALLBACK_DURATION
 	_play_sfx("attack")
 
 	# Face the target
@@ -644,6 +666,7 @@ func _on_hit_received(raw_damage: int, _knockback: Vector3, accuracy: int = 100,
 
 		# Enter hurt state — play stagger animation, no physics knockback
 		is_attacking = false  # Cancel any attack
+		_attack_anim = ""
 		current_state = EnemyState.HURT
 		hurt_timer = HURT_DURATION
 		velocity = Vector3.ZERO  # Stop movement during stagger
@@ -711,14 +734,15 @@ func _has_floor_at(check_pos: Vector3) -> bool:
 	return not result.is_empty()
 
 
-## Play an animation by name (short name like "atk" will match "s_001_atk")
-func _play_animation(anim_name: String, force: bool = false) -> void:
+## Play an animation by name (short name like "atk" will match "s_001_atk").
+## Returns the resolved full animation name, or "" if nothing played.
+func _play_animation(anim_name: String, force: bool = false) -> String:
 	if not animation_player:
-		return
+		return ""
 
 	# Don't interrupt same animation unless forced
 	if not force and current_anim == anim_name:
-		return
+		return ""
 
 	# Try to find the animation - GLB animations are named like "s_001_atk"
 	var full_name := _find_animation(anim_name)
@@ -732,7 +756,7 @@ func _play_animation(anim_name: String, force: bool = false) -> void:
 			_uses_walk_variants = true
 
 	if full_name.is_empty():
-		return
+		return ""
 
 	# Ensure looping animations actually loop
 	var anim := animation_player.get_animation(full_name)
@@ -741,6 +765,7 @@ func _play_animation(anim_name: String, force: bool = false) -> void:
 
 	animation_player.play(full_name)
 	current_anim = anim_name
+	return full_name
 
 
 ## Find animation by short name (e.g., "atk" matches "s_001_atk")
@@ -749,7 +774,7 @@ const ANIM_ALIASES := {
 	"wat": ["stt"],       # wait/idle → standing
 	"wlk": ["fly"],       # walk → fly (for airborne enemies)
 	"run": ["fly"],       # run → fly
-	"atk": ["atk1"],      # attack → attack variant 1
+	"atk": ["atk1", "atckwat"],  # attack → variant 1, or orangutan's misspelled attack-from-wait
 }
 
 func _find_animation(short_name: String) -> String:
@@ -788,15 +813,20 @@ func _find_animation(short_name: String) -> String:
 
 ## Called when animation finishes
 func _on_animation_finished(anim_name: String) -> void:
-	# Extract short name (e.g., "s_001_atk" -> "atk")
+	# Attack end is matched against the resolved name that _start_attack
+	# actually played — suffix parsing wedged atk1/atckwat rigs (#477).
+	if anim_name == _attack_anim:
+		is_attacking = false
+		_attack_anim = ""
+		return
+
+	# Extract short name (e.g., "s_001_tht" -> "tht")
 	var short_name := anim_name
 	if "_" in anim_name:
 		var parts := anim_name.split("_")
 		short_name = parts[parts.size() - 1]  # Get last part after underscore
 
 	match short_name:
-		"atk":
-			is_attacking = false
 		"tht":
 			# After threat animation, start chasing
 			if current_state == EnemyState.CHASING:

--- a/scripts/autoloads/autopilot.gd
+++ b/scripts/autoloads/autopilot.gd
@@ -272,6 +272,9 @@ var _commitment_triggered := false  # ran the probe already (fires once)
 var _combo_probe := false           # #155 three-tier combo-timing probe
 var _combo_triggered := false       # ran the probe already (fires once)
 
+var _enemy_freeze_probe := false    # #477 big-rig attack-wedge probe
+var _enemy_freeze_triggered := false  # ran the probe already (fires once)
+
 
 func _ready() -> void:
 	_enabled = OS.has_environment("PSZ_AUTOPILOT") or ("--autopilot" in OS.get_cmdline_user_args())
@@ -288,18 +291,7 @@ func _ready() -> void:
 		_:
 			_phase = Phase.ALL
 			print("[sanity] autopilot enabled (phase=all: full run from boot to quest report)")
-	_shops_phase = OS.has_environment("PSZ_AUTOPILOT_SHOPS")
-	if _shops_phase:
-		print("[sanity] autopilot SHOPS coverage enabled (principal → shops → storage smoke)")
-	_defeat_probe = OS.has_environment("PSZ_AUTOPILOT_DEFEAT")
-	if _defeat_probe:
-		print("[sanity] autopilot DEFEAT probe enabled (kill player in first field cell → return to city)")
-	_commitment_probe = OS.has_environment("PSZ_AUTOPILOT_COMMITMENT")
-	if _commitment_probe:
-		print("[sanity] autopilot COMMITMENT probe enabled (attack/dodge must not cancel each other in first field cell)")
-	_combo_probe = OS.has_environment("PSZ_AUTOPILOT_COMBO")
-	if _combo_probe:
-		print("[sanity] autopilot COMBO probe enabled (three-tier timing windows in first field cell)")
+	_parse_probe_flags()
 	# Optionally override which quest to drive (defaults to search_and_rescue).
 	# Other quests load their step list from data/quest_plans/<id>.json.
 	var qenv: String = OS.get_environment("PSZ_AUTOPILOT_QUEST")
@@ -353,6 +345,25 @@ func _ready() -> void:
 	if _menu_during_pickup:
 		print("[sanity] autopilot MENU_DURING_PICKUP on: will toggle the start menu during quest-item pickups (toast-persistence probe)")
 	set_process(true)
+
+
+## One env flag per optional coverage phase / first-field-cell probe.
+func _parse_probe_flags() -> void:
+	_shops_phase = OS.has_environment("PSZ_AUTOPILOT_SHOPS")
+	if _shops_phase:
+		print("[sanity] autopilot SHOPS coverage enabled (principal → shops → storage smoke)")
+	_defeat_probe = OS.has_environment("PSZ_AUTOPILOT_DEFEAT")
+	if _defeat_probe:
+		print("[sanity] autopilot DEFEAT probe enabled (kill player in first field cell → return to city)")
+	_commitment_probe = OS.has_environment("PSZ_AUTOPILOT_COMMITMENT")
+	if _commitment_probe:
+		print("[sanity] autopilot COMMITMENT probe enabled (attack/dodge must not cancel each other in first field cell)")
+	_combo_probe = OS.has_environment("PSZ_AUTOPILOT_COMBO")
+	if _combo_probe:
+		print("[sanity] autopilot COMBO probe enabled (three-tier timing windows in first field cell)")
+	_enemy_freeze_probe = OS.has_environment("PSZ_AUTOPILOT_ENEMY_FREEZE")
+	if _enemy_freeze_probe:
+		print("[sanity] autopilot ENEMY-FREEZE probe enabled (big rig must exit ATTACKING unhit in first field cell)")
 
 
 ## Called every frame from _process — when floor-only mode is on, mark every
@@ -2379,6 +2390,73 @@ func _commitment_dodge_phase(p, states: Dictionary) -> void:
 				_after(QUIT_GRACE, func() -> void: get_tree().quit(0)))))
 
 
+# ── Enemy attack-recovery probe (#477, spec /states/enemies) ───────────────
+## PSZ_AUTOPILOT_ENEMY_FREEZE=1: in the first field cell, spawn Hildegigas
+## (gorilla rig — its attack clip is "b_014_atk1", the wedge case) in contact
+## with the player, let it attack, and require ATTACKING to end with the
+## player never swinging back. Runs instead of the cell plan and ends the run
+## with DONE ok / FAIL.
+
+func _enemy_freeze_fail(msg: String) -> void:
+	_fail_and_quit("enemy-freeze probe — %s" % msg)
+
+
+func _run_enemy_freeze_probe(attempt: int = 0) -> void:
+	var players: Array = get_tree().get_nodes_in_group("player")
+	if players.is_empty():
+		if attempt < 60:
+			_after(STEP_DELAY, func() -> void: _run_enemy_freeze_probe(attempt + 1))
+		else:
+			_enemy_freeze_fail("no player in field")
+		return
+	var p: Node3D = players[0]
+	var edata = EnemyRegistry.get_enemy("hildegigas")
+	if edata == null:
+		_enemy_freeze_fail("hildegigas missing from EnemyRegistry")
+		return
+	var enemy := EnemyBase.new()
+	enemy.enemy_data = edata
+	var col_shape := CollisionShape3D.new()
+	var capsule := CapsuleShape3D.new()
+	capsule.radius = edata.collision_radius
+	capsule.height = edata.collision_height
+	col_shape.shape = capsule
+	col_shape.position.y = capsule.height / 2
+	enemy.add_child(col_shape)
+	enemy.collision_layer = 8
+	enemy.collision_mask = 1
+	p.get_parent().add_child(enemy)
+	enemy.global_position = p.global_position + p.global_transform.basis.z * 1.2
+	print("[sanity] checkpoint: enemy-freeze probe — Hildegigas spawned in contact with player")
+	_enemy_freeze_watch(enemy, {"attacked": false}, 0)
+
+
+## Poll the spawned enemy ~5/s: it must reach ATTACKING, then leave it for
+## LOAFING/CHASING with no damage event. ~20s budget before calling it wedged.
+func _enemy_freeze_watch(enemy: EnemyBase, seen: Dictionary, tick: int) -> void:
+	if not is_instance_valid(enemy):
+		_enemy_freeze_fail("enemy freed mid-probe")
+		return
+	var s: int = enemy.current_state
+	if s == EnemyBase.EnemyState.ATTACKING:
+		seen["attacked"] = true
+	elif seen["attacked"] and (s == EnemyBase.EnemyState.LOAFING or s == EnemyBase.EnemyState.CHASING):
+		print("[sanity] checkpoint: enemy-freeze probe — attack cycle ended (state=%d) without a hit" % s)
+		enemy.queue_free()
+		print("[sanity] DONE ok")
+		_after(QUIT_GRACE, func() -> void: get_tree().quit(0))
+		return
+	if tick >= 100:
+		if seen["attacked"]:
+			_enemy_freeze_fail("wedged in ATTACKING (is_attacking=%s anim_playing=%s) — the #477 freeze" % [
+				str(enemy.is_attacking),
+				str(enemy.animation_player.is_playing()) if enemy.animation_player else "n/a"])
+		else:
+			_enemy_freeze_fail("enemy never entered ATTACKING (state=%d)" % s)
+		return
+	_after(0.2, func() -> void: _enemy_freeze_watch(enemy, seen, tick + 1))
+
+
 func _on_field_cell_loaded(field: Node) -> void:
 	_stop_field_walk()
 	# Defeat probe: in the first field cell, kill the player instead of running
@@ -2398,6 +2476,12 @@ func _on_field_cell_loaded(field: Node) -> void:
 	if _combo_probe and not _combo_triggered:
 		_combo_triggered = true
 		_run_combo_probe()
+		return
+	# Enemy-freeze probe (#477): spawn a big atk1 rig on the player and
+	# require its attack cycle to end without a damage event.
+	if _enemy_freeze_probe and not _enemy_freeze_triggered:
+		_enemy_freeze_triggered = true
+		_run_enemy_freeze_probe()
 		return
 	var key: String = _get_current_cell_key(field)
 	var stage_id: String = ""

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -40,6 +40,7 @@ func _run_tests_combat() -> void:
 	test_target_info_panel()
 	test_area_map_overlay()
 	test_element_status()
+	test_enemy_attack_recovery()
 	test_combat_math()
 	test_combat_drops()
 	test_drop_tables()
@@ -845,6 +846,82 @@ func test_element_status() -> void:
 	assert_true(procced.has("devil"), "dark procs devil through the live path")
 	assert_true(devil_hp_ok, "devil drops 400 HP to ¼ (100) every time")
 	assert_true(procced.has("poison"), "dark procs poison through the live path")
+	print("")
+
+
+# ── Enemy attack recovery (#477, spec /states/enemies) ─────
+## Big rigs name their attack clip atk1 / atckwat (or lack one entirely);
+## ATTACKING must still end without a damage event — the playtest freeze was
+## the finished-signal suffix parse never matching "atk1".
+
+func _make_recovery_enemy(anim_name: String, anim_len: float) -> EnemyBase:
+	var e := EnemyBase.new()
+	e.enemy_data = EnemyData.new()
+	add_child(e)
+	var ap := AnimationPlayer.new()
+	e.add_child(ap)
+	var lib := AnimationLibrary.new()
+	if not anim_name.is_empty():
+		var anim := Animation.new()
+		anim.length = anim_len
+		lib.add_animation(anim_name, anim)
+	ap.add_animation_library("", lib)
+	e.animation_player = ap
+	return e
+
+
+func test_enemy_attack_recovery() -> void:
+	print("── Enemy attack recovery (#477) ──")
+	var dummy := Node3D.new()
+	add_child(dummy)
+	dummy.position = Vector3(0, 0, 2)
+
+	# Gorilla-shaped rig: only "b_014_atk1", resolved via the atk→atk1 alias.
+	var e := _make_recovery_enemy("b_014_atk1", 0.4)
+	e.target = dummy
+	assert_eq(e._find_animation("atk"), "b_014_atk1", "atk resolves atk1 rigs via alias")
+	e.current_state = EnemyBase.EnemyState.ATTACKING
+	e._start_attack()
+	assert_true(e.is_attacking, "attack starts on atk1 rig")
+	assert_eq(e._attack_anim, "b_014_atk1", "resolved attack anim tracked by full name")
+	e._on_animation_finished("b_014_atk1")
+	assert_true(not e.is_attacking, "atk1 finish clears is_attacking — no hit needed")
+	e._process_attacking(0.016)
+	assert_eq(e.current_state, EnemyBase.EnemyState.LOAFING, "ATTACKING exits to LOAFING")
+
+	# Watchdog: resolved anim stopped without a matching finished signal —
+	# the ATTACKING tick itself must notice and recover.
+	e.current_state = EnemyBase.EnemyState.ATTACKING
+	e._start_attack()
+	assert_true(e.is_attacking, "second attack starts")
+	e.animation_player.stop()
+	e._process_attacking(0.016)
+	assert_true(not e.is_attacking, "stopped attack anim recovers via ATTACKING watchdog")
+	assert_eq(e.current_state, EnemyBase.EnemyState.LOAFING, "watchdog exit lands in LOAFING")
+
+	# Rig with no attack animation at all (armadillo): nothing plays, so the
+	# fixed fallback duration must end the attack.
+	var e2 := _make_recovery_enemy("b_035_wat1", 1.0)
+	e2.target = dummy
+	e2.current_state = EnemyBase.EnemyState.ATTACKING
+	e2._start_attack()
+	assert_true(e2.is_attacking, "attack starts even with no attack anim")
+	assert_eq(e2._attack_anim, "", "no resolvable attack anim → fallback armed")
+	e2._process_attacking(0.1)
+	assert_true(e2.is_attacking, "fallback does not end the attack early")
+	e2._process_attacking(EnemyBase.ATTACK_FALLBACK_DURATION)
+	assert_true(not e2.is_attacking, "fallback duration ends the attack")
+	assert_eq(e2.current_state, EnemyBase.EnemyState.LOAFING, "no-anim rig exits to LOAFING")
+
+	# Orangutan's misspelled "atck" clip is aliased so the rig still swings.
+	var e3 := _make_recovery_enemy("b_044_atckwat", 0.5)
+	e3.target = dummy
+	assert_eq(e3._find_animation("atk"), "b_044_atckwat", "atk resolves orangutan's atckwat clip")
+
+	e.queue_free()
+	e2.queue_free()
+	e3.queue_free()
+	dummy.queue_free()
 	print("")
 
 

--- a/spec/src/pages/states/enemies.astro
+++ b/spec/src/pages/states/enemies.astro
@@ -59,6 +59,15 @@ const fsm = `stateDiagram-v2
     <tr><td><strong>DEAD</strong></td><td>Play death animation, emit <code>died</code>, free after the animation.</td></tr>
   </table>
 
+  <h3>Attack recovery — no wedging (#477)</h3>
+  <p>The <strong>ATTACKING → LOAFING</strong> transition is keyed on the attack animation ending, and the source models are inconsistent about what that animation is called (<code>_atk</code>, <code>_atk1</code>, misspelled <code>_atckwat</code>, or absent entirely — the big <code>b_*</code> rigs are the usual offenders). That naming variance <strong>MUST NOT</strong> be able to strand the state machine:</p>
+  <ul>
+    <li>ATTACKING <strong>MUST</strong> terminate for <em>every</em> model, whatever its attack animation is named — including models with <strong>no resolvable attack animation at all</strong>, which <strong>MUST</strong> recover after a fixed fallback duration instead.</li>
+    <li>Attack end <strong>MUST</strong> be detected against the <em>resolved</em> animation that was actually played (or by observing that it is no longer playing), <strong>MUST NOT</strong> rely on parsing a name suffix back out of the <code>animation_finished</code> signal.</li>
+    <li>An enemy <strong>MUST NOT</strong> require a damage event (the HURT transition) to resume AI or animation. Being hit is a recovery path, never the only one.</li>
+    <li>Player contact <strong>MUST NOT</strong> freeze an enemy: while the player stands against (or overlaps) an enemy of any size, its state machine and animation <strong>MUST</strong> keep advancing — attack, loaf, and chase cycles continue exactly as at range. Large and small enemies <strong>MUST</strong> behave identically under contact, differing only in authored stats.</li>
+  </ul>
+
   <h2>Status effects &amp; elements</h2>
   <p>A hit carrying an element <strong>MAY</strong> proc a status. Trigger chance is <code>10% + 10% × element_level</code>. The full status table (<code>CombatManager.STATUS_EFFECTS</code>):</p>
   <table>


### PR DESCRIPTION
Fixes #477.

## Root cause — not collision, and not `_is_immobilized`

The issue's original hypothesis (player collision stalling `move_and_slide` / setting `_is_immobilized`) turned out to be wrong. `_is_immobilized` is only ever set by status effects. The real mechanism:

- Walking into (or near) an enemy puts the player inside `attack_range`, so the enemy enters **ATTACKING** — that's the "on contact" trigger.
- `_process_attacking` spins until `is_attacking` is cleared, and the only clear path was `_on_animation_finished` parsing the *last underscore-suffix* of the finished clip and matching it against `"atk"`.
- The GLB rigs are prefixed by size (`s_` small / `m_` medium / `b_` big), and the **big rigs don't have a plain `atk` clip**: gorilla is `b_014_atk1`, roc `b_022_atk1` (both play via the `atk→atk1` alias, but finish as `"atk1"` — never matches), orangutan only has a misspelled `b_044_atckwat`, armadillo has no attack clip at all (those two play *nothing*, so the signal never fires). Also affected: seal `m_021_atk1`, snake `m_003_atk1`.
- Result: the enemy freezes in ATTACKING — zero velocity, one-shot clip stopped on its last frame — until `_on_hit_received` forcibly clears `is_attacking`. Exactly the playtest symptom: **large enemies freeze on contact and only unfreeze when hit; small enemies (all have `_atk` clips) are fine.**

## Fix (spec-first, per the working agreement)

1. **Spec** — `/states/enemies` gains an RFC-2119 *attack recovery* contract: ATTACKING MUST terminate for every rig regardless of clip naming/absence; attack end MUST be detected against the resolved clip actually played, never by suffix parsing; a damage event MUST NOT be the only recovery path; player contact MUST NOT freeze AI/animation.
2. **Godot** — `_play_animation` now returns the resolved full clip name; `_start_attack` records it (`_attack_anim`) or arms a fixed fallback duration when nothing resolves; `_on_animation_finished` clears by full-name match; the ATTACKING tick has an is-no-longer-playing watchdog. Bonus: the `atk` alias list gains orangutan's `atckwat` so that rig actually swings instead of timing out invisibly.
3. **Tests, two layers**:
   - `test_enemy_attack_recovery` (test_runner, 14 asserts): alias resolution for `atk1`/`atckwat` rigs, finished-signal clear by resolved name, watchdog recovery on a stopped clip, fallback-duration path for no-clip rigs, ATTACKING→LOAFING exits.
   - `PSZ_AUTOPILOT_ENEMY_FREEZE=1` autopilot probe: in the first field cell it spawns **Hildegigas** (the real gorilla rig) in contact with the player and requires the attack cycle to end with the player never swinging back.

## Verification (local, macOS headless)

| Check | Result |
|---|---|
| Full test_runner suite | **2179 passed, 0 failed** |
| Freeze probe on this branch | `DONE ok` — attack cycle ended (LOAFING) unhit |
| Freeze probe on pre-fix `enemy_base.gd` (red check) | `FAIL: wedged in ATTACKING (is_attacking=true anim_playing=false)` |
| `code_graph.py --check` / `orphan_files.py --check` | clean — dup and complexity baselines each net **−1** (probe-flag parsing extracted from `_ready`, fail helper reuses `_fail_and_quit`) |
| Spec Astro build | OK |

Note for the hardware pass: gorilla-family (Hildegigas/Hildeghana/Hildegao), roc-family (Pelcatraz/Pelcatobur), orangutan-family (Froutang/Frunaked), seal and snake families are the affected rigs — running into any of them should now show them keep attacking/loafing instead of freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)