### PR TITLE
Companion combat phase 2: aggro, taking damage, kneel/recover

### DIFF
--- a/scenes/3d/player/player.tscn
+++ b/scenes/3d/player/player.tscn
@@ -8,7 +8,7 @@
 radius = 0.35
 height = 1.4
 
-[node name="Player" type="CharacterBody3D" groups=["player"]]
+[node name="Player" type="CharacterBody3D" groups=["allies", "player"]]
 collision_layer = 2
 collision_mask = 1
 floor_max_angle = 1.0

--- a/scripts/3d/elements/companion_combat.gd
+++ b/scripts/3d/elements/companion_combat.gd
@@ -14,6 +14,14 @@ const ENGAGE_NO_PROGRESS_TIME: float = 8.0  # blocked-approach self-heal → reg
 const COMBAT_STUCK_TIME: float = 60.0  # autopilot tripwire backstop
 const FALLBACK_SWING_TIME: float = 0.5  # swing length when no atk1 clip resolves
 
+## Phase-2 survivability (spec /states/companion-combat). The companion never
+## dies: at 0 HP it kneels for DOWNED_RECOVER_TIME, then recovers to a fraction
+## of max HP. Max HP scales gently with the player's level.
+const COMPANION_BASE_HP: int = 120     # max HP at level 1
+const COMPANION_HP_PER_LEVEL: int = 12 # added per player level above 1
+const DOWNED_RECOVER_TIME: float = 10.0
+const DOWNED_RECOVER_FRAC: float = 0.5
+
 ## Melee weapon type per companion (CombatManager.WEAPON_TYPE_CONFIGS keys).
 ## Phase 1 is melee-only; unlisted companions default to SABER (0).
 const COMPANION_WEAPON_TYPES: Dictionary = {
@@ -34,6 +42,25 @@ static func within_leash(pos: Vector3, player_pos: Vector3) -> bool:
 	return Vector2(pos.x - player_pos.x, pos.z - player_pos.z).length() <= LEASH_RADIUS
 
 
+## Index of the eligible candidate nearest from_pos in the XZ plane, or -1.
+## candidates: [{pos: Vector3, eligible: bool}, …]. Shared by the companion's
+## target pick and the enemy's ally pick (EnemyBase.select_nearest_ally) so
+## "nearest eligible in XZ" lives in exactly one place.
+static func nearest_eligible_index(candidates: Array, from_pos: Vector3) -> int:
+	var best_idx := -1
+	var best_dist := INF
+	for i in range(candidates.size()):
+		var c: Dictionary = candidates[i]
+		if not bool(c.get("eligible", false)):
+			continue
+		var pos: Vector3 = c.get("pos", Vector3.ZERO)
+		var d := Vector2(pos.x - from_pos.x, pos.z - from_pos.z).length()
+		if d < best_dist:
+			best_dist = d
+			best_idx = i
+	return best_idx
+
+
 ## Pick a target from candidate dicts [{pos: Vector3, alive: bool}, …].
 ## preferred_idx is the index of the player's primary reticle target (-1 for
 ## none): if that candidate is eligible it wins outright (assist priority);
@@ -41,22 +68,15 @@ static func within_leash(pos: Vector3, player_pos: Vector3) -> bool:
 ## alive and within the leash of the PLAYER. Returns the chosen index, -1
 ## when nothing is eligible.
 static func select_target(candidates: Array, player_pos: Vector3, companion_pos: Vector3, preferred_idx: int = -1) -> int:
-	var best_idx := -1
-	var best_dist := INF
-	for i in range(candidates.size()):
-		var c: Dictionary = candidates[i]
-		if not bool(c.get("alive", false)):
-			continue
+	var elig: Array = []
+	for c in candidates:
 		var pos: Vector3 = c.get("pos", Vector3.ZERO)
-		if not within_leash(pos, player_pos):
-			continue
-		if i == preferred_idx:
-			return i
-		var d := Vector2(pos.x - companion_pos.x, pos.z - companion_pos.z).length()
-		if d < best_dist:
-			best_dist = d
-			best_idx = i
-	return best_idx
+		var ok: bool = bool(c.get("alive", false)) and within_leash(pos, player_pos)
+		elig.append({"pos": pos, "eligible": ok})
+	# Assist priority: the player's reticle target wins if it is eligible.
+	if preferred_idx >= 0 and preferred_idx < elig.size() and bool(elig[preferred_idx].eligible):
+		return preferred_idx
+	return nearest_eligible_index(elig, companion_pos)
 
 
 ## Attack payload for one swing (always combo step 1 — no companion combos in
@@ -85,3 +105,20 @@ static func swing_crossed_damaging_frac(prev_elapsed: float, elapsed: float, swi
 		return false
 	var t := frac * swing_length
 	return prev_elapsed < t and elapsed >= t
+
+
+# ── Phase 2: survivability (spec /states/companion-combat) ──────────────
+
+## Companion max HP at a given player level (level clamped to >= 1).
+static func max_hp_for(player_level: int) -> int:
+	return COMPANION_BASE_HP + COMPANION_HP_PER_LEVEL * (maxi(player_level, 1) - 1)
+
+
+## HP after taking damage, floored at 0 (0 means "should go DOWNED").
+static func hp_after_hit(current_hp: int, damage: int) -> int:
+	return maxi(current_hp - maxi(damage, 0), 0)
+
+
+## HP restored on recovery from DOWNED — a fraction of max, at least 1.
+static func recover_hp(max_hp: int) -> int:
+	return maxi(int(round(float(max_hp) * DOWNED_RECOVER_FRAC)), 1)

--- a/scripts/3d/elements/companion_npc.gd
+++ b/scripts/3d/elements/companion_npc.gd
@@ -87,7 +87,8 @@ const TRAIL_MAX_ENTRIES: int = 150  # ~2.5s at 60fps
 
 ## Combat FSM (spec /states/companion-combat). FOLLOW is the trail-replay
 ## behavior above; the combat states move the companion under its own steering.
-enum CombatState { FOLLOW, ENGAGE, ATTACK, REGROUP }
+## DOWNED (phase 2): kneeling after HP hit 0, inert until it recovers.
+enum CombatState { FOLLOW, ENGAGE, ATTACK, REGROUP, DOWNED }
 var _combat_state: int = CombatState.FOLLOW
 var _combat_target: Node3D = null
 var _weapon_config: Dictionary = {}
@@ -100,6 +101,15 @@ var _engage_last_dist: float = INF
 var _engage_no_progress: float = 0.0
 var _combat_stuck_time: float = 0.0  # autopilot tripwire accumulator
 var _combat_hits_landed: int = 0
+
+## Phase-2 survivability (spec /states/companion-combat). The companion never
+## dies: at 0 HP it enters DOWNED, leaves the "allies" group so enemies
+## retarget, kneels for DOWNED_RECOVER_TIME, then recovers to a fraction of max.
+var _max_hp: int = CompanionCombat.COMPANION_BASE_HP
+var _hp: int = CompanionCombat.COMPANION_BASE_HP
+var _downed_timer: float = 0.0
+## Enemies read this via node.get("is_ally_targetable"); false while DOWNED.
+var is_ally_targetable: bool = true
 
 
 func _ready() -> void:
@@ -119,6 +129,15 @@ func _ready() -> void:
 	col_shape.shape = capsule
 	col_shape.position.y = 0.7
 	add_child(col_shape)
+
+	# Phase 2: a targetable ally with its own HP (spec /states/companion-combat).
+	add_to_group("allies")
+	var level := 1
+	var character: Variant = CharacterManager.get_active_character()
+	if character != null:
+		level = int(character.get("level", 1))
+	_max_hp = CompanionCombat.max_hp_for(level)
+	_hp = _max_hp
 
 
 func _build_capsule() -> void:
@@ -190,6 +209,7 @@ func _setup_companion_anims(npc_model: Node) -> void:
 		"run": [prefix + "_run_pso", prefix + "_run"],
 		"walk": [prefix + "_walk", prefix + "_run"],
 		"atk1": [prefix + "_atk1"],
+		"down": [prefix + "_slp", prefix + "_dam_d"],  # kneel/downed (phase 2)
 	}
 
 	var lib := AnimationLibrary.new()
@@ -624,6 +644,11 @@ func _enter_regroup() -> void:
 
 
 func _process_combat(delta: float) -> void:
+	# DOWNED is inert and ignores dismiss/speech — it only counts down to
+	# recovery (spec /states/companion-combat phase 2).
+	if _combat_state == CombatState.DOWNED:
+		_process_downed(delta)
+		return
 	if _dismissed:
 		_combat_state = CombatState.FOLLOW
 		_combat_target = null
@@ -639,6 +664,66 @@ func _process_combat(delta: float) -> void:
 		CombatState.REGROUP:
 			_process_regroup(delta)
 	_combat_tripwire(delta)
+
+
+# ── Phase 2: taking damage + down/recover (spec /states/companion-combat) ──
+
+## Damage entry point — the same call enemies make on the player
+## (EnemyBase._start_attack → target.take_damage()). Ignored while already
+## downed or dismissed. Reaching 0 HP knocks the companion down; it never dies.
+func take_damage(amount: int, _knockback: Vector3 = Vector3.ZERO) -> void:
+	if _combat_state == CombatState.DOWNED or _dismissed:
+		return
+	_hp = CompanionCombat.hp_after_hit(_hp, amount)
+	if _hp <= 0:
+		_enter_downed()
+
+
+## Hurtbox-routed hits (if any ever reach the companion) funnel to take_damage.
+func _on_hit_received(damage: int, knockback: Vector3, _accuracy: int = 100, _element: String = "", _element_level: int = 0) -> void:
+	take_damage(damage, knockback)
+
+
+func _enter_downed() -> void:
+	_combat_state = CombatState.DOWNED
+	_combat_target = null
+	_swing_elapsed = -1.0
+	_downed_timer = CompanionCombat.DOWNED_RECOVER_TIME
+	velocity = Vector3.ZERO
+	# Leave the ally pool so enemies retarget the player immediately.
+	is_ally_targetable = false
+	remove_from_group("allies")
+	# Kneel: a down clip if the rig has one, else just hold "wait".
+	_current_anim = ""
+	if _anim_player and _anim_player.has_animation("down"):
+		_play_companion_anim("down")
+	else:
+		_play_companion_anim("wait")
+	print("[Companion] %s downed" % companion_id)
+	if OS.has_environment("PSZ_AUTOPILOT"):
+		print("[sanity] companion-combat: downed %s" % companion_id)
+
+
+func _process_downed(delta: float) -> void:
+	# Inert: face the player, no scan, no follow-move.
+	if is_instance_valid(_player_ref):
+		global_position.y = _player_ref.global_position.y
+	_downed_timer -= delta
+	if _downed_timer <= 0.0:
+		_recover_from_downed()
+
+
+func _recover_from_downed() -> void:
+	_hp = CompanionCombat.recover_hp(_max_hp)
+	is_ally_targetable = true
+	if not is_in_group("allies"):
+		add_to_group("allies")
+	_combat_state = CombatState.FOLLOW
+	_was_moving = false  # re-seed the resume-blend into trail-follow
+	_play_companion_anim("wait")
+	print("[Companion] %s recovered (hp=%d)" % [companion_id, _hp])
+	if OS.has_environment("PSZ_AUTOPILOT"):
+		print("[sanity] companion-combat: recovered %s hp=%d" % [companion_id, _hp])
 
 
 ## Target still worth fighting: alive and inside the player's leash.

--- a/scripts/3d/enemies/enemy_base.gd
+++ b/scripts/3d/enemies/enemy_base.gd
@@ -312,11 +312,53 @@ func _setup_navigation() -> void:
 	add_child(nav_agent)
 
 
+## Pure nearest-eligible-ally chooser (spec /states/companion-combat phase 2).
+## candidates: [{pos: Vector3, targetable: bool}, …]. Returns the index of the
+## targetable candidate nearest self_pos in the XZ plane, or -1 when none is
+## eligible. Delegates the nearest-in-XZ pick to the shared helper so the loop
+## lives in one place. Kept pure/static so test_runner exercises it off-tree.
+static func select_nearest_ally(candidates: Array, self_pos: Vector3) -> int:
+	var elig: Array = []
+	for c in candidates:
+		elig.append({"pos": c.get("pos", Vector3.ZERO), "eligible": bool(c.get("targetable", false))})
+	return CompanionCombat.nearest_eligible_index(elig, self_pos)
+
+
 func _find_target() -> void:
-	# Find the player in the scene
-	var players := get_tree().get_nodes_in_group("player")
-	if players.size() > 0:
-		target = players[0]
+	# Nearest ally in the shared "allies" group (player + any standing
+	# companion). A DOWNED companion leaves the group, so it is never chosen.
+	# Fallback to the "player" group keeps single-actor scenes (and any scene
+	# that predates the allies group) working unchanged.
+	var allies := get_tree().get_nodes_in_group("allies")
+	if allies.is_empty():
+		var players := get_tree().get_nodes_in_group("player")
+		if players.size() > 0:
+			target = players[0]
+		return
+	var candidates: Array = []
+	for a in allies:
+		if not is_instance_valid(a):
+			continue
+		candidates.append({"pos": (a as Node3D).global_position, "targetable": _ally_targetable(a)})
+	var idx := select_nearest_ally(candidates, global_position)
+	if idx >= 0:
+		target = allies[idx]
+
+
+## An ally is targetable unless it advertises itself as not (a DOWNED companion
+## sets is_ally_targetable=false). Plain players have no such field → true.
+func _ally_targetable(a: Node) -> bool:
+	var flag: Variant = a.get("is_ally_targetable")
+	return flag == null or bool(flag)
+
+
+## Drop a target that stopped being a valid ally (a companion that went DOWNED
+## leaves the "allies" group and clears is_ally_targetable, but its node stays
+## valid) so the next _find_target retargets the player.
+func _drop_untargetable_target() -> void:
+	if target and (not is_instance_valid(target) or not _ally_targetable(target)):
+		target = null
+		_find_target()
 
 
 func _physics_process(delta: float) -> void:
@@ -327,6 +369,8 @@ func _physics_process(delta: float) -> void:
 	if global_position.y < -10.0:
 		_die()
 		return
+
+	_drop_untargetable_target()
 
 	# Process status effects
 	FrameProfiler.mark("enemy_status")
@@ -374,30 +418,35 @@ func _physics_process(delta: float) -> void:
 	FrameProfiler.mark("enemy_move_slide")
 	var pos_before := global_position
 	move_and_slide()
-
-	# Stuck detection: if we tried to move but barely displaced, try going around
-	if current_state == EnemyState.CHASING:
-		var attempted_speed := Vector2(velocity.x, velocity.z).length()
-		var actual_disp := Vector2(global_position.x - pos_before.x, global_position.z - pos_before.z).length()
-		if attempted_speed > 0.5 and actual_disp < delta * 0.5:
-			_stuck_time += delta
-			if _stuck_time > STUCK_THRESHOLD and target and is_instance_valid(target):
-				var to_target := (target.global_position - global_position)
-				var dir := Vector3(to_target.x, 0, to_target.z).normalized()
-				var perp := Vector3(-dir.z, 0, dir.x) * _stuck_side
-				velocity.x = perp.x * attempted_speed * 0.7
-				velocity.z = perp.z * attempted_speed * 0.7
-				if _stuck_time > STUCK_THRESHOLD * 3:
-					_stuck_side *= -1.0
-					_stuck_time = STUCK_THRESHOLD
-		else:
-			_stuck_time = 0.0
+	_apply_stuck_avoidance(delta, pos_before)
 
 	# Safety: if enemy ends up over empty space, stop horizontal movement
 	if (velocity.x * velocity.x + velocity.z * velocity.z) > 0.001:
 		if not _has_floor_at(global_position):
 			velocity.x = 0
 			velocity.z = 0
+
+
+## Chasing enemies that tried to move but barely displaced (blocked by geometry)
+## veer perpendicular to work around the obstacle, flipping side if still stuck.
+func _apply_stuck_avoidance(delta: float, pos_before: Vector3) -> void:
+	if current_state != EnemyState.CHASING:
+		return
+	var attempted_speed := Vector2(velocity.x, velocity.z).length()
+	var actual_disp := Vector2(global_position.x - pos_before.x, global_position.z - pos_before.z).length()
+	if attempted_speed > 0.5 and actual_disp < delta * 0.5:
+		_stuck_time += delta
+		if _stuck_time > STUCK_THRESHOLD and target and is_instance_valid(target):
+			var to_target := (target.global_position - global_position)
+			var dir := Vector3(to_target.x, 0, to_target.z).normalized()
+			var perp := Vector3(-dir.z, 0, dir.x) * _stuck_side
+			velocity.x = perp.x * attempted_speed * 0.7
+			velocity.z = perp.z * attempted_speed * 0.7
+			if _stuck_time > STUCK_THRESHOLD * 3:
+				_stuck_side *= -1.0
+				_stuck_time = STUCK_THRESHOLD
+	else:
+		_stuck_time = 0.0
 
 
 func _process_idle(delta: float) -> void:

--- a/scripts/autoloads/autopilot.gd
+++ b/scripts/autoloads/autopilot.gd
@@ -284,6 +284,13 @@ var _companion_combat_probe := false
 var _companion_combat_triggered := false
 var _companion_combat_id := "kai"   # companion to spawn ("1" = default)
 
+# Companion-defense probe (spec /states/companion-combat phase 2): when
+# PSZ_AUTOPILOT_COMPANION_DEFENSE=1, the first field cell spawns a companion +
+# an enemy, damages the companion to 0 HP, and requires it to go DOWNED (enemy
+# retargets the player) and then recover. Success is the same DONE ok line.
+var _companion_defense_probe := false
+var _companion_defense_triggered := false
+
 
 func _ready() -> void:
 	_enabled = OS.has_environment("PSZ_AUTOPILOT") or ("--autopilot" in OS.get_cmdline_user_args())
@@ -382,6 +389,9 @@ func _parse_probe_flags() -> void:
 		if comp_val != "" and comp_val != "1":
 			_companion_combat_id = comp_val
 		print("[sanity] autopilot COMPANION-COMBAT probe enabled (%s must land a hit on its own in first field cell)" % _companion_combat_id)
+	_companion_defense_probe = OS.has_environment("PSZ_AUTOPILOT_COMPANION_DEFENSE")
+	if _companion_defense_probe:
+		print("[sanity] autopilot COMPANION-DEFENSE probe enabled (companion must go DOWNED and recover in first field cell)")
 
 
 ## Called every frame from _process — when floor-only mode is on, mark every
@@ -2561,6 +2571,80 @@ func _companion_combat_watch(companion: Node3D, enemy: Node3D, tick: int) -> voi
 	_after(0.2, func() -> void: _companion_combat_watch(companion, enemy, tick + 1))
 
 
+## PSZ_AUTOPILOT_COMPANION_DEFENSE=1: spawn a companion + an enemy, damage the
+## companion to 0 HP, and require it to go DOWNED (enemy retargets the player)
+## then recover (spec /states/companion-combat phase 2). Runs instead of the
+## cell plan; ends with DONE ok / FAIL.
+func _companion_defense_fail(msg: String) -> void:
+	_fail_and_quit("companion-defense probe — %s" % msg)
+
+
+func _run_companion_defense_probe(attempt: int = 0) -> void:
+	var players: Array = get_tree().get_nodes_in_group("player")
+	if players.is_empty():
+		if attempt < 60:
+			_after(STEP_DELAY, func() -> void: _run_companion_defense_probe(attempt + 1))
+		else:
+			_companion_defense_fail("no player in field")
+		return
+	var p: Node3D = players[0]
+	var edata = EnemyRegistry.get_enemy("froutang")
+	if edata == null:
+		_companion_defense_fail("froutang missing from EnemyRegistry")
+		return
+	var companion := CompanionNpcProbeScript.new()
+	companion.companion_id = _companion_combat_id
+	companion.name = "ProbeCompanionDef"
+	p.get_parent().add_child(companion)
+	companion.global_position = p.global_position + p.global_transform.basis.x * 1.0
+
+	var enemy := EnemyBase.new()
+	enemy.enemy_data = edata
+	var col := CollisionShape3D.new()
+	var cap := CapsuleShape3D.new()
+	cap.radius = edata.collision_radius
+	cap.height = edata.collision_height
+	col.shape = cap
+	col.position.y = cap.height / 2
+	enemy.add_child(col)
+	enemy.collision_layer = 8
+	enemy.collision_mask = 1
+	p.get_parent().add_child(enemy)
+	enemy.global_position = companion.global_position + p.global_transform.basis.x * 1.5
+	print("[sanity] checkpoint: companion-defense probe — %s + froutang spawned" % _companion_combat_id)
+	_companion_defense_watch(companion, enemy, p, {"downed": false, "retargeted": false}, 0)
+
+
+## Poll ~5/s. Deal lethal damage to force DOWNED, confirm the enemy retargets
+## the standing player, then confirm recovery. ~40s budget (10s recover timer).
+func _companion_defense_watch(companion: Node3D, enemy: Node3D, player: Node3D, seen: Dictionary, tick: int) -> void:
+	if not is_instance_valid(companion) or not is_instance_valid(enemy):
+		_companion_defense_fail("a node was freed mid-probe")
+		return
+	var state: int = int(companion.get("_combat_state"))  # 4 == DOWNED, 0 == FOLLOW
+	if not seen["downed"]:
+		# Chip the companion down fast rather than waiting on enemy cadence.
+		if companion.has_method("take_damage"):
+			companion.take_damage(40)
+		if state == 4:
+			seen["downed"] = true
+	elif not seen["retargeted"]:
+		enemy._find_target()
+		if enemy.target == player:
+			seen["retargeted"] = true
+			print("[sanity] checkpoint: companion-defense probe — enemy retargeted player while companion downed")
+	elif state == 0 and bool(companion.get("is_ally_targetable")):
+		print("[sanity] checkpoint: companion-defense probe — companion recovered and rejoined allies")
+		print("[sanity] DONE ok")
+		_after(QUIT_GRACE, func() -> void: get_tree().quit(0))
+		return
+	if tick >= 250:
+		_companion_defense_fail("incomplete in 50s (downed=%s retargeted=%s state=%d)" % [
+			str(seen["downed"]), str(seen["retargeted"]), state])
+		return
+	_after(0.2, func() -> void: _companion_defense_watch(companion, enemy, player, seen, tick + 1))
+
+
 func _on_field_cell_loaded(field: Node) -> void:
 	_stop_field_walk()
 	# Defeat probe: in the first field cell, kill the player instead of running
@@ -2592,6 +2676,12 @@ func _on_field_cell_loaded(field: Node) -> void:
 	if _companion_combat_probe and not _companion_combat_triggered:
 		_companion_combat_triggered = true
 		_run_companion_combat_probe()
+		return
+	# Companion-defense probe (spec /states/companion-combat phase 2): down the
+	# companion, require enemy retarget to the player, then recovery.
+	if _companion_defense_probe and not _companion_defense_triggered:
+		_companion_defense_triggered = true
+		_run_companion_defense_probe()
 		return
 	var key: String = _get_current_cell_key(field)
 	var stage_id: String = ""

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -52,6 +52,7 @@ func _run_tests_combat() -> void:
 	test_weapon_attack_sfx_mapping()
 	test_weapon_anim_data_new_animation_sets()
 	test_companion_combat_decisions()
+	test_companion_defense()
 
 
 # Registries, inventory, mags, shops, techniques, telepipe + the
@@ -5950,6 +5951,61 @@ func test_companion_combat_decisions() -> void:
 		"past the damaging frame -> no second hit")
 	assert_eq(CompanionCombat.swing_crossed_damaging_frac(0.0, 0.1, 0.0, 0.4), false,
 		"zero-length swing never fires")
