### PR TITLE
Start menu: split Debug submenu out of Options + add Unlock All Missions

### DIFF
--- a/scripts/3d/field/pso_start_menu.gd
+++ b/scripts/3d/field/pso_start_menu.gd
@@ -58,7 +58,7 @@ const FONT_SIZE_LG := 17
 const FONT_SIZE_ITEM := 14
 
 # ── State ───────────────────────────────────────────────────────────────────────
-enum Mode { MAIN, ITEMS, ITEMS_MOVE, EQUIP, EQUIP_PICK, TECHS, PALETTE, PALETTE_PICK, MAGS, MAG_FEED, QUEST, SYSTEM, OPTIONS }
+enum Mode { MAIN, ITEMS, ITEMS_MOVE, EQUIP, EQUIP_PICK, TECHS, PALETTE, PALETTE_PICK, MAGS, MAG_FEED, QUEST, SYSTEM, OPTIONS, DEBUG }
 
 var _mode: Mode = Mode.MAIN
 var _menu_idx: int = 0
@@ -71,6 +71,8 @@ var _pal_slot_idx: int = 0
 var _mag_idx: int = 0
 var _mag_feed_idx: int = 0
 var _options_idx: int = 0
+var _debug_idx: int = 0
+var _debug_msg: String = ""  # One-shot result line for a Debug action (e.g. Unlock All), cleared on nav
 var _action_message: String = ""  # One-shot message after Items use, cleared on navigation
 var _move_from_idx: int = -1  # Origin row when in Mode.ITEMS_MOVE (Manual sort)
 var _move_from_id: String = ""  # Origin item id, used to relocate cursor after move
@@ -105,8 +107,8 @@ func _can_use_techs() -> bool:
 	if class_data and class_data.race == "Cast":
 		return false
 	return true
