### PR TITLE
Boss debug rooms (#493) + de-duplicated enemy-room index

### DIFF
--- a/web/src/enemy-room/EnemyRoomIndex.tsx
+++ b/web/src/enemy-room/EnemyRoomIndex.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { loadConfig, loadRoster, type EnemyAttackConfig, type RosterEntry } from './types';
-import { loadBossConfig, type BossArenaConfig } from '../boss-room/types';
 import { ARCHETYPES } from './archetypes';
 
 /**
@@ -9,18 +8,16 @@ import { ARCHETYPES } from './archetypes';
  * /mechanics/enemy-attacks "Rig groups & behavior archetypes"). Each room
  * previews and captures that archetype's behavior for its enemies.
  *
- * The 'boss' archetype is arena-bound (#493), so instead of a flat-sandbox
- * room its slot renders one card per boss linking into #/boss-room/<id>.
+ * The 'boss' archetype is arena-bound (#493) and lives in its own tool, so
+ * bosses are omitted here — see #/boss-room for the dedicated boss index.
  */
 export default function EnemyRoomIndex() {
   const [config, setConfig] = useState<EnemyAttackConfig | null>(null);
-  const [bossConfig, setBossConfig] = useState<BossArenaConfig | null>(null);
   const [roster, setRoster] = useState<Map<string, RosterEntry>>(new Map());
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     loadConfig().then(setConfig, (e) => setError(String(e)));
-    loadBossConfig().then(setBossConfig, (e) => setError(String(e)));
     loadRoster().then(setRoster, (e) => setError(String(e)));
   }, []);
 
@@ -48,8 +45,8 @@ export default function EnemyRoomIndex() {
       <p style={{ color: '#9ab', fontSize: 13, maxWidth: 720 }}>
         One room per behavior archetype — the taxonomy from spec <code>/mechanics/enemy-attacks</code>, stamped
         onto every enemy in <code>data/enemy_attacks.json</code>. Pick a room to preview and tune that
-        archetype's enemies against the sim. Bosses are arena-bound, so their cards open a{' '}
-        <Link to="/boss-room" style={{ color: '#88aaff' }}>boss room</Link> in the boss's own stage instead.
+        archetype's enemies against the sim. Bosses are arena-bound and live in the{' '}
+        <Link to="/boss-room" style={{ color: '#88aaff' }}>boss room</Link> tool instead.
       </p>
       {error && <div style={{ color: '#f66' }}>{error}</div>}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 12, marginTop: 12 }}>
@@ -75,26 +72,6 @@ export default function EnemyRoomIndex() {
             </Link>
           );
         })}
-        {bossConfig &&
-          Object.entries(bossConfig.bosses).map(([id, b]) => {
-            const arena = bossConfig.arenas[b.arena];
-            return (
-              <Link key={id} to={`/boss-room/${id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-                <div style={cardStyle(false)}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-                    <strong>{roster.get(id)?.name ?? id}</strong>
-                    <span style={{ color: '#889', fontSize: 11 }}>boss</span>
-                  </div>
-                  <div style={{ color: '#9ab', fontSize: 11, margin: '6px 0' }}>
-                    {b.model_id} · {arena?.label ?? b.arena} ({b.arena}) · from {b.quest_source}
-                  </div>
-                  <div style={{ color: '#786', fontSize: 10, fontStyle: 'italic' }}>
-                    Arena-bound boss room (#493) — opens in the boss's own stage.
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Why

Bosses need arena context that the flat-sandbox enemy-room tool can't provide (#493), so this branch adds a **dedicated boss debug tool** and cleans up an overlap that resulted from it.

## What's here

- **`#/boss-room` — boss debug tool (#493).** `#/boss-room` lists the 5 bosses; `#/boss-room/<id>` loads each boss into its real arena — stage visual geometry (`_m.glb`), baked floor collider (`-floor.glb`), skybox, and a physics player capsule (floor raycast, gravity, jump, step-up). Includes an arena picker, per-boss scale overrides, clip playback with st→lp→ed segment chains, and click-to-place anchors exportable to JSON. Backed by the new `data/boss_arenas.json` (5 bosses × 8 z-arenas).
- **Enemy-room index de-duplicated.** An earlier commit on this branch had added the 5 boss cards *into* the `#/enemy-room` index as a bridge, but that duplicated `#/boss-room` outright — same 5 bosses, same links into `#/boss-room/<id>`. Since bosses are arena-bound and explicitly filtered out of the archetype tool (`ARCHETYPES` drops `'boss'`), their only real home is the dedicated tool. The final commit removes the redundant cards and the now-unused boss-config load; the intro still links out to the boss room for discoverability.
- CI fix for the boss-room tests (`/assets/` tree isn't in git).

## Verification

- `tsc -b` clean, `vitest run` — **396 passed**.
- Browser check: `#/enemy-room` now renders **19 archetype cards, 0 boss cards**; `#/boss-room` still lists **5 bosses**. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)