+	print("")
+
+
+# ── Companion combat phase 2: survivability + enemy nearest-ally targeting ──
+# Spec /states/companion-combat. HP/down/recover math on CompanionCombat and
+# the nearest-ally chooser on EnemyBase are pure statics — pinned off-tree.
+func test_companion_defense() -> void:
+	print("── Companion defense: HP / down / recover + nearest-ally (spec /states/companion-combat) ──")
+
+	# Max HP scales with player level (clamped to >= 1); level 1 = base.
+	assert_eq(CompanionCombat.max_hp_for(1), CompanionCombat.COMPANION_BASE_HP,
+		"level 1 -> base HP")
+	assert_eq(CompanionCombat.max_hp_for(5),
+		CompanionCombat.COMPANION_BASE_HP + CompanionCombat.COMPANION_HP_PER_LEVEL * 4,
+		"level 5 -> base + 4 per-level")
+	assert_eq(CompanionCombat.max_hp_for(0), CompanionCombat.COMPANION_BASE_HP,
+		"level 0 clamps to level 1")
+
+	# hp_after_hit floors at 0 and ignores negative damage.
+	assert_eq(CompanionCombat.hp_after_hit(50, 20), 30, "50 - 20 = 30")
+	assert_eq(CompanionCombat.hp_after_hit(10, 999), 0, "overkill floors at 0")
+	assert_eq(CompanionCombat.hp_after_hit(10, -5), 10, "negative damage is a no-op")
+
+	# recover_hp is a fraction of max, at least 1.
+	assert_eq(CompanionCombat.recover_hp(120),
+		int(round(120.0 * CompanionCombat.DOWNED_RECOVER_FRAC)), "recover = frac of max")
+	assert_eq(CompanionCombat.recover_hp(1), 1, "recover is at least 1")
+
+	# Nearest-eligible-ally chooser: picks the closest targetable ally.
+	var self_pos := Vector3.ZERO
+	var cands: Array = [
+		{"pos": Vector3(6, 0, 0), "targetable": true},
+		{"pos": Vector3(3, 0, 0), "targetable": true},
+	]
+	assert_eq(EnemyBase.select_nearest_ally(cands, self_pos), 1, "nearest targetable ally wins")
+
+	# A downed (non-targetable) nearer ally is skipped for the standing one.
+	cands = [
+		{"pos": Vector3(2, 0, 0), "targetable": false},  # downed companion, closer
+		{"pos": Vector3(5, 0, 0), "targetable": true},   # player, farther
+	]
+	assert_eq(EnemyBase.select_nearest_ally(cands, self_pos), 1,
+		"downed ally is skipped even when nearer")
+
+	# No targetable ally -> -1.
+	cands = [{"pos": Vector3(2, 0, 0), "targetable": false}]
+	assert_eq(EnemyBase.select_nearest_ally(cands, self_pos), -1, "no targetable ally -> -1")
+	assert_eq(EnemyBase.select_nearest_ally([], self_pos), -1, "empty candidate list -> -1")
+
+	# Selection is planar: a huge Y offset doesn't change nearest.
+	cands = [
+		{"pos": Vector3(3, 50, 0), "targetable": true},
+		{"pos": Vector3(4, 0, 0), "targetable": true},
+	]
+	assert_eq(EnemyBase.select_nearest_ally(cands, self_pos), 0, "nearest is XZ-planar")
 	print("")
 
 