-const SYSTEM_LABELS := ["Save", "Return to Title", "Options"]
-const SYSTEM_DESCS := ["Save your progress.", "Return to the title screen.", "Adjust game settings."]
+const SYSTEM_LABELS := ["Save", "Return to Title", "Options", "Debug"]
+const SYSTEM_DESCS := ["Save your progress.", "Return to the title screen.", "Adjust game settings.", "Debug tools and cheats."]
 ## Equipment slots are built dynamically from the equipped frame instance's slots
 const TYPE_ICONS := {"weapon": "W", "armor": "A", "shield": "S", "unit": "U", "tool": "T", "tech": "M", "material": "R", "mag": "G"}
 const TYPE_COLORS := {
@@ -429,6 +431,8 @@ func open() -> void:
 	_mag_idx = 0
 	_mag_feed_idx = 0
 	_options_idx = 0
+	_debug_idx = 0
+	_debug_msg = ""
 	_action_message = ""
 	_canvas.queue_redraw()
 	print("[PsoStartMenu] Opened")
@@ -558,6 +562,17 @@ func _get_options_list() -> Array:
 		"Camera Rotation: %s" % ("Inverted" if InputConfig.invert_camera_x else "Direct"),
 		"Camera Y-Axis: %s" % (on if InputConfig.enable_camera_y else off),
 		"Auto-Sort Inventory: %s" % (on if Inventory.is_auto_sort() else off),
+	]
+
+
+## Debug submenu — developer toggles + cheats, split out of Options (#menu-debug).
+## Row 0 is the one-shot "Unlock All Missions" action; the rest mirror the
+## DebugConfig boolean flags. Kept index-aligned with _toggle_debug().
+func _get_debug_list() -> Array:
+	var on := "ON"
+	var off := "OFF"
+	return [
+		"Unlock All Missions",
 		"Floor Collision: %s" % (on if DebugConfig.show_floor_collision else off),
 		"Gate Dots: %s" % (on if DebugConfig.show_gate_dots else off),
 		"Hitboxes: %s" % (on if DebugConfig.show_hitboxes else off),
@@ -599,20 +614,31 @@ func _toggle_option(idx: int) -> void:
 			# actually saved. Manual Sort/Move already save_game (above); the
 			# option toggle was the gap.
 			SaveManager.save_game()
-		7: DebugConfig.show_floor_collision = not DebugConfig.show_floor_collision
-		8: DebugConfig.show_gate_dots = not DebugConfig.show_gate_dots
-		9: DebugConfig.show_hitboxes = not DebugConfig.show_hitboxes
-		10: DebugConfig.show_combo_timing = not DebugConfig.show_combo_timing
-		11:
+
+
+## Dispatch a Debug-submenu row. Index-aligned with _get_debug_list().
+func _toggle_debug(idx: int) -> void:
+	_debug_msg = ""
+	match idx:
+		0:
+			var n: int = GameState.unlock_all_missions()
+			SaveManager.save_game()
+			SfxManager.play("res://assets/sfx/ui/game_saved.wav")
+			_debug_msg = "Unlocked all missions (%d newly cleared)." % n
+		1: DebugConfig.show_floor_collision = not DebugConfig.show_floor_collision
+		2: DebugConfig.show_gate_dots = not DebugConfig.show_gate_dots
+		3: DebugConfig.show_hitboxes = not DebugConfig.show_hitboxes
+		4: DebugConfig.show_combo_timing = not DebugConfig.show_combo_timing
+		5:
 			DebugConfig.show_time_room = not DebugConfig.show_time_room
 			TimeManager.show_hud(DebugConfig.show_time_room)
-		12:
+		6:
 			DebugConfig.profile_frames = not DebugConfig.profile_frames
-		13:
+		7:
 			DebugConfig.show_player_position = not DebugConfig.show_player_position
-		14:
+		8:
 			DebugConfig.equip_all = not DebugConfig.equip_all
-		15:
+		9:
 			DebugConfig.reveal_map = not DebugConfig.reveal_map
 
 

--- a/scripts/3d/field/start_menu_input.gd
+++ b/scripts/3d/field/start_menu_input.gd
@@ -129,6 +129,8 @@ func handle_input(event: InputEvent) -> void:
 			handled = _input_system(event)
 		PsoStartMenu.Mode.OPTIONS:
 			handled = _input_options(event)
+		PsoStartMenu.Mode.DEBUG:
+			handled = _input_debug(event)
 
 	if handled:
 		# Skip generic SFX if menu was just closed — close() plays its own sound
@@ -349,6 +351,10 @@ func _input_system(event: InputEvent) -> bool:
 			2:
 				_c._mode = PsoStartMenu.Mode.OPTIONS
 				_c._options_idx = 0
+			3:
+				_c._mode = PsoStartMenu.Mode.DEBUG
+				_c._debug_idx = 0
+				_c._debug_msg = ""
 		return true
 	elif event.is_action_pressed("ui_cancel"):
 		_c._mode = PsoStartMenu.Mode.MAIN
@@ -385,6 +391,24 @@ func _input_options(event: InputEvent) -> bool:
 	elif event.is_action_pressed("ui_cancel"):
 		_c._mode = PsoStartMenu.Mode.SYSTEM
 		_c._sub_idx = 2
+		return true
+	return false
+
+
+func _input_debug(event: InputEvent) -> bool:
+	var items: Array = _c._get_debug_list()
+	if event.is_action_pressed("ui_up", false) and items.size() > 0:
+		_c._debug_idx = wrapi(_c._debug_idx - 1, 0, items.size())
+		return true
+	elif event.is_action_pressed("ui_down", false) and items.size() > 0:
+		_c._debug_idx = wrapi(_c._debug_idx + 1, 0, items.size())
+		return true
+	elif event.is_action_pressed("ui_accept"):
+		_c._toggle_debug(_c._debug_idx)
+		return true
+	elif event.is_action_pressed("ui_cancel"):
+		_c._mode = PsoStartMenu.Mode.SYSTEM
+		_c._sub_idx = 3
 		return true
 	return false
 

--- a/scripts/3d/field/start_menu_renderer.gd
+++ b/scripts/3d/field/start_menu_renderer.gd
@@ -93,6 +93,7 @@ func _draw_menu() -> void:
 		PsoStartMenu.Mode.QUEST: _draw_quest(c, font)
 		PsoStartMenu.Mode.SYSTEM: _draw_system(c, font)
 		PsoStartMenu.Mode.OPTIONS: _draw_options(c, font)
+		PsoStartMenu.Mode.DEBUG: _draw_debug(c, font)
 
 
 func _draw_main(c: Control, font: Font) -> void:
@@ -848,7 +849,18 @@ func _draw_options(c: Control, font: Font) -> void:
 	for o in opts:
 		items.append({"name": o, "type": "tool"})
 	_draw_bottom_list(c, font, items, _c._options_idx)
-	_draw_bottom_desc(c, font, "Toggle debug settings.\n\n[Enter] Toggle\n[Esc] Back")
+	_draw_bottom_desc(c, font, "Adjust game settings.\n\n[Enter] Select\n[Esc] Back")
+
+
+func _draw_debug(c: Control, font: Font) -> void:
+	_draw_section_label(c, font, "Debug")
+	var rows: Array = _c._get_debug_list()
+	var items: Array = []
+	for o in rows:
+		items.append({"name": o, "type": "tool"})
+	_draw_bottom_list(c, font, items, _c._debug_idx)
+	var desc: String = _c._debug_msg if _c._debug_msg != "" else "Debug tools and cheats.\n\n[Enter] Select\n[Esc] Back"
+	_draw_bottom_desc(c, font, desc)
 
 
 # ── Draw helpers ────────────────────────────────────────────────────────────────

--- a/scripts/autoloads/game_state.gd
+++ b/scripts/autoloads/game_state.gd
@@ -127,6 +127,23 @@ func is_mission_completed(mission_id: String) -> bool:
 	return mission_id in completed_missions
 
 
+## Debug cheat: mark every real quest complete so the guild counter surfaces
+## the whole roster as available (its parent_quest / required_quests gates all
+## read is_mission_completed). Skips the manifest sentinel and hello_quest,
+## which are not missions. Beta/disabled quests stay hard-locked by the guild's
+## own `disabled` flag regardless. Returns how many were newly marked complete.
+## Caller is responsible for persisting via SaveManager.save_game().
+func unlock_all_missions() -> int:
+	var newly: int = 0
+	for qid in QuestLoader.list_quests():
+		if qid == "hello_quest" or qid == "manifest":
+			continue
+		if qid not in completed_missions:
+			completed_missions.append(qid)
+			newly += 1
+	return newly
+
+
 # ── Difficulty unlock loop (#344, spec /states/difficulty-unlock) ──
 
 ## The story-finale quest whose clear unlocks the next difficulty tier.

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -158,6 +158,7 @@ func _run_tests_systems() -> void:
 	test_scaled_rewards()
 	test_difficulty_unlock()
 	test_difficulty_unlock_persistence()
+	test_debug_unlock_all_missions()
 	test_input_config()
 	test_confirm_input_precedence()
 	test_blackjack()
@@ -7493,6 +7494,51 @@ func _reward_item_resolvable(iid: String) -> bool:
 	return ConsumableRegistry.get_consumable(iid) != null \
 		or ItemRegistry.get_item(iid) != null \
 		or WeaponRegistry.get_weapon(iid) != null
+
+
+# ── Debug: Unlock All Missions (spec /states/start-menu §DEBUG) ──
+# The System → Debug "Unlock All Missions" cheat marks every real quest
+# complete so the guild counter surfaces the whole roster. Deterministic,
+# no RNG: clear completion, unlock, and assert every non-sentinel quest id
+# is now completed and the count is right; then assert idempotency.
+func test_debug_unlock_all_missions() -> void:
+	print("── Debug Unlock All Missions ──")
+
+	# Snapshot + clear so the run is independent of prior test order.
+	var saved: Array = GameState.completed_missions.duplicate()
+	GameState.completed_missions.clear()
+
+	# The set the cheat should cover: every quest id minus the sentinels.
+	var expected: Array = []
+	for qid in QuestLoader.list_quests():
+		if qid == "manifest" or qid == "hello_quest":
+			continue
+		expected.append(qid)
+	assert_gt(expected.size(), 0, "roster has real quests to unlock")
+
+	var newly: int = GameState.unlock_all_missions()
+	assert_eq(newly, expected.size(), "unlock_all_missions clears every real quest")
+
+	# Every parent/required gate reads is_mission_completed — all must pass now.
+	var all_completed := true
+	for qid in expected:
+		if not GameState.is_mission_completed(qid):
+			all_completed = false
+			assert_true(false, "quest marked complete: %s" % qid)
+	assert_true(all_completed, "all real quests report completed after unlock")
+
+	# The sentinels MUST NOT be marked complete.
+	assert_true(not GameState.is_mission_completed("manifest"), "manifest sentinel not marked complete")
+	assert_true(not GameState.is_mission_completed("hello_quest"), "hello_quest not marked complete")
+
+	# Idempotent: re-running adds nothing.
+	var again: int = GameState.unlock_all_missions()
+	assert_eq(again, 0, "second unlock is a no-op (idempotent)")
+	assert_eq(GameState.completed_missions.size(), expected.size(), "no duplicate mission entries")
+
+	# Restore the pre-test completion set.
+	GameState.completed_missions = saved
+	print("")
 
 
 # ── Completion-scaled rewards (#190) ────────────────────────────

--- a/spec/src/pages/states/start-menu.astro
+++ b/spec/src/pages/states/start-menu.astro
@@ -40,6 +40,9 @@ const chart = `stateDiagram-v2
   SYSTEM --> OPTIONS: select "Options"
   OPTIONS --> SYSTEM: Back
 
+  SYSTEM --> DEBUG: select "Debug"
+  DEBUG --> SYSTEM: Back
+
   SYSTEM --> CLOSED: "Return to Title" (save + goto title)
 `;
 ---
@@ -107,11 +110,15 @@ const chart = `stateDiagram-v2
   <h3>QUEST</h3>
   <p>Read-only view of the current quest's info / objectives. It has no sub-navigation — its only input is Back to <code>MAIN</code> (<code>_input_back</code>).</p>
 
-  <h3>SYSTEM (and OPTIONS)</h3>
-  <p>A fixed three-item list (<code>SYSTEM_LABELS</code>): <code>Save</code> (writes the save and plays the saved SFX), <code>Return to Title</code> (saves, closes the menu, and navigates to the title scene — leaving the open state entirely; the in-memory session teardown, including the city-hub position cache, is delegated to the title scene's <code>SessionManager.reset_all_state()</code> — see <a href="/states/session-model#city-hub-position">Session Model</a>), and <code>Options</code> (enters <strong>OPTIONS</strong>). Back returns to <code>MAIN</code>.</p>
+  <h3>SYSTEM (and OPTIONS, DEBUG)</h3>
+  <p>A fixed four-item list (<code>SYSTEM_LABELS</code>): <code>Save</code> (writes the save and plays the saved SFX), <code>Return to Title</code> (saves, closes the menu, and navigates to the title scene — leaving the open state entirely; the in-memory session teardown, including the city-hub position cache, is delegated to the title scene's <code>SessionManager.reset_all_state()</code> — see <a href="/states/session-model#city-hub-position">Session Model</a>), <code>Options</code> (enters <strong>OPTIONS</strong>), and <code>Debug</code> (enters <strong>DEBUG</strong>). Back returns to <code>MAIN</code>. Player-facing settings and developer tooling are separated: everyday settings live under <strong>OPTIONS</strong>, and all debug toggles and cheats live under <strong>DEBUG</strong>. Each submenu's Back <strong>MUST</strong> return to <strong>SYSTEM</strong> with the cursor restored to the row that opened it (<code>Options</code> for OPTIONS, <code>Debug</code> for DEBUG).</p>
 
   <h3>OPTIONS</h3>
-  <p>An adjustable settings list (<code>_get_options_list</code>): Music Volume and SFX Volume are stepped with Left / Right; the remaining rows are toggles or actions fired with Accept — <code>Controls: Reconfigure</code> (closes the menu, clears the input config, and pushes the input-select scene as an overlay), On-Screen Controls, camera-rotation / camera-Y options, Auto-Sort Inventory, and a block of debug toggles (floor collision, gate dots, hitboxes, combo timing, time/room, frame profiler, player position). Back returns to <strong>SYSTEM</strong> with the cursor restored to the <code>Options</code> row.</p>
+  <p>An adjustable settings list (<code>_get_options_list</code>) of player-facing settings only: Music Volume and SFX Volume are stepped with Left / Right; the remaining rows are toggles or actions fired with Accept — <code>Controls: Reconfigure</code> (closes the menu, clears the input config, and pushes the input-select scene as an overlay), On-Screen Controls, camera-rotation / camera-Y options, and Auto-Sort Inventory. OPTIONS <strong>MUST NOT</strong> contain debug toggles or cheats; those belong to <strong>DEBUG</strong>. Back returns to <strong>SYSTEM</strong> with the cursor restored to the <code>Options</code> row.</p>
+
+  <h3>DEBUG</h3>
+  <p>A developer-tools list (<code>_get_debug_list</code>) reached from <code>System → Debug</code>, dispatched by <code>_toggle_debug</code>. Row 0 is <strong>Unlock All Missions</strong>, a one-shot action (not a toggle); the remaining rows are the <code>DebugConfig</code> boolean flags (floor collision, gate dots, hitboxes, combo timing, time/room, frame profiler, player position, equip-all, reveal-map), fired ON/OFF with Accept. Up / Down navigate; Accept fires the highlighted row; Back returns to <strong>SYSTEM</strong> with the cursor on the <code>Debug</code> row.</p>
+  <p><strong>Unlock All Missions</strong> (<code>GameState.unlock_all_missions()</code>) <strong>MUST</strong> mark every real quest complete — appending each quest id from <code>QuestLoader.list_quests()</code> to <code>GameState.completed_missions</code>, skipping the <code>manifest</code> sentinel and <code>hello_quest</code> (which are not missions) — so the guild counter, whose availability gates read <code>is_mission_completed</code> for <code>parent_quest</code> / <code>required_quests</code>, surfaces the whole roster as available. It <strong>MUST</strong> be idempotent (re-running adds nothing) and <strong>MUST</strong> return the count of newly cleared missions. It affects mission availability only; it <strong>MUST NOT</strong> unlock difficulty tiers (that axis is governed by <a href="/states/difficulty-unlock">Difficulty Unlock</a>). Beta/disabled quests stay hard-locked by the guild's own <code>disabled</code> flag regardless. The menu action <strong>MUST</strong> persist the result via <code>SaveManager.save_game()</code> and report the count in the description line.</p>
 
   <h2>Techs gating</h2>
   <p>The <code>Techs</code> view <strong>MAY</strong> be absent. <code>_can_use_techs()</code> looks up the active character's class and returns <code>false</code> when its race is <code>CAST</code>; <code>_get_menu_labels()</code> (and the parallel <code>_get_menu_descs()</code>) omit the <code>Techs</code> entry in that case. Therefore, for a CAST character the main menu <strong>MUST NOT</strong> offer Techs, and for any non-CAST character it <strong>MUST</strong>. Because the label list is the cursor's wrap bound, the same gate that hides the label also keeps the cursor from ever landing on a missing row.</p>


### PR DESCRIPTION
## Why
The System menu had grown a block of nine developer toggles jammed into the player-facing Options list — floor collision, hitboxes, frame profiler, etc. mixed in with volume and camera settings. And there was no way to jump ahead to a specific quest for playtesting without grinding its parent quests to satisfy the guild's gates.

## What
- **Menu split.** System now offers `Save / Return to Title / Options / Debug`. Options keeps only real player-facing settings; the nine debug toggles move into a new **Debug** submenu. Follows the existing `System → Options` push pattern exactly (new `Mode.DEBUG`, `_get_debug_list`/`_toggle_debug`, `_input_debug`, `_draw_debug`).
- **Unlock All Missions.** New one-shot action at the top of the Debug submenu. Marks every real quest complete (skipping `manifest`/`hello_quest`), so the guild surfaces the whole roster. Idempotent; persists via save. Missions only — difficulty tiers stay governed by the difficulty-unlock loop.

## Spec / tests
- `spec/states/start-menu.astro`: adds the DEBUG state to the diagram + an RFC-2119 contract for the split and the cheat.
- `test_runner`: seeded `test_debug_unlock_all_missions` (coverage, idempotency, sentinel exclusion). Full suite: **2232 passed, 0 failed**.
- Autopilot layer intentionally skipped — debug tooling, not shipped combat/timing (agreed out-of-band).

## Verification
- Godot test runner green locally.
- Astro spec build passes.
- Runtime menu nav (System → Debug → Unlock All Missions) best confirmed on the Mac before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)