### PR TITLE
Web tools: warn when a local asset drifts from its R2 copy

### DIFF
--- a/web/src/__tests__/asset-drift.test.ts
+++ b/web/src/__tests__/asset-drift.test.ts
@@ -1,0 +1,79 @@
+// Asset drift detection (utils/assets.ts) — the s00e_sa2 counter incident
+// guard. assetUrl() reads R2 when VITE_ASSETS_BASE is set while the game and
+// city-walk-mock read the local /assets/ tree; checkAssetDrift flags when the
+// two copies differ so the web tools can warn instead of silently disagreeing.
+import { describe, it, expect } from 'vitest';
+import { repoAssetPath, checkAssetDrift } from '../utils/assets';
+
+const CDN = 'https://cdn.example';
+
+// fetch stub: maps URL → content-length (null → 404).
+function fetchWithSizes(sizes: Record<string, number | null>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const size = sizes[url];
+    if (size == null) return new Response(null, { status: 404 });
+    return new Response(null, { status: 200, headers: { 'content-length': String(size) } });
+  }) as typeof fetch;
+}
+
+describe('repoAssetPath', () => {
+  it('extracts from a CDN URL', () => {
+    expect(repoAssetPath(`${CDN}/assets/stages/city_e/s00e_sa2/lndmd/s00e_sa2_m.glb`))
+      .toBe('assets/stages/city_e/s00e_sa2/lndmd/s00e_sa2_m.glb');
+  });
+  it('extracts from a BASE_URL-prefixed local path', () => {
+    expect(repoAssetPath('/psz-godot/assets/foo/bar.glb')).toBe('assets/foo/bar.glb');
+  });
+  it('accepts a bare repo-relative path and strips query strings', () => {
+    expect(repoAssetPath('assets/foo.glb?cb=123')).toBe('assets/foo.glb');
+  });
+  it('rejects non-asset paths and lookalike prefixes', () => {
+    expect(repoAssetPath('/psz-godot/data/quests/foo.json')).toBeNull();
+    expect(repoAssetPath('/web-assets/foo.glb')).toBeNull();
+  });
+});
+
+describe('checkAssetDrift', () => {
+  const PATH = 'assets/stages/city_e/s00e_sa2/lndmd/s00e_sa2_m.glb';
+  const localUrl = `/${PATH}`;      // BASE_URL is '/' under vitest
+  const cdnUrl = `${CDN}/${PATH}`;
+
+  it('reports drift when sizes differ (the incident: 101KB local vs 810KB R2)', async () => {
+    const drift = await checkAssetDrift(cdnUrl, {
+      cdnBase: CDN, dev: true,
+      fetchFn: fetchWithSizes({ [localUrl]: 101448, [cdnUrl]: 810244 }),
+    });
+    expect(drift).toEqual({ path: PATH, localSize: 101448, cdnSize: 810244 });
+  });
+
+  it('is silent when the copies match', async () => {
+    expect(await checkAssetDrift(cdnUrl, {
+      cdnBase: CDN, dev: true,
+      fetchFn: fetchWithSizes({ [localUrl]: 810244, [cdnUrl]: 810244 }),
+    })).toBeNull();
+  });
+
+  it('is silent when either copy is missing (asset never synced)', async () => {
+    expect(await checkAssetDrift(cdnUrl, {
+      cdnBase: CDN, dev: true,
+      fetchFn: fetchWithSizes({ [cdnUrl]: 810244 }),
+    })).toBeNull();
+    expect(await checkAssetDrift(cdnUrl, {
+      cdnBase: CDN, dev: true,
+      fetchFn: fetchWithSizes({ [localUrl]: 810244 }),
+    })).toBeNull();
+  });
+
+  it('is silent outside dev or without a CDN configured', async () => {
+    const fetchFn = fetchWithSizes({ [localUrl]: 1, [cdnUrl]: 2 });
+    expect(await checkAssetDrift(cdnUrl, { cdnBase: CDN, dev: false, fetchFn })).toBeNull();
+    expect(await checkAssetDrift(cdnUrl, { cdnBase: '', dev: true, fetchFn })).toBeNull();
+  });
+
+  it('is silent for local-only (never-on-R2) prefixes and non-asset paths', async () => {
+    const fetchFn = fetchWithSizes({});
+    expect(await checkAssetDrift('assets/kenney_nature-pack/tree.glb', { cdnBase: CDN, dev: true, fetchFn })).toBeNull();
+    expect(await checkAssetDrift('blob:abc123', { cdnBase: CDN, dev: true, fetchFn })).toBeNull();
+  });
+});

