### PR TITLE
Fix guild counter speech bubble anchoring off in the distance

### DIFF
--- a/scripts/3d/city/city_counter_controller.gd
+++ b/scripts/3d/city/city_counter_controller.gd
@@ -3,6 +3,8 @@ extends "res://scripts/3d/city/city_area_base.gd"
 
 const BUBBLE_WIDTH := 400
 const BUBBLE_HEIGHT := 180
+## Head-height offset above the NPC origin (feet) for the speech bubble anchor.
+const BUBBLE_OFFSET := Vector3(0, 2.5, 0)
 
 const TelepipeScript := preload("res://scripts/3d/elements/telepipe.gd")
 const TeleporterDressingScript := preload("res://scripts/3d/elements/teleporter_dressing.gd")
@@ -216,7 +218,9 @@ func _check_quest_accepted() -> void:
 		return
 	if counter_npc.has_method("play_oneshot"):
 		counter_npc.play_oneshot("pso_f_emote_bow")
-	_show_npc_speech_bubble(counter_npc, Vector3(-8.31, 2.8, -10.37),
+	# Anchor the bubble to the NPC's live position + head offset. (A stale
+	# hardcoded world pos left it floating far from the repositioned counter.)
+	_show_npc_speech_bubble(counter_npc, counter_npc.global_position + BUBBLE_OFFSET,
 		"Please head to the Principal's office for your briefing.")
 
 


### PR DESCRIPTION
## Why

The guild counter's quest-accepted speech bubble ("Please head to the Principal's office for your briefing.") was rendering **far off in the distance** instead of over the counter NPC's head.

## Root cause

`_check_quest_accepted()` passed a **stale hardcoded world position** to the bubble:

```gdscript
_show_npc_speech_bubble(counter_npc, Vector3(-8.31, 2.8, -10.37), ...)
```

which gets assigned straight to `sprite.global_position`. But `QuestCounterNPC` is spawned at `(-7.86, -10.67, 111.39)` — the **z is off by ~122 units** (and y by ~13). The coords are leftover from before the counter scene was repositioned. The `_show_npc_speech_bubble` `_npc` param was already unused, so the function already had the node it should have been reading from.

## Fix

Anchor the bubble to the NPC's **live** `global_position` plus a head-height offset (`BUBBLE_OFFSET = Vector3(0, 2.5, 0)`). This mirrors the pattern `city_office_controller.gd` already uses for the Principal's bubble — derive from the actual position, add a fixed head offset, never parent to the scaled NPC (so the SubViewport→Sprite3D bubble stays undistorted). CityNPC loads its glb at native scale with the origin at the feet, so a 2.5m offset clears the head.

## Testing

- Counter scene compiles clean with autoloads live (`godot --headless --path . res://scenes/3d/city/city_counter.tscn` — no script/compile errors).
- Full boot to title clean.
- **Visual confirmation** (bubble sits over the counter NPC on quest-accept) is best verified on the Mac interactive round — it's a city-interaction flow the autopilot matrix doesn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)