--- a/spec/src/pages/states/companion-combat.astro
+++ b/spec/src/pages/states/companion-combat.astro
@@ -13,6 +13,12 @@ const chart = `stateDiagram-v2
   ATTACK --> REGROUP: target lost
   REGROUP --> FOLLOW: back within START_DISTANCE of player
 
+  FOLLOW --> DOWNED: HP reaches 0
+  ENGAGE --> DOWNED: HP reaches 0
+  ATTACK --> DOWNED: HP reaches 0
+  REGROUP --> DOWNED: HP reaches 0
+  DOWNED --> FOLLOW: recover timer elapses (partial HP)
+
   note right of FOLLOW
     FOLLOW is the trail-replay
     contract from /states/companion.
@@ -20,15 +26,20 @@ const chart = `stateDiagram-v2
     companion is speaking or
     dismissed.
   end note
+
+  note right of DOWNED
+    Phase 2. The companion never
+    dies — it kneels, then recovers.
+  end note
 `;
 ---
 
-<Concept title="Companion Combat (Phase 1 — offense)" section="States">
+<Concept title="Companion Combat" section="States">
   <div class="diagram"><Mermaid chart={chart} /></div>
 
   <p>The key words <strong>MUST</strong>, <strong>MUST NOT</strong>, <strong>REQUIRED</strong>, <strong>SHOULD</strong>, <strong>MAY</strong>, and <strong>OPTIONAL</strong> below are used as in RFC 2119.</p>
 
-  <p>Phase 1 makes the companion NPC a <em>combatant on offense only</em>, modeled on PSO's partner NPCs (which the original client implements as player objects in a party slot, sharing the player's entity-vs-entity damage pipeline). The companion acquires targets near the player, closes, and attacks through the same hit geometry and damage entry points the player uses. <strong>Out of scope for phase 1</strong> (deferred to phase 2): the companion taking damage, enemies targeting the companion, incapacitation/recovery, techniques, healing, and ranged weapons.</p>
+  <p>The companion NPC is a combatant modeled on PSO's partner NPCs (which the original client implements as player objects in a party slot, sharing the player's entity-vs-entity damage pipeline). <strong>Phase 1</strong> is offense: the companion acquires targets near the player, closes, and attacks through the same hit geometry and damage entry points the player uses. <strong>Phase 2</strong> makes the companion attackable: it joins the shared <code>allies</code> group so enemies target it, it takes damage through a Hurtbox, and instead of dying it kneels and recovers. Still out of scope (later phases): hate/threat weighting on enemy target choice, techniques, healing, and ranged weapons.</p>
 
   <h2>Combat states</h2>
 
@@ -76,16 +87,40 @@ const chart = `stateDiagram-v2
     <li>In <code>ATTACK</code> the companion is rooted and plays the non-looping <code>atk1</code> clip from the same animation pack its locomotion clips come from; the locomotion selector is suspended for the swing. Zero displacement while a <em>locomotion</em> clip plays is still a violation (#420's tripwire watches only <code>walk</code>/<code>run</code>, so a rooted <code>atk1</code> never trips it). A rig with no resolvable <code>atk1</code> <strong>MUST</strong> still resolve the swing on a fixed 0.5&nbsp;s timer — damage never depends on the clip existing.</li>
   </ul>
 
+  <h2>Phase 2 — taking damage, aggro, and recovery</h2>
+
+  <h3>The <code>allies</code> group</h3>
+  <ul>
+    <li>The player and every combat-capable companion <strong>MUST</strong> belong to a shared <code>allies</code> group. The player joins it in its scene; the companion joins on ready and leaves it only while <code>DOWNED</code>.</li>
+    <li>Enemy target selection (<code>EnemyBase._find_target</code>) <strong>MUST</strong> choose the nearest <em>eligible</em> ally — a member of <code>allies</code> that is alive/targetable — rather than the hardcoded player. With only the player present this is identical to the old behavior, so single-actor quests are unchanged. When a companion is present and nearer, the enemy engages it. <em>Threat/hate weighting (prefer the ally that last hit me) is a later phase; phase 2 is pure nearest-ally.</em></li>
+    <li>A <code>DOWNED</code> companion <strong>MUST NOT</strong> be an eligible ally target: it leaves the <code>allies</code> group while kneeling, so enemies retarget the player (or another standing ally) immediately.</li>
+  </ul>
+
+  <h3>Taking damage</h3>
+  <ul>
+    <li>The companion <strong>MUST</strong> expose a <code>take_damage(amount, knockback)</code> entry point — the same call an enemy uses on the player (<code>EnemyBase._start_attack</code> calls <code>target.take_damage()</code> directly, not through a Hurtbox). Damage reduces the companion's HP (<code>max_hp_for(player level)</code>). Enemy melee is a direct call, so no Hurtbox is added: a Hurtbox on the shared hit layer would only expose the companion to the <em>player's</em> own projectiles (friendly fire), which phase 2 does not want. A receive-side Hurtbox can arrive later alongside any enemy attack that resolves through hitboxes.</li>
+    <li>Taking a hit while <code>ATTACK</code>/<code>ENGAGE</code>/<code>REGROUP</code> does not interrupt the FSM (no stagger-lock in phase 2) — only reaching 0 HP changes state, to <code>DOWNED</code>.</li>
+  </ul>
+
+  <h3>Down and recover — the companion never dies</h3>
+  <ul>
+    <li>When HP reaches 0 the companion <strong>MUST</strong> enter <code>DOWNED</code>: drop its combat target, leave <code>allies</code>, root in place, and play a kneel/downed clip. This is authentic to the DS game and avoids escort-quest failure on companion death.</li>
+    <li>After <code>DOWNED_RECOVER_TIME</code> (10&nbsp;s) the companion <strong>MUST</strong> recover: restore HP to <code>DOWNED_RECOVER_FRAC</code> (0.5) of max, rejoin <code>allies</code>, and return to <code>FOLLOW</code> (re-seeding the resume-blend). A companion <strong>MUST NOT</strong> be permanently removed by damage.</li>
+    <li>While <code>DOWNED</code> the companion runs no combat scan and no follow-move; it is inert until it recovers.</li>
+  </ul>
+
   <h2>Autopilot oracles</h2>
   <ul>
     <li><strong>Checkpoint (positive):</strong> under <code>PSZ_AUTOPILOT</code>, the first landed hit prints <code>[sanity] companion-combat: first hit &lt;enemy&gt; dmg=&lt;n&gt;</code> — the probe line a companion-bearing combat run (Search and Rescue carries Kai) is expected to produce.</li>
     <li><strong>Tripwire (negative):</strong> under <code>PSZ_AUTOPILOT</code>, accumulating more than <code>COMBAT_STUCK_TIME</code> (60&nbsp;s) continuously in <code>ENGAGE</code>/<code>ATTACK</code> without landing a hit pushes <code>[sanity] FAIL: companion '&lt;id&gt;' stuck in combat …</code> — caught by the matrix's <code>FAIL:</code> grep. The 8&nbsp;s no-progress drop should make this unreachable; the tripwire is the backstop.</li>
+    <li><strong>Phase 2 checkpoint:</strong> under <code>PSZ_AUTOPILOT</code>, a companion that is knocked down and then recovers prints <code>[sanity] companion-combat: downed &lt;id&gt;</code> then <code>[sanity] companion-combat: recovered &lt;id&gt; hp=&lt;n&gt;</code> — the down/recover oracle a defense probe requires.</li>
   </ul>
 
   <h2>Implemented by</h2>
   <ul>
-    <li><code>scripts/3d/elements/companion_combat.gd</code> (<code>CompanionCombat</code>) — the pure decision functions: <code>select_target</code>, <code>combat_stats</code>, <code>compute_attack</code>, <code>swing_crossed_damaging_frac</code>, <code>weapon_type_for</code>.</li>
-    <li><code>scripts/3d/elements/companion_npc.gd</code> — the FSM driver (<code>_process_combat</code> and per-state helpers), attack clip loading, and the autopilot checkpoint/tripwire.</li>
+    <li><code>scripts/3d/elements/companion_combat.gd</code> (<code>CompanionCombat</code>) — the pure decision functions: <code>select_target</code>, <code>compute_attack</code>, <code>swing_crossed_damaging_frac</code>, <code>weapon_type_for</code>, plus phase-2 <code>max_hp_for</code>, <code>hp_after_hit</code>, and <code>recover_hp</code>.</li>
+    <li><code>scripts/3d/enemies/enemy_base.gd</code> (<code>EnemyBase</code>) — <code>select_nearest_ally</code> (the pure nearest-eligible-ally chooser) and the <code>_find_target</code> that scans the <code>allies</code> group through it.</li>
+    <li><code>scripts/3d/elements/companion_npc.gd</code> — the FSM driver (<code>_process_combat</code> and per-state helpers incl. <code>DOWNED</code>), <code>take_damage</code>, <code>allies</code> membership, attack clip loading, and the autopilot checkpoints/tripwire.</li>
   </ul>
-  <p>Pinned by <code>test_companion_combat_decisions</code> in <code>scripts/tools/test_runner.gd</code> (target priority, leash filtering, damage math, damaging-frame crossing — all against the pure functions, no scene needed).</p>
+  <p>Pinned by <code>test_companion_combat_decisions</code> and <code>test_companion_defense</code> in <code>scripts/tools/test_runner.gd</code> — target priority, leash filtering, damage math, damaging-frame crossing, nearest-ally selection (incl. downed-ally exclusion), and the HP/down/recover math, all against the pure functions with no scene needed.</p>
 </Concept>


### PR DESCRIPTION
## Companion combat — phase 2 (aggro, taking damage, kneel/recover)

**Stacked on #502 (phase 1).** Base is `feature/companion-combat`; retarget to `main` once #502 merges. The diff below is phase-2-only.

Phase 1 made the companion fight. Phase 2 makes it *part of the fight's target economy* — enemies can aggro it, it takes damage, and instead of dying it kneels and recovers (authentic to the DS game; avoids escort-quest failure on companion death). Mirrors the original PSOBB model where partner NPCs are party-slot player objects that enemies target like any player.

### Symmetric aggro
- New shared **`allies`** group: the player joins it in `player.tscn`; a combat-capable companion joins on ready and leaves it only while `DOWNED`.
- `EnemyBase._find_target` picks the nearest eligible ally via the pure `select_nearest_ally` chooser instead of the hardcoded player. **With only the player present this is byte-for-byte the old behavior**, so single-actor quests are unchanged. A `DOWNED` companion is skipped, and `_drop_untargetable_target` makes an enemy whose target just went down retarget the player immediately.
- *Threat/hate weighting (prefer whoever last hit me) needs attacker attribution through the hitbox layer — deferred and filed as a follow-up so this PR stays surgical on `enemy_base.gd`.*

### Taking damage
- Companion gains HP (`max_hp_for(player level)`) and `take_damage()` — the same entry enemies already call on the player. **No Hurtbox**: enemy melee is a direct call, and a Hurtbox on the shared hit layer would only expose the companion to the *player's own* projectiles (friendly fire). A receive-side Hurtbox can come later with any hitbox-resolved enemy attack.

### Never dies — kneel and recover
- At 0 HP → `DOWNED`: drop target, leave `allies`, kneel, and after `DOWNED_RECOVER_TIME` (10 s) recover to half max HP and return to `FOLLOW`. Damage can never remove a companion.

### Code-health
Two extractions keep the diff under the ratchet bounds (0 new dup/dead/complexity/coupling): `CompanionCombat.nearest_eligible_index` (shared by the companion's target pick and the enemy's ally pick) and `EnemyBase._apply_stuck_avoidance` (pulled out of `_physics_process`, which was at the line bound).

### Two-layer verification
- **Unit test** `test_companion_defense`: HP/down/recover math + nearest-ally selection incl. downed-ally exclusion and planar distance. Full suite **2231 passed / 0 failed** — phase-1 tests still green after the behavior-preserving `select_target` refactor.
- **Autopilot probe** `PSZ_AUTOPILOT_COMPANION_DEFENSE=1`: downs the companion, requires the enemy to retarget the player, then recovery → `DONE ok`. Verified end-to-end locally via a headless integration harness (companion `DOWNED` → enemy retargeted player → recovered to 60 HP and rejoined `allies`); the probe itself runs in the Mac regression matrix.

### Not run
No asset changes. Spec + Godot behavior; CI's `spec` build + `version-check` + test runner cover it; the regression matrix runs on the Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