--- a/web/src/city-walk-mock/CityWalkMock.tsx
+++ b/web/src/city-walk-mock/CityWalkMock.tsx
@@ -15,6 +15,7 @@ import { useSearchParams } from 'react-router-dom';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import AssetDriftWarning from '../components/AssetDriftWarning';
 
 const DEFAULT_MODEL = '/psz-godot/assets/stages/city_e/s00e_sa2/lndmd/s00e_sa2_m.glb';
 const DEFAULT_FLOOR = '/psz-godot/assets/stages/city_e/s00e_sa2/lndmd/s00e_sa2-floor.glb';
@@ -300,6 +301,9 @@ export default function CityWalkMock() {
         <div ref={mountRef} style={{ width: '100%', height: '100%' }} />
         <div style={{ position: 'absolute', top: 8, left: 8, background: 'rgba(0,0,0,0.6)', padding: '6px 10px', borderRadius: 4, fontSize: 12 }}>
           {status}
+        </div>
+        <div style={{ position: 'absolute', top: 40, left: 8 }}>
+          <AssetDriftWarning paths={[modelUrl, floorUrl]} shows="local" />
         </div>
         <div style={{ position: 'absolute', top: 8, right: 8, background: 'rgba(0,0,0,0.7)', padding: '8px 10px', borderRadius: 4, fontSize: 13, fontFamily: 'monospace' }}>
           <span style={{ color: '#8b949e' }}>pos </span>

--- a/web/src/components/AssetDriftWarning.tsx
+++ b/web/src/components/AssetDriftWarning.tsx
@@ -1,0 +1,61 @@
+// Dev-only banner that warns when a tool's asset source has drifted from the
+// other source the pipeline reads (local /assets/ tree vs the R2 CDN).
+//
+// Why: assetUrl() resolves to R2 when VITE_ASSETS_BASE is set, but the
+// city-walk-mock (and Godot itself) read the local repo tree. A stale/broken
+// local copy shadowing the canonical R2 file made a traced floor collider
+// look "desynced" with no indication why (the s00e_sa2 counter incident).
+// This banner names the drift the moment a tool loads an affected file.
+
+import { useEffect, useState } from 'react';
+import { checkAssetDrift, type AssetDrift } from '../utils/assets';
+
+function kb(n: number): string {
+  return n >= 1024 ? `${(n / 1024).toFixed(n >= 10240 ? 0 : 1)} KB` : `${n} B`;
+}
+
+interface Props {
+  /** URLs or repo-relative paths this tool loaded; non-asset entries are ignored. */
+  paths: (string | null | undefined)[];
+  /** Which copy THIS tool renders: 'local' (dev-server path) or 'cdn' (assetUrl → R2). */
+  shows: 'local' | 'cdn';
+}
+
+export default function AssetDriftWarning({ paths, shows }: Props) {
+  const [drifts, setDrifts] = useState<AssetDrift[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    const targets = paths.filter((p): p is string => !!p);
+    Promise.all(targets.map((p) => checkAssetDrift(p))).then((results) => {
+      if (!alive) return;
+      const seen = new Set<string>();
+      setDrifts(results.filter((d): d is AssetDrift => {
+        if (!d || seen.has(d.path)) return false;
+        seen.add(d.path);
+        return true;
+      }));
+    });
+    return () => { alive = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paths.join('|')]);
+
+  if (!drifts.length) return null;
+  return (
+    <div style={{
+      background: '#5c3c00', border: '1px solid #d29922', color: '#ffd88a',
+      borderRadius: 4, padding: '8px 12px', fontSize: 12, lineHeight: 1.5,
+      maxWidth: 560,
+    }}>
+      {drifts.map((d) => (
+        <div key={d.path}>
+          <b>⚠ {d.path}</b> — local copy ({kb(d.localSize)}) differs from R2 ({kb(d.cdnSize)}).{' '}
+          {shows === 'cdn'
+            ? <>This tool is showing the <b>R2</b> file; the game (and city-walk-mock) render the <b>local</b> file.</>
+            : <>This tool and the game render the <b>local</b> file; the floor-collider-builder shows the <b>R2</b> file.</>}
+          {' '}Re-export or <code>npm run sync-tree</code> until they match.
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/floor-collider-builder/FloorColliderBuilder.tsx
+++ b/web/src/floor-collider-builder/FloorColliderBuilder.tsx
@@ -22,6 +22,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 import { assetUrl } from '../utils/assets';
+import AssetDriftWarning from '../components/AssetDriftWarning';
 
 const AREA_FOLDER: Record<string, string> = {
   '00': 'city', '01': 'valley', '02': 'wetlands', '03': 'snowfield',
@@ -264,6 +265,9 @@ export default function FloorColliderBuilder() {
     || (glbParam ? outPathFromGlb(glbParam) : '')
     || (stageId ? defaultOutPath(stageId) : '')
     || '';
+  // What the auto-load effect fetches — drift-checked against the local copy,
+  // since assetUrl() reads R2 while the game (and city-walk-mock) read local.
+  const loadedUrl = glbParam || (stageId ? visualGlbUrl(stageId) : '');
 
   const mountRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
@@ -739,6 +743,9 @@ export default function FloorColliderBuilder() {
         <div ref={mountRef} style={{ width: '100%', height: '100%' }} />
         <div style={{ position: 'absolute', top: 8, left: 8, background: 'rgba(0,0,0,0.6)', padding: '6px 10px', borderRadius: 4, fontSize: 12 }}>
           {status}
+        </div>
+        <div style={{ position: 'absolute', top: 40, left: 8 }}>
+          <AssetDriftWarning paths={[loadedUrl]} shows="cdn" />
         </div>
         <div style={{ position: 'absolute', bottom: 8, left: 8, display: 'flex', gap: 6, alignItems: 'center' }}>
           {(['orbit', 'paint', 'erase', 'probe'] as Mode[]).map((m) => (

--- a/web/src/utils/assets.ts
+++ b/web/src/utils/assets.ts
@@ -37,3 +37,74 @@ export function assetUrl(path: string): string {
   }
   return `${base}${clean}`;
 }
+
+/** Always resolve against the local dev server (web/public symlinks → repo /assets/). */
+export function localAssetUrl(path: string): string {
+  const base = import.meta.env.BASE_URL || '/';
+  const clean = path.startsWith('/') ? path.slice(1) : path;
+  return `${base}${clean}`;
+}
+
+/**
+ * Extract the repo-relative `assets/...` path from any URL or path, or null if
+ * there isn't one (blob:, file-input loads, non-asset routes).
+ */
+export function repoAssetPath(urlOrPath: string): string | null {
+  const idx = urlOrPath.indexOf('assets/');
+  if (idx < 0) return null;
+  // Guard against e.g. ".../web-assets/foo": require a separator (or string
+  // start) before "assets/".
+  if (idx > 0 && !'/'.includes(urlOrPath[idx - 1])) return null;
+  return urlOrPath.slice(idx).split(/[?#]/)[0];
+}
+
+export interface AssetDrift {
+  path: string;      // repo-relative assets/... path
+  localSize: number; // bytes served by the dev server (what the game renders)
+  cdnSize: number;   // bytes on R2 (what assetUrl()-based tools show)
+}
+
+/**
+ * Detect drift between the local copy of an asset and its R2 (CDN) copy.
+ *
+ * The web tools split their reads: assetUrl() resolves to R2 when
+ * VITE_ASSETS_BASE is set, while hardcoded/local paths (and Godot itself) read
+ * the repo's /assets/ tree. When the two copies differ, a floor traced in one
+ * tool silently mismatches the model rendered in another — the s00e_sa2
+ * counter incident. This check makes that drift loud.
+ *
+ * Dev-only and advisory: resolves null when the check doesn't apply (no CDN
+ * configured, prod build, non-asset path), when either copy is missing, or
+ * when sizes match. Size comparison is deliberate — cheap (HEAD), and any
+ * real re-export changes byte count in practice.
+ */
+export async function checkAssetDrift(
+  urlOrPath: string,
+  opts?: { cdnBase?: string; dev?: boolean; fetchFn?: typeof fetch },
+): Promise<AssetDrift | null> {
+  const dev = opts?.dev ?? import.meta.env.DEV;
+  const cdn = (opts?.cdnBase ?? import.meta.env.VITE_ASSETS_BASE ?? '').replace(/\/$/, '');
+  if (!dev || !cdn) return null;
+  const path = repoAssetPath(urlOrPath);
+  if (!path || LOCAL_ONLY_PREFIXES.some((p) => path.startsWith(p))) return null;
+  const doFetch = opts?.fetchFn ?? fetch;
+  const size = async (url: string): Promise<number | null> => {
+    try {
+      const res = await doFetch(url, { method: 'HEAD' });
+      if (!res.ok) return null;
+      const len = res.headers.get('content-length');
+      return len != null ? parseInt(len, 10) : null;
+    } catch {
+      return null;
+    }
+  };
+  const [localSize, cdnSize] = await Promise.all([
+    size(localAssetUrl(path)),
+    size(`${cdn}/${path}`),
+  ]);
+  // Either copy missing/unreadable → can't judge; stay quiet rather than cry
+  // wolf on every asset that was never synced to R2.
+  if (localSize == null || cdnSize == null) return null;
+  if (localSize === cdnSize) return null;
+  return { path, localSize, cdnSize };
+}


### PR DESCRIPTION
## Why
`assetUrl()` reads the **R2 CDN** when `VITE_ASSETS_BASE` is set, while the city-walk-mock (and Godot itself) read the **local** `/assets/` tree through the `web/public` symlinks. When the two copies diverge, the tools silently disagree — a floor traced in the builder looks "desynced" in the mock and in-game with no hint why. That's exactly what burned us on the s00e_sa2 counter (#511): a broken 101 KB partial re-export shadowing the canonical 810 KB mesh.

## What
- `checkAssetDrift()` in `web/src/utils/assets.ts` — dev-only, HEADs both copies, compares Content-Length. Deliberately quiet when the check doesn't apply: prod builds, no CDN configured, local-only prefixes (kenney packs, fonts), non-asset paths, or either copy missing (never-synced assets shouldn't cry wolf).
- Shared `<AssetDriftWarning>` banner — names the file, both sizes, and **which copy each consumer renders**, with per-tool wording:
  - FloorColliderBuilder: "this tool shows **R2**; the game (and city-walk-mock) render **local**"
  - CityWalkMock: "this tool and the game render **local**; the builder shows **R2**"

## Verification
- **Live repro of the incident**: truncated the local `s00e_sa2_m.glb` to 101 KB → both tools banner with correct sizes/wording (screenshots in session); restored the file → banners clear. No false positive on matching copies.
- `tsc -b` clean; vitest: 9 new tests, **573/574 passing** — the 1 failure (`boss-room-segments` / `boss_robot`) pre-exists on a clean `main` checkout on this machine (stale local boss asset, unrelated; itself an instance of the drift class this PR warns about).
- Web-only change — no Godot autopilot needed per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)