### PR TITLE
Ponytail cleanup: dead code, dedupe, stdlib swaps (#517)

### DIFF
--- a/scripts/2d/blackjack/blackjack_game.gd
+++ b/scripts/2d/blackjack/blackjack_game.gd
@@ -12,7 +12,6 @@ enum Outcome { PLAYER_BLACKJACK, PLAYER_WIN, DEALER_WIN, PLAYER_BUST, PUSH }
 
 const SUITS := ["clubs", "diamonds", "hearts", "spades"]
 const RANKS := ["02", "03", "04", "05", "06", "07", "08", "09", "10", "J", "Q", "K", "A"]
-const DEALER_HITS_SOFT_17 := false  # Stand on soft 17 (player-friendly H17 vs S17 toggle)
 
 var state: int = State.IDLE
 var bet: int = 0
@@ -151,14 +150,11 @@ func _dealer_play() -> void:
 	while true:
 		var t := hand_total(_dealer_hand)
 		var total: int = t[0]
-		var soft: bool = t[1]
 		if total > 21:
 			break
+		# Dealer stands on 17+, including soft 17 (S17 rule, player-friendly).
 		if total >= 17:
-			if soft and total == 17 and DEALER_HITS_SOFT_17:
-				pass  # hit soft 17
-			else:
-				break
+			break
 		_deal_to(_dealer_hand, 1, false)
 	_resolve()
 

--- a/scripts/2d/character_select.gd
+++ b/scripts/2d/character_select.gd
@@ -105,6 +105,9 @@ func _ready() -> void:
 	_build_next_button()
 	_build_hint_bar()
 
+	# Shared hold-to-repeat for list nav (same helper the shops use).
+	_nav = NavRepeat.new(["ui_up", "ui_down"], _on_nav_repeat)
+
 	_refresh_selection()
 
 
@@ -520,7 +523,7 @@ func _update_preview() -> void:
 
 
 func _play_idle_animation(model: Node3D, is_female: bool) -> void:
-	var skeleton := _find_skeleton(model)
+	var skeleton := NodeUtils.first_of_type(model, "Skeleton3D") as Skeleton3D
 	if skeleton == null:
 		return
 	var anim_glb := "res://assets/player/animations/common_w.glb" if is_female else "res://assets/player/animations/common_m.glb"
@@ -530,7 +533,7 @@ func _play_idle_animation(model: Node3D, is_female: bool) -> void:
 	if packed == null:
 		return
 	var anim_scene := packed.instantiate()
-	var src_player: AnimationPlayer = _find_animation_player(anim_scene)
+	var src_player: AnimationPlayer = NodeUtils.first_of_type(anim_scene, "AnimationPlayer") as AnimationPlayer
 	if src_player == null:
 		anim_scene.queue_free()
 		return
@@ -565,16 +568,6 @@ func _play_idle_animation(model: Node3D, is_female: bool) -> void:
 	anim_scene.queue_free()
 
 
-func _find_skeleton(node: Node) -> Skeleton3D:
-	var hit := node.find_children("*", "Skeleton3D", true, false)
-	return hit[0] if not hit.is_empty() else null
-
-
-func _find_animation_player(node: Node) -> AnimationPlayer:
-	var hit := node.find_children("*", "AnimationPlayer", true, false)
-	return hit[0] if not hit.is_empty() else null
-
-
 func _remap_animation(source: Animation, skeleton_name: String) -> Animation:
 	# Original track paths look like "pc_000_000/Skeleton3D:BoneName" or
 	# "pc_000_000/Skeleton3D::blend_shapes/shape". The destination skeleton
@@ -602,14 +595,12 @@ func _filled_count() -> int:
 # --- Input handling ---
 
 func _process(delta: float) -> void:
-	# PSO-style auto-repeat scroll via the shared NavRepeat helper. Skipped
+	# PSO-style auto-repeat scroll (_nav built in _ready). Held nav is paused
 	# while a delete confirmation is up so it doesn't blow past the prompt.
-	if _nav == null:
-		_nav = NavRepeat.new(["ui_up", "ui_down"], _on_nav_repeat)
 	if _confirming_delete:
 		_nav.reset()
-		return
-	_nav.tick(delta)
+	else:
+		_nav.tick(delta)
 
 
 ## NavRepeat callback: re-emit a held nav action as a synthetic input event

--- a/scripts/2d/character_select.gd
+++ b/scripts/2d/character_select.gd
@@ -55,12 +55,8 @@ var _desc_label: Label
 var _preview_viewport: SubViewport
 var _preview_root: Node3D = null
 
-# Hold-to-scroll repeat (matches PSO start menu / NPC shop timing)
-const SCROLL_HOLD := 0.2
-const SCROLL_REPEAT := 1.0 / 30.0
-const NAV_ACTIONS := ["ui_up", "ui_down"]
-var _nav_hold: Dictionary = {}
-var _nav_next: Dictionary = {}
+# Hold-to-scroll repeat (matches PSO start menu / NPC shop timing) — shared helper.
+var _nav: NavRepeat = null
 
 
 # --- Inner Banner Control: draws the 6-vertex polygon + outline ---
@@ -91,10 +87,6 @@ class BannerPolygon extends Control:
 
 func _ready() -> void:
 	MusicManager.play_location_music("character_select")
-
-	for action in NAV_ACTIONS:
-		_nav_hold[action] = 0.0
-		_nav_next[action] = 0.0
 
 	# Drop tscn placeholders, build everything programmatically.
 	for child in get_children():
@@ -574,23 +566,13 @@ func _play_idle_animation(model: Node3D, is_female: bool) -> void:
 
 
 func _find_skeleton(node: Node) -> Skeleton3D:
-	if node is Skeleton3D:
-		return node
-	for child in node.get_children():
-		var found := _find_skeleton(child)
-		if found:
-			return found
-	return null
+	var hit := node.find_children("*", "Skeleton3D", true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _find_animation_player(node: Node) -> AnimationPlayer:
-	if node is AnimationPlayer:
-		return node
-	for child in node.get_children():
-		var found := _find_animation_player(child)
-		if found:
-			return found
-	return null
+	var hit := node.find_children("*", "AnimationPlayer", true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _remap_animation(source: Animation, skeleton_name: String) -> Animation:
@@ -620,30 +602,23 @@ func _filled_count() -> int:
 # --- Input handling ---
 
 func _process(delta: float) -> void:
-	# PSO-style auto-repeat scroll: hold ui_up/ui_down, after SCROLL_HOLD
-	# fire one synthetic press every SCROLL_REPEAT. Skipped while a delete
-	# confirmation is up so it doesn't blow past the prompt.
+	# PSO-style auto-repeat scroll via the shared NavRepeat helper. Skipped
+	# while a delete confirmation is up so it doesn't blow past the prompt.
+	if _nav == null:
+		_nav = NavRepeat.new(["ui_up", "ui_down"], _on_nav_repeat)
 	if _confirming_delete:
-		for action in NAV_ACTIONS:
-			_nav_hold[action] = 0.0
-			_nav_next[action] = 0.0
+		_nav.reset()
 		return
-	for action in NAV_ACTIONS:
-		if Input.is_action_pressed(action):
-			var held: float = float(_nav_hold[action]) + delta
-			_nav_hold[action] = held
-			if held >= SCROLL_HOLD:
-				var next_at: float = float(_nav_next[action]) - delta
-				while next_at <= 0.0:
-					var ev := InputEventAction.new()
-					ev.action = action
-					ev.pressed = true
-					_unhandled_input(ev)
-					next_at += SCROLL_REPEAT
-				_nav_next[action] = next_at
-		else:
-			_nav_hold[action] = 0.0
-			_nav_next[action] = 0.0
+	_nav.tick(delta)
+
+
+## NavRepeat callback: re-emit a held nav action as a synthetic input event
+## so this screen's own _unhandled_input handles it (hold-to-repeat nav).
+func _on_nav_repeat(action: String) -> void:
+	var ev := InputEventAction.new()
+	ev.action = action
+	ev.pressed = true
+	_unhandled_input(ev)
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/scripts/2d/equipment_screen.gd
+++ b/scripts/2d/equipment_screen.gd
@@ -173,9 +173,9 @@ func _equip_selected_item() -> void:
 		if slot_key == "frame":
 			_auto_unequip_excess_units(equipment, 0)
 		if slot_key == "weapon":
-			_notify_player_weapon_changed()
+			_notify_player("refresh_weapon")
 		if slot_key == "mag":
-			_notify_player_mag_changed()
+			_notify_player("refresh_mag")
 		_choosing_item = false
 		if not old_id.is_empty():
 			var info: Dictionary = Inventory._lookup_item(old_id)
@@ -203,9 +203,9 @@ func _equip_selected_item() -> void:
 
 	# Update 3D weapon model if weapon slot changed
 	if slot_key == "weapon":
-		_notify_player_weapon_changed()
+		_notify_player("refresh_weapon")
 	if slot_key == "mag":
-		_notify_player_mag_changed()
+		_notify_player("refresh_mag")
 
 	_choosing_item = false
 	hint_label.text = "Equipped %s!" % item.name
@@ -460,13 +460,7 @@ func _refresh_stats() -> void:
 	stats_panel.add_child(scroll)
 
 
-func _notify_player_weapon_changed() -> void:
+func _notify_player(method: String) -> void:
 	var player = get_tree().get_first_node_in_group("player")
-	if player and player.has_method("refresh_weapon"):
-		player.refresh_weapon()
-
-
-func _notify_player_mag_changed() -> void:
-	var player = get_tree().get_first_node_in_group("player")
-	if player and player.has_method("refresh_mag"):
-		player.refresh_mag()
+	if player and player.has_method(method):
+		player.call(method)

--- a/scripts/2d/field.gd
+++ b/scripts/2d/field.gd
@@ -639,7 +639,7 @@ func _return_to_city() -> void:
 		_heal_to_full()
 
 	SessionManager.return_to_city()
-	SaveManager.auto_save()
+	SaveManager.save_game()
 	SceneManager.goto_scene("res://scenes/3d/city/city_market.tscn")
 
 

--- a/scripts/2d/guild_counter.gd
+++ b/scripts/2d/guild_counter.gd
@@ -351,7 +351,7 @@ func _report_quest() -> void:
 	msg += _format_rewards(data.get("rewards_granted", {}))
 	hint_label.text = msg
 	# Auto-save after quest completion so progress isn't lost
-	SaveManager.auto_save()
+	SaveManager.save_game()
 	_selected_index = 0
 	_load_entries()
 	_refresh_display()

--- a/scripts/2d/shops/weapon_shop.gd
+++ b/scripts/2d/shops/weapon_shop.gd
@@ -38,16 +38,6 @@ const SHOP_WEAPON_TIER2 := [
 	"autogun", "sniper", "assault", "pole", "staff",
 	"spinner",
 ]
-const SHOP_WEAPON_TIER3 := [
-	"buster", "breaker", "blade", "glaive",
-	"lockgun", "blaster", "repeater", "pillar", "baton",
-	"cutter",
-]
-const SHOP_WEAPON_TIER4 := [
-	"pallasch", "claymore", "edge", "berdys",
-	"railgun", "beam", "gatling", "striker", "scepter",
-	"sawcer",
-]
 
 ## Shop armor pool — 3 tiers of each type
 const SHOP_ARMOR_IDS := [
@@ -97,8 +87,8 @@ func _generate_inventory() -> void:
 	_armors.clear()
 	_units.clear()
 
-	# Two weapons per type: tier 1 + tier 2. Tiers 3-4 stay in the catalog
-	# (drops, future stock) but the shop stocks only two of each kind.
+	# Two weapons per type: tier 1 + tier 2. Higher tiers come from drops, not
+	# the shop.
 	var weapon_ids: Array = SHOP_WEAPON_TIER1.duplicate()
 	weapon_ids.append_array(SHOP_WEAPON_TIER2)
 	for wid in weapon_ids:

--- a/scripts/3d/city/city_area_base.gd
+++ b/scripts/3d/city/city_area_base.gd
@@ -167,7 +167,7 @@ func _process(_delta: float) -> void:
 	for trigger in _interactive_triggers:
 		if is_instance_valid(trigger):
 			var label: Label3D = trigger.get_meta("_prompt_label")
-			label.visible = player.get_nearest_interactable() == trigger
+			label.visible = player.nearest_interactable == trigger
 	_update_position_overlay()
 
 

--- a/scripts/3d/city/city_market_controller.gd
+++ b/scripts/3d/city/city_market_controller.gd
@@ -4,14 +4,6 @@ extends "res://scripts/3d/city/city_area_base.gd"
 const DEFAULT_SPAWN := Vector3(0.98, 2, 62.79)
 const DEFAULT_ROT := PI
 
-## In-house replacement for the original weapon-shop cart. The market
-## GLB referenced by city_market.tscn has been pre-edited (via the
-## /market-editor download workflow) to remove the old cart geometry,
-## leaving an empty spot for this model. Transform was dialed in inside
-## the same web tool's Place mode and pasted here verbatim.
-const WEAPON_SHOP_CART_SCENE := preload("res://assets/stages/city_e/market/weapon_shop/weapon_shop_cart.glb")
-const ITEM_SHOP_CART_SCENE := preload("res://assets/stages/city_e/market/item_shop/item_cart.glb")
-
 const SPAWN_VARIANTS := {
 	"counter-exit": {
 		"position": Vector3(0.98, 2, 18.84),
@@ -27,11 +19,6 @@ const SPAWN_VARIANTS := {
 func _ready() -> void:
 	# s00e_sa1 uses baked textures from psz-asset-viewer — no runtime fixes needed
 	_add_interior_lights([Vector3(0, 5, 0), Vector3(0, 5, -15), Vector3(0, 5, 15)])
-
-	# Drop in the replacement shop carts over the empty spots the no-cart
-	# GLB left behind. Disabled while evaluating dairon2, which may have the
-	# item/weapon stalls baked into the geometry — re-enable if not.
-	#_add_shop_carts()
 
 	# Heal on city entry
 	_heal_character()
@@ -101,28 +88,3 @@ func _ready() -> void:
 
 func _get_area_name() -> String:
 	return "market"
-
-
-## Place the weapon + item shop carts at their fixed transforms.
-func _add_shop_carts() -> void:
-	_add_shop_cart(WEAPON_SHOP_CART_SCENE, Transform3D(
-		Vector3(2.0545, 0.0, -2.0467),
-		Vector3(0.0, 2.9, 0.0),
-		Vector3(2.0467, 0.0, 2.0545),
-		Vector3(-9.0751, 0.0, 20.1794)
-	))
-	_add_shop_cart(ITEM_SHOP_CART_SCENE, Transform3D(
-		Vector3(-0.0798, 0.0, -2.2987),
-		Vector3(0.0, 2.3, 0.0),
-		Vector3(2.2987, 0.0, -0.0798),
-		Vector3(-14.5643, 0.0, 27.5287)
-	))
-
-
-## Instantiate a shop-cart scene at a fixed transform and parent it here.
-## Replaces the per-shop _add_*_shop_cart pair — they differed only in the
-## scene + transform data (#294).
-func _add_shop_cart(scene: PackedScene, xform: Transform3D) -> void:
-	var cart: Node3D = scene.instantiate()
-	cart.transform = xform
-	add_child(cart)

--- a/scripts/3d/city/city_npc.gd
+++ b/scripts/3d/city/city_npc.gd
@@ -225,7 +225,7 @@ func _process(delta: float) -> void:
 	super._process(delta)
 	# Show prompt when player's nearest interactable is this NPC
 	if _player_ref and is_instance_valid(_player_ref):
-		_prompt_label.visible = _player_ref.get_nearest_interactable() == self
+		_prompt_label.visible = _player_ref.nearest_interactable == self
 	else:
 		_prompt_label.visible = false
 

--- a/scripts/3d/city/city_office_controller.gd
+++ b/scripts/3d/city/city_office_controller.gd
@@ -375,9 +375,6 @@ func _play_bubble_page() -> void:
 	# Auto-advance duration based on text length
 	_bubble_timer = maxf(3.0, text.length() / 20.0)
 
-	# Log to action log
-	_log_briefing_speech(speaker, text)
-
 
 func _advance_briefing() -> void:
 	if not _briefing_active:
@@ -399,18 +396,7 @@ func _on_briefing_complete() -> void:
 	if not aq.is_empty():
 		aq["briefing_shown"] = true
 
-	# Log "Quest accepted!" to action log
-	var field_hud := _find_field_hud()
-	if field_hud:
-		field_hud.log_entry("Quest accepted!", Color(0.4, 0.8, 1.0))
-
 	player.transition_to(player.PlayerState.IDLE)
-
-
-func _log_briefing_speech(speaker: String, text: String) -> void:
-	var field_hud := _find_field_hud()
-	if field_hud:
-		field_hud.log_speech(speaker, text)
 
 
 func _find_field_hud() -> Node:

--- a/scripts/3d/city/warp_pad.gd
+++ b/scripts/3d/city/warp_pad.gd
@@ -103,7 +103,7 @@ func _process(delta: float) -> void:
 		_prompt_label.visible = false
 		return
 
-	var is_nearest: bool = _player_ref.get_nearest_interactable() == self
+	var is_nearest: bool = _player_ref.nearest_interactable == self
 
 	if _is_central_pad():
 		_process_central_prompt(is_nearest)

--- a/scripts/3d/elements/box.gd
+++ b/scripts/3d/elements/box.gd
@@ -104,26 +104,7 @@ func destroy() -> void:
 
 
 func _setup_reticle() -> void:
-	_reticle = Sprite3D.new()
-	_reticle.name = "TargetReticle"
-	_reticle.pixel_size = 0.008
-	_reticle.billboard = BaseMaterial3D.BILLBOARD_ENABLED
-	_reticle.no_depth_test = true
-	_reticle.modulate = Color(1.0, 0.15, 0.15, 0.9)
-	_reticle.visible = false
-
-	var size := 48
-	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
-	img.fill(Color(0, 0, 0, 0))
-	var half: int = size / 2
-	for y in range(size):
-		var progress: float = float(y) / float(size - 1)
-		var half_width: int = int(float(half) * (1.0 - progress))
-		for x in range(half - half_width, half + half_width + 1):
-			if x >= 0 and x < size:
-				img.set_pixel(x, y, Color.WHITE)
-	_reticle.texture = ImageTexture.create_from_image(img)
-	_reticle.position = Vector3(0, collision_size.y + 0.5, 0)
+	_reticle = TargetReticle.build(collision_size.y + 0.5)
 	add_child(_reticle)
 
 

--- a/scripts/3d/elements/companion_npc.gd
+++ b/scripts/3d/elements/companion_npc.gd
@@ -182,7 +182,7 @@ func _setup_companion_anims(npc_model: Node) -> void:
 	var wa: Dictionary = WEAPON_ANIM.get(wtype, WEAPON_ANIM[0])
 	var loco: Dictionary = WEAPON_ANIM[0]  # shared PSO locomotion (saber retarget)
 
-	var skel: Skeleton3D = _find_typed(npc_model, "Skeleton3D") as Skeleton3D
+	var skel: Skeleton3D = NodeUtils.first_of_type(npc_model, "Skeleton3D") as Skeleton3D
 	if not skel:
 		return
 
@@ -196,10 +196,10 @@ func _setup_companion_anims(npc_model: Node) -> void:
 	var wscene: Node = _load_anim_scene(wglb)
 	if wscene == null:
 		return
-	var wsrc: AnimationPlayer = _find_typed(wscene, "AnimationPlayer") as AnimationPlayer
+	var wsrc: AnimationPlayer = NodeUtils.first_of_type(wscene, "AnimationPlayer") as AnimationPlayer
 	var lscene: Node = wscene if lglb == wglb else _load_anim_scene(lglb)
 	var lsrc: AnimationPlayer = wsrc if lglb == wglb else \
-		(_find_typed(lscene, "AnimationPlayer") as AnimationPlayer if lscene else null)
+		(NodeUtils.first_of_type(lscene, "AnimationPlayer") as AnimationPlayer if lscene else null)
 	if wsrc == null:
 		wscene.queue_free()
 		if lscene and lscene != wscene:
@@ -269,7 +269,7 @@ func _attach_companion_weapon(npc_model: Node) -> void:
 	if not ResourceLoader.exists(glb_path):
 		push_warning("[Companion] %s weapon GLB missing: %s" % [companion_id, glb_path])
 		return
-	var skel: Skeleton3D = _find_typed(npc_model, "Skeleton3D") as Skeleton3D
+	var skel: Skeleton3D = NodeUtils.first_of_type(npc_model, "Skeleton3D") as Skeleton3D
 	if not skel:
 		return
 	var bone_idx: int = skel.find_bone(WEAPON_BONE_NAME)
@@ -355,11 +355,6 @@ func _autopilot_anim_tripwire(prev_pos: Vector3, curr_pos: Vector3, delta: float
 	if _stationary_anim_time > ANIM_HOLD_TIME:
 		push_error("[sanity] FAIL: companion '%s' holds '%s' while stationary for %.2fs (planar speed %.3f m/s < %.2f)" % [companion_id, _current_anim, _stationary_anim_time, planar_speed, CompanionCombat.IDLE_EPS])
 		_stationary_anim_time = 0.0  # avoid log spam
-
-
-func _find_typed(root: Node, type_name: String) -> Node:
-	var hit := root.find_children("*", type_name, true, false)
-	return hit[0] if not hit.is_empty() else null
 
 
 func _build_name_label() -> void:

--- a/scripts/3d/elements/companion_npc.gd
+++ b/scripts/3d/elements/companion_npc.gd
@@ -13,19 +13,6 @@ const START_DISTANCE: float = 3.0  # Must exceed START to begin moving (hysteres
 const CATCHUP_DISTANCE: float = 5.0
 const TELEPORT_DISTANCE: float = 20.0
 
-## Companion models — maps companion_id to { glb, texture } paths
-const COMPANION_MODELS: Dictionary = {
-	"kai": {"glb": "res://assets/npcs/kai/pc_a01_000.glb", "texture": "res://assets/npcs/kai/pc_a01_000.png"},
-	"sarisa": {"glb": "res://assets/npcs/sarisa/pc_a00_000.glb", "texture": "res://assets/npcs/sarisa/pc_a00_000.png"},
-	"dorn": {"glb": "res://assets/npcs/dorn/dorn.glb", "texture": "res://assets/npcs/dorn/dorn.png"},
-	"dr_carlo": {"glb": "res://assets/npcs/dr_carlo/dr_carlo.glb", "texture": "res://assets/npcs/dr_carlo/dr_carlo.png"},
-	"elio": {"glb": "res://assets/npcs/elio/elio.glb", "texture": "res://assets/npcs/elio/elio.png"},
-	"fern": {"glb": "res://assets/npcs/fern/fern.glb", "texture": "res://assets/npcs/fern/fern.png"},
-	"vash": {"glb": "res://assets/npcs/vash/vash.glb", "texture": "res://assets/npcs/vash/vash.png"},
-	"ren": {"glb": "res://assets/npcs/ren/ren.glb", "texture": "res://assets/npcs/ren/ren.png"},
-	"mira": {"glb": "res://assets/npcs/mira/mira.glb", "texture": "res://assets/npcs/mira/mira.png"},
-}
-
 ## Fallback colors for NPCs without GLB models
 const COMPANION_COLORS: Dictionary = {
 	"kai": Color(1.0, 0.9, 0.1),
@@ -36,16 +23,6 @@ const COMPANION_COLORS: Dictionary = {
 	"sarisa": Color(1.0, 0.5, 0.7),
 }
 const DEFAULT_COLOR := Color(1.0, 1.0, 1.0)
-
-## Gender detection for animation prefix (female classes)
-const FEMALE_CLASSES := ["humarl", "ramarl", "fomarl", "hunewearl", "fonewearl", "hucaseal", "racaseal"]
-
-## Companion class IDs for animation selection
-const COMPANION_CLASSES: Dictionary = {
-	"kai": "humar", "sarisa": "hunewearl", "dorn": "hucast",
-	"dr_carlo": "fomar", "elio": "racaseal", "fern": "humarl",
-	"vash": "ramar", "ren": "humar", "mira": "fomarl",
-}
 
 ## Weapon-type → animation pack + name prefix, keyed by WeaponData.WeaponType,
 ## the same packs the player uses (player.gd WEAPON_ANIM_DATA). The companion's
@@ -155,7 +132,7 @@ func _ready() -> void:
 
 func _build_capsule() -> void:
 	# Try to load a real model first
-	var entry: Variant = COMPANION_MODELS.get(companion_id, null)
+	var entry: Variant = NpcAssets.MODELS.get(companion_id, null)
 	if entry != null:
 		var glb_path: String = entry["glb"]
 		var tex_path: String = entry["texture"]
@@ -199,8 +176,8 @@ func _setup_companion_anims(npc_model: Node) -> void:
 	##     (the saber pack's pmsa/pwsa _walk / _run_pso) — never the weapon pack's
 	##     psz "dash" (_run). Gunblade/sword/dagger packs have no _run_pso, so
 	##     using them for locomotion is what made Kai dash instead of PSO-run.
-	var class_id: String = COMPANION_CLASSES.get(companion_id, "humar")
-	_is_female = class_id in FEMALE_CLASSES
+	var class_id: String = NpcAssets.CLASSES.get(companion_id, "humar")
+	_is_female = class_id in NpcAssets.FEMALE_CLASSES
 	var wtype: int = CompanionCombat.weapon_type_for(companion_id)
 	var wa: Dictionary = WEAPON_ANIM.get(wtype, WEAPON_ANIM[0])
 	var loco: Dictionary = WEAPON_ANIM[0]  # shared PSO locomotion (saber retarget)
@@ -381,13 +358,8 @@ func _autopilot_anim_tripwire(prev_pos: Vector3, curr_pos: Vector3, delta: float
 
 
 func _find_typed(root: Node, type_name: String) -> Node:
-	if root.get_class() == type_name:
-		return root
-	for child in root.get_children():
-		var found := _find_typed(child, type_name)
-		if found:
-			return found
-	return null
+	var hit := root.find_children("*", type_name, true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _build_name_label() -> void:
@@ -882,14 +854,14 @@ func _execute_companion_hit() -> void:
 		_note_companion_hit(enemy, int(atk.damage))
 
 
-## Companion attack/accuracy: its class (COMPANION_CLASSES) at the player's
+## Companion attack/accuracy: its class (NpcAssets.CLASSES) at the player's
 ## current level — no weapon/mag/material/buff terms in phase 1.
 func _companion_stats() -> Dictionary:
 	var level := 1
 	var character: Variant = CharacterManager.get_active_character()
 	if character != null:
 		level = int(character.get("level", 1))
-	var class_id: String = COMPANION_CLASSES.get(companion_id, "humar")
+	var class_id: String = NpcAssets.CLASSES.get(companion_id, "humar")
 	var class_data: Variant = ClassRegistry.get_class_data(class_id)
 	if class_data == null:
 		return {"attack": 10, "accuracy": 100}
@@ -952,22 +924,3 @@ func show_speech(text: String, _speaker: String = "", duration: float = 4.0) -> 
 	_speech_timer = duration
 	_name_label.visible = false
 	speech_started.emit()
-	# Log to action log
-	var speaker_name: String = _speaker if not _speaker.is_empty() else companion_id.capitalize()
-	_log_to_hud(speaker_name, text)
-
-
-func _log_to_hud(speaker: String, text: String) -> void:
-	var hud := _find_field_hud()
-	if hud and hud.has_method("log_speech"):
-		hud.log_speech(speaker, text)
-
-
-func _find_field_hud() -> Node:
-	var node := get_parent()
-	while node:
-		for child in node.get_children():
-			if child is CanvasLayer and child.name == "FieldHud":
-				return child
-		node = node.get_parent()
-	return null

--- a/scripts/3d/elements/drop_base.gd
+++ b/scripts/3d/elements/drop_base.gd
@@ -14,7 +14,6 @@ class_name DropBase
 const SPIN_SPEED: float = 2.0
 
 var _prompt_label: Label3D
-var _player_nearby: bool = false
 
 
 func _init() -> void:
@@ -83,14 +82,12 @@ func _on_body_entered(body: Node3D) -> void:
 		if auto_collect:
 			_collect(body)
 			return
-		_player_nearby = true
 		if element_state == "available" and _prompt_label:
 			_prompt_label.visible = true
 
 
 func _on_body_exited(body: Node3D) -> void:
 	if body.is_in_group("player") or body.name == "Player":
-		_player_nearby = false
 		if _prompt_label:
 			_prompt_label.visible = false
 

--- a/scripts/3d/elements/enemy_spawn.gd
+++ b/scripts/3d/elements/enemy_spawn.gd
@@ -107,7 +107,7 @@ func _load_enemy_model() -> void:
 	add_child(model)
 
 	# Find and play idle animation
-	_anim_player = _find_anim_player(model)
+	_anim_player = NodeUtils.first_of_type(model, "AnimationPlayer") as AnimationPlayer
 
 	# Rare variants without embedded animations — load from base model
 	if ANIM_SOURCE.has(_model_id):
@@ -135,13 +135,13 @@ func _load_anims_from_source(source_id: String) -> void:
 	if not src_packed:
 		return
 	var src_scene := src_packed.instantiate()
-	var src_anim: AnimationPlayer = _find_anim_player(src_scene)
+	var src_anim: AnimationPlayer = NodeUtils.first_of_type(src_scene, "AnimationPlayer") as AnimationPlayer
 	if not src_anim:
 		src_scene.queue_free()
 		return
 
 	# Find skeleton in our model for track remapping
-	var skel: Skeleton3D = _find_typed(model, "Skeleton3D") as Skeleton3D
+	var skel: Skeleton3D = NodeUtils.first_of_type(model, "Skeleton3D") as Skeleton3D
 	if not skel:
 		src_scene.queue_free()
 		return
@@ -154,7 +154,7 @@ func _load_anims_from_source(source_id: String) -> void:
 		model.add_child(_anim_player)
 
 	# Copy animations, remapping skeleton paths to our model
-	var src_skel: Skeleton3D = _find_typed(src_scene, "Skeleton3D") as Skeleton3D
+	var src_skel: Skeleton3D = NodeUtils.first_of_type(src_scene, "Skeleton3D") as Skeleton3D
 	var src_skel_parent_name: String = src_skel.get_parent().name if src_skel else ""
 	var dst_skel_parent_name: String = skel.get_parent().name
 
@@ -293,16 +293,6 @@ func _die() -> void:
 	set_state("dead")
 	defeated.emit()
 	print("[EnemySpawn] %s defeated!" % enemy_id)
-
-
-func _find_anim_player(node: Node) -> AnimationPlayer:
-	var hit := node.find_children("*", "AnimationPlayer", true, false)
-	return hit[0] if not hit.is_empty() else null
-
-
-func _find_typed(root: Node, type_name: String) -> Node:
-	var hit := root.find_children("*", type_name, true, false)
-	return hit[0] if not hit.is_empty() else null
 
 
 func _find_animation(short_name: String) -> String:

--- a/scripts/3d/elements/enemy_spawn.gd
+++ b/scripts/3d/elements/enemy_spawn.gd
@@ -296,23 +296,13 @@ func _die() -> void:
 
 
 func _find_anim_player(node: Node) -> AnimationPlayer:
-	if node is AnimationPlayer:
-		return node
-	for child in node.get_children():
-		var found := _find_anim_player(child)
-		if found:
-			return found
-	return null
+	var hit := node.find_children("*", "AnimationPlayer", true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _find_typed(root: Node, type_name: String) -> Node:
-	if root.get_class() == type_name:
-		return root
-	for child in root.get_children():
-		var found := _find_typed(child, type_name)
-		if found:
-			return found
-	return null
+	var hit := root.find_children("*", type_name, true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _find_animation(short_name: String) -> String:
@@ -342,26 +332,7 @@ func _find_animation(short_name: String) -> String:
 
 
 func _setup_reticle() -> void:
-	_reticle = Sprite3D.new()
-	_reticle.name = "TargetReticle"
-	_reticle.pixel_size = 0.008
-	_reticle.billboard = BaseMaterial3D.BILLBOARD_ENABLED
-	_reticle.no_depth_test = true
-	_reticle.modulate = Color(1.0, 0.15, 0.15, 0.9)
-	_reticle.visible = false
-
-	var size := 48
-	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
-	img.fill(Color(0, 0, 0, 0))
-	var half: int = size / 2
-	for y in range(size):
-		var progress: float = float(y) / float(size - 1)
-		var half_width: int = int(float(half) * (1.0 - progress))
-		for x in range(half - half_width, half + half_width + 1):
-			if x >= 0 and x < size:
-				img.set_pixel(x, y, Color.WHITE)
-	_reticle.texture = ImageTexture.create_from_image(img)
-	_reticle.position = Vector3(0, collision_size.y + 0.5, 0)
+	_reticle = TargetReticle.build(collision_size.y + 0.5)
 	add_child(_reticle)
 
 

--- a/scripts/3d/elements/fence.gd
+++ b/scripts/3d/elements/fence.gd
@@ -82,19 +82,6 @@ func _apply_state() -> void:
 				collision_body.collision_layer = 0
 
 
-## Activate the fence (block passage)
-func activate() -> void:
-	set_state("active")
-
-
 ## Disable the fence (allow passage, hide lasers)
 func disable() -> void:
 	set_state("disabled")
-
-
-## Toggle fence state
-func toggle() -> void:
-	if element_state == "active":
-		disable()
-	else:
-		activate()

--- a/scripts/3d/elements/field_npc.gd
+++ b/scripts/3d/elements/field_npc.gd
@@ -138,7 +138,7 @@ func _apply_state() -> void:
 func _load_and_play_animation(anim_field: String) -> void:
 	if not model:
 		return
-	var skel: Skeleton3D = _find_typed(model, "Skeleton3D") as Skeleton3D
+	var skel: Skeleton3D = NodeUtils.first_of_type(model, "Skeleton3D") as Skeleton3D
 	if not skel:
 		return
 
@@ -161,7 +161,7 @@ func _load_and_play_animation(anim_field: String) -> void:
 	if not anim_packed:
 		return
 	var anim_scene := anim_packed.instantiate()
-	var source_player: AnimationPlayer = _find_typed(anim_scene, "AnimationPlayer") as AnimationPlayer
+	var source_player: AnimationPlayer = NodeUtils.first_of_type(anim_scene, "AnimationPlayer") as AnimationPlayer
 	if not source_player or not source_player.has_animation(anim_name):
 		push_warning("[FieldNpc] Animation '%s' not found in %s" % [anim_name, anim_glb])
 		anim_scene.queue_free()
@@ -185,8 +185,3 @@ func _load_and_play_animation(anim_field: String) -> void:
 	player.play(anim_name)
 	anim_scene.queue_free()
 	print("[FieldNpc] Playing '%s' on %s" % [anim_name, npc_id])
-
-
-func _find_typed(root: Node, type_name: String) -> Node:
-	var hit := root.find_children("*", type_name, true, false)
-	return hit[0] if not hit.is_empty() else null

--- a/scripts/3d/elements/field_npc.gd
+++ b/scripts/3d/elements/field_npc.gd
@@ -11,28 +11,6 @@ signal dialog_finished
 @export var dialog: Array = []  # Array of {speaker: String, text: String}
 @export var npc_animation: String = ""  # e.g. "~dam_d_lp" — tilde prefix resolved to gender
 
-## NPC class IDs for animation prefix selection
-const NPC_CLASSES: Dictionary = {
-	"kai": "humar", "sarisa": "hunewearl", "dorn": "hucast",
-	"dr_carlo": "fomar", "elio": "racaseal", "fern": "humarl",
-	"vash": "ramar", "ren": "humar", "mira": "fomarl",
-}
-const FEMALE_CLASSES := ["humarl", "ramarl", "fomarl", "hunewearl", "fonewearl", "hucaseal", "racaseal"]
-
-## Known NPC models — maps npc_id to { glb, texture } paths
-const NPC_MODELS: Dictionary = {
-	"kai": {"glb": "res://assets/npcs/kai/pc_a01_000.glb", "texture": "res://assets/npcs/kai/pc_a01_000.png"},
-	"sarisa": {"glb": "res://assets/npcs/sarisa/pc_a00_000.glb", "texture": "res://assets/npcs/sarisa/pc_a00_000.png"},
-	"dorn": {"glb": "res://assets/npcs/dorn/dorn.glb", "texture": "res://assets/npcs/dorn/dorn.png"},
-	"dr_carlo": {"glb": "res://assets/npcs/dr_carlo/dr_carlo.glb", "texture": "res://assets/npcs/dr_carlo/dr_carlo.png"},
-	"elio": {"glb": "res://assets/npcs/elio/elio.glb", "texture": "res://assets/npcs/elio/elio.png"},
-	"fern": {"glb": "res://assets/npcs/fern/fern.glb", "texture": "res://assets/npcs/fern/fern.png"},
-	"vash": {"glb": "res://assets/npcs/vash/vash.glb", "texture": "res://assets/npcs/vash/vash.png"},
-	"ren": {"glb": "res://assets/npcs/ren/ren.glb", "texture": "res://assets/npcs/ren/ren.png"},
-	"mira": {"glb": "res://assets/npcs/mira/mira.glb", "texture": "res://assets/npcs/mira/mira.png"},
-}
-
-
 func _init() -> void:
 	interactable = true
 	auto_collect = false
@@ -63,7 +41,7 @@ const CAPSULE_COLORS: Dictionary = {
 
 
 func _load_npc_model() -> void:
-	var entry: Variant = NPC_MODELS.get(npc_id, null)
+	var entry: Variant = NpcAssets.MODELS.get(npc_id, null)
 	if entry == null:
 		_spawn_capsule_placeholder()
 		return
@@ -167,14 +145,14 @@ func _load_and_play_animation(anim_field: String) -> void:
 	# Resolve animation name: "~dam_d_lp" → "pwsa_dam_d_lp" (female) or "pmsa_dam_d_lp" (male)
 	var anim_name := anim_field
 	if anim_name.begins_with("~"):
-		var class_id: String = NPC_CLASSES.get(npc_id, "humar")
-		var is_female: bool = class_id in FEMALE_CLASSES
+		var class_id: String = NpcAssets.CLASSES.get(npc_id, "humar")
+		var is_female: bool = class_id in NpcAssets.FEMALE_CLASSES
 		var prefix: String = "pwsa_" if is_female else "pmsa_"
 		anim_name = prefix + anim_name.substr(1)
 
 	# Pick animation source GLB based on gender
-	var class_id: String = NPC_CLASSES.get(npc_id, "humar")
-	var is_female: bool = class_id in FEMALE_CLASSES
+	var class_id: String = NpcAssets.CLASSES.get(npc_id, "humar")
+	var is_female: bool = class_id in NpcAssets.FEMALE_CLASSES
 	var anim_glb: String = "res://assets/player/animations/saver_w.glb" if is_female else "res://assets/player/animations/saber_m.glb"
 	if not ResourceLoader.exists(anim_glb):
 		return
@@ -210,10 +188,5 @@ func _load_and_play_animation(anim_field: String) -> void:
 
 
 func _find_typed(root: Node, type_name: String) -> Node:
-	if root.get_class() == type_name:
-		return root
-	for child in root.get_children():
-		var found := _find_typed(child, type_name)
-		if found:
-			return found
-	return null
+	var hit := root.find_children("*", type_name, true, false)
+	return hit[0] if not hit.is_empty() else null

--- a/scripts/3d/elements/gate.gd
+++ b/scripts/3d/elements/gate.gd
@@ -81,10 +81,3 @@ func open() -> void:
 func lock() -> void:
 	set_state("locked")
 
-
-## Toggle gate state
-func toggle() -> void:
-	if element_state == "locked":
-		open()
-	else:
-		lock()

--- a/scripts/3d/elements/interact_switch.gd
+++ b/scripts/3d/elements/interact_switch.gd
@@ -4,7 +4,6 @@ class_name InteractSwitch
 ## States: off, on
 
 signal activated
-signal deactivated
 
 # MIRROR_SHADER is inherited from GameElement (same mirror_repeat shader).
 
@@ -78,7 +77,6 @@ func turn_off() -> void:
 	if element_state == "off":
 		return
 	set_state("off")
-	deactivated.emit()
 	print("[InteractSwitch] Deactivated")
 
 

--- a/scripts/3d/elements/key_pickup.gd
+++ b/scripts/3d/elements/key_pickup.gd
@@ -10,7 +10,6 @@ class_name KeyPickup
 const SPIN_SPEED: float = 2.0
 
 var _prompt_label: Label3D
-var _player_nearby: bool = false
 var _collected: bool = false
 
 
@@ -60,14 +59,12 @@ func _apply_state() -> void:
 
 func _on_body_entered(body: Node3D) -> void:
 	if body.is_in_group("player") or body.name == "Player":
-		_player_nearby = true
 		if element_state == "available":
 			_prompt_label.visible = true
 
 
 func _on_body_exited(body: Node3D) -> void:
 	if body.is_in_group("player") or body.name == "Player":
-		_player_nearby = false
 		_prompt_label.visible = false
 
 

--- a/scripts/3d/elements/npc_assets.gd
+++ b/scripts/3d/elements/npc_assets.gd
@@ -1,0 +1,29 @@
+extends RefCounted
+class_name NpcAssets
+## Shared NPC asset tables — model GLB/texture paths, animation class IDs, and
+## the female-class list. Companion NPCs (companion_npc.gd) and field NPCs
+## (field_npc.gd) index the same character set, so these three tables were
+## byte-identical in both (#517). Per-file capsule/fallback colors stay local.
+
+## npc_id → { glb, texture } model paths.
+const MODELS: Dictionary = {
+	"kai": {"glb": "res://assets/npcs/kai/pc_a01_000.glb", "texture": "res://assets/npcs/kai/pc_a01_000.png"},
+	"sarisa": {"glb": "res://assets/npcs/sarisa/pc_a00_000.glb", "texture": "res://assets/npcs/sarisa/pc_a00_000.png"},
+	"dorn": {"glb": "res://assets/npcs/dorn/dorn.glb", "texture": "res://assets/npcs/dorn/dorn.png"},
+	"dr_carlo": {"glb": "res://assets/npcs/dr_carlo/dr_carlo.glb", "texture": "res://assets/npcs/dr_carlo/dr_carlo.png"},
+	"elio": {"glb": "res://assets/npcs/elio/elio.glb", "texture": "res://assets/npcs/elio/elio.png"},
+	"fern": {"glb": "res://assets/npcs/fern/fern.glb", "texture": "res://assets/npcs/fern/fern.png"},
+	"vash": {"glb": "res://assets/npcs/vash/vash.glb", "texture": "res://assets/npcs/vash/vash.png"},
+	"ren": {"glb": "res://assets/npcs/ren/ren.glb", "texture": "res://assets/npcs/ren/ren.png"},
+	"mira": {"glb": "res://assets/npcs/mira/mira.glb", "texture": "res://assets/npcs/mira/mira.png"},
+}
+
+## npc_id → class ID, used to pick the animation prefix (and gender via FEMALE_CLASSES).
+const CLASSES: Dictionary = {
+	"kai": "humar", "sarisa": "hunewearl", "dorn": "hucast",
+	"dr_carlo": "fomar", "elio": "racaseal", "fern": "humarl",
+	"vash": "ramar", "ren": "humar", "mira": "fomarl",
+}
+
+## Classes that use the female animation prefix.
+const FEMALE_CLASSES := ["humarl", "ramarl", "fomarl", "hunewearl", "fonewearl", "hucaseal", "racaseal"]

--- a/scripts/3d/elements/npc_assets.gd.uid
+++ b/scripts/3d/elements/npc_assets.gd.uid
@@ -1,0 +1,1 @@
+uid://yyjtxkyvrh56

--- a/scripts/3d/elements/step_switch.gd
+++ b/scripts/3d/elements/step_switch.gd
@@ -4,7 +4,6 @@ class_name StepSwitch
 ## States: off, on
 
 signal activated
-signal deactivated
 
 
 func _init() -> void:
@@ -47,11 +46,3 @@ func turn_on() -> void:
 	activated.emit()
 	print("[StepSwitch] Activated")
 
-
-## Turn switch off
-func turn_off() -> void:
-	if element_state == "off":
-		return
-	set_state("off")
-	deactivated.emit()
-	print("[StepSwitch] Deactivated")

--- a/scripts/3d/elements/story_prop.gd
+++ b/scripts/3d/elements/story_prop.gd
@@ -9,8 +9,6 @@ class_name StoryProp
 ## needs to walk through (e.g. Apothecary's Supply plants).
 @export var no_collision: bool = false
 
-var element_state: String = "default"
-
 
 func _ready() -> void:
 	if prop_path.is_empty():
@@ -99,7 +97,3 @@ func _get_combined_aabb(node: Node) -> AABB:
 			else:
 				result = result.merge(child_aabb)
 	return result
-
-
-func set_state(new_state: String) -> void:
-	element_state = new_state

--- a/scripts/3d/elements/target_reticle.gd
+++ b/scripts/3d/elements/target_reticle.gd
@@ -1,0 +1,32 @@
+extends RefCounted
+class_name TargetReticle
+## Shared builder for the red downward-triangle reticle shown above a target
+## when the player is locked onto it. The Sprite3D + triangle texture were
+## duplicated verbatim in enemy_base / enemy_spawn / box (#517); only the
+## vertical offset differed, so callers pass that in.
+
+## Build the reticle sprite. `y_offset` is the local height above the target's
+## origin (typically collision height + 0.5). Caller add_child()s the result.
+static func build(y_offset: float) -> Sprite3D:
+	var reticle := Sprite3D.new()
+	reticle.name = "TargetReticle"
+	reticle.pixel_size = 0.008
+	reticle.billboard = BaseMaterial3D.BILLBOARD_ENABLED
+	reticle.no_depth_test = true
+	reticle.modulate = Color(1.0, 0.15, 0.15, 0.9)
+	reticle.visible = false
+
+	# Filled downward-pointing triangle: top row full width, narrowing to a point.
+	var size := 48
+	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0, 0, 0, 0))
+	var half: int = size / 2
+	for y in range(size):
+		var progress: float = float(y) / float(size - 1)
+		var half_width: int = int(float(half) * (1.0 - progress))
+		for x in range(half - half_width, half + half_width + 1):
+			if x >= 0 and x < size:
+				img.set_pixel(x, y, Color.WHITE)
+	reticle.texture = ImageTexture.create_from_image(img)
+	reticle.position = Vector3(0, y_offset, 0)
+	return reticle

--- a/scripts/3d/elements/target_reticle.gd.uid
+++ b/scripts/3d/elements/target_reticle.gd.uid
@@ -1,0 +1,1 @@
+uid://cq51e3mr5b1vm

--- a/scripts/3d/elements/warp_base.gd
+++ b/scripts/3d/elements/warp_base.gd
@@ -51,12 +51,3 @@ func _on_collected(_player: Node3D) -> void:
 	# Trigger map transition via game controller
 	get_tree().call_group("map_controller", "on_trigger_activated", target_map, spawn_index)
 
-
-## Activate the warp gate
-func activate() -> void:
-	set_state("active")
-
-
-## Deactivate the warp gate
-func deactivate() -> void:
-	set_state("inactive")

--- a/scripts/3d/elements/waypoint.gd
+++ b/scripts/3d/elements/waypoint.gd
@@ -66,16 +66,3 @@ func _apply_unique_materials(node: Node, offset_x: float) -> void:
 		_apply_unique_materials(child, offset_x)
 
 
-## Mark as new area
-func mark_new() -> void:
-	set_state("new")
-
-
-## Mark as unvisited
-func mark_unvisited() -> void:
-	set_state("unvisited")
-
-
-## Mark as visited
-func mark_visited() -> void:
-	set_state("visited")

--- a/scripts/3d/enemies/enemy_base.gd
+++ b/scripts/3d/enemies/enemy_base.gd
@@ -261,23 +261,13 @@ func _cache_model_materials() -> void:
 
 
 func _find_animation_player(node: Node) -> AnimationPlayer:
-	if node is AnimationPlayer:
-		return node
-	for child in node.get_children():
-		var found := _find_animation_player(child)
-		if found:
-			return found
-	return null
+	var hit := node.find_children("*", "AnimationPlayer", true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _find_skeleton(node: Node) -> Skeleton3D:
-	if node is Skeleton3D:
-		return node
-	for child in node.get_children():
-		var found := _find_skeleton(child)
-		if found:
-			return found
-	return null
+	var hit := node.find_children("*", "Skeleton3D", true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _setup_hurtbox() -> void:
@@ -886,33 +876,10 @@ func _spawn_damage_number(text: String, color: Color = Color.WHITE) -> void:
 
 
 func _setup_reticle() -> void:
-	_reticle = Sprite3D.new()
-	_reticle.name = "TargetReticle"
-	_reticle.pixel_size = 0.008
-	_reticle.billboard = BaseMaterial3D.BILLBOARD_ENABLED
-	_reticle.no_depth_test = true
-	_reticle.modulate = Color(1.0, 0.15, 0.15, 0.9)
-	_reticle.visible = false
-
-	# Draw a filled downward-pointing triangle
-	var size := 48
-	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
-	img.fill(Color(0, 0, 0, 0))
-	var half: int = size / 2
-	for y in range(size):
-		# Triangle: top row is full width, narrows to a point at bottom
-		var progress: float = float(y) / float(size - 1)
-		var half_width: int = int(float(half) * (1.0 - progress))
-		for x in range(half - half_width, half + half_width + 1):
-			if x >= 0 and x < size:
-				img.set_pixel(x, y, Color.WHITE)
-	var tex := ImageTexture.create_from_image(img)
-	_reticle.texture = tex
-
 	var height := 1.5
 	if enemy_data:
 		height = enemy_data.collision_height
-	_reticle.position = Vector3(0, height + 0.5, 0)
+	_reticle = TargetReticle.build(height + 0.5)
 	add_child(_reticle)
 
 
@@ -973,11 +940,6 @@ func _process_status_effects(delta: float) -> void:
 	if _status_effects.is_empty():
 		return
 
-	# TODO(#291 combat window): hp_before is currently unused — remove it (and
-	# this annotation) when the combat pass revisits status-effect damage. Kept
-	# now to avoid churning enemy_base.gd outside the combat-last window.
-	@warning_ignore("unused_variable")
-	var hp_before := current_hp
 	var expired: Array = []
 
 	for fx in _status_effects:

--- a/scripts/3d/enemies/enemy_base.gd
+++ b/scripts/3d/enemies/enemy_base.gd
@@ -185,7 +185,7 @@ func _setup_model() -> void:
 				MeshUtils.apply_texture(model, texture)
 
 	# Find AnimationPlayer in the model hierarchy
-	animation_player = _find_animation_player(model)
+	animation_player = NodeUtils.first_of_type(model, "AnimationPlayer") as AnimationPlayer
 
 	# If no animations in the model, load from animation_model_id source
 	if animation_player:
@@ -201,15 +201,15 @@ func _setup_model() -> void:
 			var anim_scene: PackedScene = load(anim_glb_path)
 			if anim_scene:
 				var anim_model := anim_scene.instantiate()
-				var source_player := _find_animation_player(anim_model)
+				var source_player := NodeUtils.first_of_type(anim_model, "AnimationPlayer") as AnimationPlayer
 				if source_player:
 					# Find the skeleton parents on both models so we can remap
 					# track paths from source mesh root → destination mesh root.
 					# Guard get_parent() in case the Skeleton3D ends up at the
 					# scene root with no parent (shouldn't happen for these GLBs
 					# but is cheap to handle).
-					var dst_skel := _find_skeleton(model)
-					var src_skel := _find_skeleton(anim_model)
+					var dst_skel := NodeUtils.first_of_type(model, "Skeleton3D") as Skeleton3D
+					var src_skel := NodeUtils.first_of_type(anim_model, "Skeleton3D") as Skeleton3D
 					var src_root_name: String = ""
 					var dst_root_name: String = ""
 					if src_skel and src_skel.get_parent():
@@ -258,16 +258,6 @@ func _cache_model_materials() -> void:
 				var mat := mi.get_active_material(i)
 				if mat is StandardMaterial3D:
 					_cached_materials.append(mat)
-
-
-func _find_animation_player(node: Node) -> AnimationPlayer:
-	var hit := node.find_children("*", "AnimationPlayer", true, false)
-	return hit[0] if not hit.is_empty() else null
-
-
-func _find_skeleton(node: Node) -> Skeleton3D:
-	var hit := node.find_children("*", "Skeleton3D", true, false)
-	return hit[0] if not hit.is_empty() else null
 
 
 func _setup_hurtbox() -> void:

--- a/scripts/3d/field/cell_object_spawner.gd
+++ b/scripts/3d/field/cell_object_spawner.gd
@@ -576,7 +576,6 @@ func _save_cell_state() -> void:
 			var prop_entry := {
 				"type": "story_prop",
 				"px": prop.position.x, "py": prop.position.y, "pz": prop.position.z,
-				"state": prop.element_state,
 				"prop_path": prop.prop_path,
 				"prop_scale": prop.prop_scale,
 			}
@@ -858,12 +857,8 @@ func _spawn_enemy_drops(pos: Vector3, enemy_id: String) -> void:
 	if exp_amount > 0:
 		var result := CharacterManager.add_experience(exp_amount)
 		print("[EnemyDrop] +%d EXP for %s" % [exp_amount, enemy_name])
-		if _c._field_hud:
-			_c._field_hud.log_entry("+%d EXP" % exp_amount, Color(0.4, 0.9, 1.0))
 		if result.leveled_up:
 			print("[EnemyDrop] LEVEL UP! Now level %d" % result.new_level)
-			if _c._field_hud:
-				_c._field_hud.log_entry("LEVEL UP! Lv. %d" % result.new_level, Color(1.0, 0.9, 0.3))
 			# The HP/PP/Lv panel is the persistent HudStats autoload (#444) —
 			# it already refreshed via CharacterManager.level_up above; this is
 			# the same belt-and-suspenders nudge the per-scene panel used to get.

--- a/scripts/3d/field/field_hud.gd
+++ b/scripts/3d/field/field_hud.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
-## Field HUD — per-scene HUD elements: quest log docked left (toggleable, only
-## when quest active), action palette, quick weapon menu, FPS counter, and it
-## hosts the room minimap (always visible).
+## Field HUD — per-scene HUD elements: action palette, quick weapon menu,
+## target-info plate, FPS counter, and it hosts the room minimap (always
+## visible).
 ##
 ## The HP/PP/Lv stats panel is NOT here: it lives on the persistent HudStats
 ## autoload (#444; spec /states/field-lifecycle) so it survives area
@@ -10,7 +10,6 @@ extends CanvasLayer
 const MARGIN := 12.0
 
 var _target_info: Control
-var _quest_log: Control
 var _action_palette: Control
 var _quick_weapon: Control
 var _debug_info: Control
@@ -21,7 +20,6 @@ var _session_start_msec: int = 0
 var _debug_last_quest: String = ""
 var _debug_last_section: String = ""
 var _debug_last_cell: String = ""
-var _log_visible: bool = false
 var _hidden_for_overlay: bool = false
 
 
@@ -64,9 +62,6 @@ func _ready() -> void:
 		add_child(_debug_info)
 		set_process(true)
 		_session_start_msec = Time.get_ticks_msec()
-
-	# Quest log disabled for now
-	_log_visible = false
 
 
 func _connect_player_charge_signals() -> void:
@@ -152,19 +147,6 @@ func _update_target_info_panel() -> void:
 	_target_info.update_info(info)
 
 
-func _unhandled_input(event: InputEvent) -> void:
-	if event.is_action_pressed("quest_log"):
-		_toggle_log()
-		get_viewport().set_input_as_handled()
-
-
-func _toggle_log() -> void:
-	if not _quest_log:
-		return
-	_log_visible = not _log_visible
-	_quest_log.visible = _log_visible
-
-
 func _is_in_city() -> bool:
 	return SessionManager.get_location() == "city"
 
@@ -191,38 +173,10 @@ func restore_after_menu() -> void:
 				child.visible = (child as DialogBox).is_active()
 			else:
 				child.visible = true
-	# Log respects its own toggle state
-	if _quest_log:
-		_quest_log.visible = _log_visible
 	# Grid minimap respects its toggle state (stored as meta by field controller)
 	for child in get_children():
 		if child.has_meta("toggled_off") and child.get_meta("toggled_off"):
 			child.visible = false
-
-
-## Log companion speech to the action log.
-func log_speech(speaker: String, text: String) -> void:
-	if not _quest_log:
-		return
-	_quest_log.add_speech_entry(speaker, text)
-	_auto_show_log()
-
-
-## Log an arbitrary entry to the action log.
-func log_entry(text: String, color: Color = Color(0.85, 0.85, 0.85)) -> void:
-	if not _quest_log:
-		return
-	_quest_log.add_entry(text, color)
-	_auto_show_log()
-
-
-## Auto-show log when a new entry arrives during a quest.
-func _auto_show_log() -> void:
-	if not _quest_log:
-		return
-	if not _log_visible:
-		_log_visible = true
-		_quest_log.visible = true
 
 
 ## Set the debug info text shown at top-center (quest ID, section, cell).
@@ -309,173 +263,6 @@ class _DebugInfoPanel extends Control:
 		if not cell_pos.is_empty():
 			parts.append("Cell %s" % cell_pos)
 		_label.text = " | ".join(parts)
-
-
-# ── Action Log (bottom-left, fixed box with scroll) ─────────────────────────
-
-class _QuestLogPanel extends Control:
-	const PANEL_W := 180.0
-	const PANEL_H := 120.0
-	const PAD := 4.0
-	const FONT_SIZE := 9
-
-	# PSZ palette — semi-transparent for single-screen
-	const BG_COLOR := Color(0.66, 0.80, 0.91, 0.5)   # Pale icy blue, translucent
-	const BORDER_COLOR := Color(0.48, 0.63, 0.75, 0.4)
-	const HEADER_BG := Color(0.16, 0.16, 0.22, 0.7)   # Dark navy header
-	const HEADER_TEXT := Color(1.0, 1.0, 1.0, 0.9)
-	const CONTENT_BG := Color(1.0, 1.0, 1.0, 0.6)     # White content area, translucent
-	const TEXT_COLOR := Color(0.1, 0.1, 0.17)          # Dark text
-	const ITEM_COLOR := Color(0.53, 0.33, 0.13)        # Brown/orange items
-	const MESETA_COLOR := Color(0.53, 0.4, 0.0)        # Dark gold
-	const QUEST_COLOR := Color(0.17, 0.33, 0.6)        # Dark blue
-	const SPEECH_COLOR := Color(0.2, 0.2, 0.3)         # Dark gray
-	const COMPLETE_COLOR := Color(0.13, 0.53, 0.13)    # Dark green
-
-	var _scroll: ScrollContainer
-	var _vbox: VBoxContainer
-	var _prev_meseta: int = 0
-	var _panel_bg: PanelContainer
-
-	func _ready() -> void:
-		mouse_filter = MOUSE_FILTER_IGNORE
-
-		# Bottom-left corner
-		set_anchors_preset(Control.PRESET_BOTTOM_LEFT)
-		offset_left = MARGIN
-		offset_bottom = -MARGIN
-		offset_top = -MARGIN - PANEL_H
-		offset_right = MARGIN + PANEL_W
-		size = Vector2(PANEL_W, PANEL_H)
-
-		# Background panel — PSZ blue
-		_panel_bg = PanelContainer.new()
-		_panel_bg.mouse_filter = MOUSE_FILTER_IGNORE
-		_panel_bg.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		var style := StyleBoxFlat.new()
-		style.bg_color = BG_COLOR
-		style.border_color = BORDER_COLOR
-		style.set_border_width_all(2)
-		style.set_corner_radius_all(6)
-		style.set_content_margin_all(PAD)
-		_panel_bg.add_theme_stylebox_override("panel", style)
-		add_child(_panel_bg)
-
-		# Outer VBox: header label + scroll content
-		var outer_vbox := VBoxContainer.new()
-		outer_vbox.mouse_filter = MOUSE_FILTER_IGNORE
-		outer_vbox.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		outer_vbox.add_theme_constant_override("separation", 2)
-		_panel_bg.add_child(outer_vbox)
-
-		# "Log" header label
-		var header := Label.new()
-		header.text = "Log"
-		header.add_theme_font_size_override("font_size", 10)
-		header.add_theme_color_override("font_color", HEADER_TEXT)
-		header.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-		header.mouse_filter = MOUSE_FILTER_IGNORE
-		var header_panel := PanelContainer.new()
-		header_panel.mouse_filter = MOUSE_FILTER_IGNORE
-		var header_style := StyleBoxFlat.new()
-		header_style.bg_color = HEADER_BG
-		header_style.set_corner_radius_all(4)
-		header_style.content_margin_left = 8.0
-		header_style.content_margin_right = 8.0
-		header_style.content_margin_top = 2.0
-		header_style.content_margin_bottom = 2.0
-		header_panel.add_theme_stylebox_override("panel", header_style)
-		header_panel.add_child(header)
-		outer_vbox.add_child(header_panel)
-
-		# White content area
-		var content_panel := PanelContainer.new()
-		content_panel.mouse_filter = MOUSE_FILTER_IGNORE
-		content_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		var content_style := StyleBoxFlat.new()
-		content_style.bg_color = CONTENT_BG
-		content_style.set_corner_radius_all(3)
-		content_style.set_content_margin_all(4.0)
-		content_panel.add_theme_stylebox_override("panel", content_style)
-		outer_vbox.add_child(content_panel)
-
-		# ScrollContainer — auto-scrolls to bottom
-		_scroll = ScrollContainer.new()
-		_scroll.mouse_filter = MOUSE_FILTER_IGNORE
-		_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-		_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_SHOW_NEVER
-		_scroll.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		content_panel.add_child(_scroll)
-
-		# VBoxContainer holds the label entries
-		_vbox = VBoxContainer.new()
-		_vbox.mouse_filter = MOUSE_FILTER_IGNORE
-		_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		_vbox.add_theme_constant_override("separation", 2)
-		_scroll.add_child(_vbox)
-
-		SessionManager.quest_item_collected.connect(_on_item_collected)
-		SessionManager.quest_completed.connect(_on_quest_completed)
-		GameState.meseta_changed.connect(_on_meseta_changed)
-		_prev_meseta = GameState.meseta
-
-		# Restore entries from previous rooms
-		for entry in SessionManager._action_log:
-			_add_label(str(entry.get("text", "")), entry.get("color", TEXT_COLOR))
-		_scroll_to_bottom.call_deferred()
-
-		# Log quest acceptance once per quest (not every room transition)
-		var objectives: Array = SessionManager.get_quest_objectives()
-		if not objectives.is_empty() and not SessionManager._quest_accepted_shown:
-			SessionManager._quest_accepted_shown = true
-			get_tree().create_timer(0.5).timeout.connect(func() -> void:
-				_add_entry("Quest accepted", QUEST_COLOR)
-			)
-
-	func _on_item_collected(item_id: String, new_count: int, target: int) -> void:
-		var label := item_id
-		for obj in SessionManager.get_quest_objectives():
-			if str(obj.get("item_id", "")) == item_id:
-				label = str(obj.get("label", item_id))
-				break
-		_add_entry("Picked up %s (%d/%d)" % [label, mini(new_count, target), target], ITEM_COLOR)
-
-	func _on_quest_completed() -> void:
-		_add_entry("Quest complete!", COMPLETE_COLOR)
-
-	func _on_meseta_changed(new_amount: int) -> void:
-		var diff: int = new_amount - _prev_meseta
-		_prev_meseta = new_amount
-		if diff > 0:
-			_add_entry("Picked up %d meseta" % diff, MESETA_COLOR)
-
-	## Public: log companion speech to the action log.
-	func add_speech_entry(speaker: String, text: String) -> void:
-		_add_entry("%s: %s" % [speaker, text], SPEECH_COLOR)
-
-	## Public: log an arbitrary action.
-	func add_entry(text: String, color: Color = TEXT_COLOR) -> void:
-		_add_entry(text, color)
-
-	func _add_entry(text: String, color: Color) -> void:
-		# Persist to SessionManager so entries survive room transitions
-		SessionManager._action_log.append({"text": text, "color": color})
-		_add_label(text, color)
-		_scroll_to_bottom.call_deferred()
-
-	func _add_label(text: String, color: Color) -> void:
-		var lbl := Label.new()
-		lbl.text = text
-		lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		lbl.add_theme_font_size_override("font_size", FONT_SIZE)
-		lbl.add_theme_color_override("font_color", color)
-		lbl.mouse_filter = MOUSE_FILTER_IGNORE
-		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		_vbox.add_child(lbl)
-
-	func _scroll_to_bottom() -> void:
-		await get_tree().process_frame
-		_scroll.scroll_vertical = int(_scroll.get_v_scroll_bar().max_value)
 
 
 # ── Action Palette (bottom-right) ────────────────────────────────────────────

--- a/scripts/3d/field/grid_generator.gd
+++ b/scripts/3d/field/grid_generator.gd
@@ -12,14 +12,6 @@ const DIR_OFFSET := {
 }
 
 
-## Rotate a direction clockwise by the given degrees (0, 90, 180, 270).
-## CW from above: 90 → N→E, E→S, S→W, W→N.
-## Thin alias over StageRotation.rotate_dir — kept so callers/tests that use
-## the grid-generator name don't have to change (#215-C8).
-static func rotate_direction(dir: String, rotation: int) -> String:
-	return StageRotation.rotate_dir(dir, rotation)
-
-
 ## Get gate directions in grid-space for a cell, applying its rotation.
 func _get_rotated_gates(cell: Dictionary) -> Array[String]:
 	var stage_id: String = str(cell.get("stage_id", ""))
@@ -29,7 +21,7 @@ func _get_rotated_gates(cell: Dictionary) -> Array[String]:
 		return original
 	var rotated: Array[String] = []
 	for g in original:
-		rotated.append(rotate_direction(g, rotation))
+		rotated.append(StageRotation.rotate_dir(g, rotation))
 	return rotated
 
 ## Area configuration: maps area_id → prefix, folder, display name.
@@ -760,7 +752,7 @@ func _place_dead_end(grid: Dictionary, pos_key: String, entry_dir: String,
 			continue
 		# Try each rotation to see if the single gate maps to entry_dir
 		for rot in [0, 90, 180, 270]:
-			if rotate_direction(gates[0], rot) == entry_dir:
+			if StageRotation.rotate_dir(gates[0], rot) == entry_dir:
 				grid[pos_key] = {
 					"stage_id": stage_id, "rotation": rot,
 					"entry_direction": entry_dir, "is_start": false,

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -1159,9 +1159,9 @@ func _spawn_field_elements() -> void:
 				(mat as StandardMaterial3D).cull_mode = BaseMaterial3D.CULL_DISABLED
 		)
 		if is_spawn_edge:
-			waypoint.mark_unvisited()
+			waypoint.set_state("unvisited")
 		else:
-			waypoint.mark_new()
+			waypoint.set_state("new")
 
 		# Debug spheres (gate=yellow, spawn=green, trigger=red)
 		_add_debug_sphere(aw_gate_pos, Color(1, 1, 0), "GateMark_%s" % portal_dir)
@@ -1299,13 +1299,13 @@ func _spawn_field_elements() -> void:
 		var target_cell_pos: String = str(connections[dir])
 		var wp_state: String
 		if dir == _spawn_edge:
-			gate_waypoint.mark_unvisited()
+			gate_waypoint.set_state("unvisited")
 			wp_state = "came_from"
 		elif _visited_cells.has(target_cell_pos):
-			gate_waypoint.mark_visited()
+			gate_waypoint.set_state("visited")
 			wp_state = "visited_prior"
 		else:
-			gate_waypoint.mark_new()
+			gate_waypoint.set_state("new")
 			wp_state = "unvisited"
 		_fdbg("[Waypoint] dir=%s → target_cell=%s  state=%s" % [dir, target_cell_pos, wp_state])
 
@@ -1878,48 +1878,42 @@ func _toggle_debug_panel() -> void:
 		_debug_panel.visible = not _debug_panel.visible
 
 
+# Shared tail of every debug toggle: set visibility on the (possibly freed)
+# mesh group, then refresh the debug label.
+func _apply_group_visibility(meshes: Array, vis: bool) -> void:
+	for m in meshes:
+		if is_instance_valid(m):
+			m.visible = vis
+	_update_debug_label()
+
+
 func _toggle_triggers() -> void:
 	_show_triggers = not _show_triggers
-	for m in _debug_trigger_meshes:
-		if is_instance_valid(m):
-			m.visible = _show_triggers
-	_update_debug_label()
+	_apply_group_visibility(_debug_trigger_meshes, _show_triggers)
 
 
 func _toggle_gate_markers() -> void:
 	_show_gate_markers = not _show_gate_markers
 	DebugConfig.show_gate_dots = _show_gate_markers
-	for m in _debug_gate_meshes:
-		if is_instance_valid(m):
-			m.visible = _show_gate_markers
-	_update_debug_label()
+	_apply_group_visibility(_debug_gate_meshes, _show_gate_markers)
 
 
 func _toggle_floor_collision() -> void:
 	_show_floor_collision = not _show_floor_collision
 	DebugConfig.show_floor_collision = _show_floor_collision
-	for m in _debug_collision_meshes:
-		if is_instance_valid(m):
-			m.visible = _show_floor_collision
-	_update_debug_label()
+	_apply_group_visibility(_debug_collision_meshes, _show_floor_collision)
 
 
 func _toggle_spawn_points() -> void:
 	_show_spawn_points = not _show_spawn_points
-	for m in _debug_spawn_meshes:
-		if is_instance_valid(m):
-			m.visible = _show_spawn_points
-	_update_debug_label()
+	_apply_group_visibility(_debug_spawn_meshes, _show_spawn_points)
 
 
 func _toggle_all_collision() -> void:
 	_show_all_collision = not _show_all_collision
 	if _show_all_collision and _debug_all_collision_meshes.is_empty():
 		_build_all_collision_debug()
-	for m in _debug_all_collision_meshes:
-		if is_instance_valid(m):
-			m.visible = _show_all_collision
-	_update_debug_label()
+	_apply_group_visibility(_debug_all_collision_meshes, _show_all_collision)
 
 
 func _sync_debug_config() -> void:

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -1594,6 +1594,46 @@ func _lock_gates_for_enemies() -> void:
 				_area_map_panel.set_gate_state(str(_current_cell.get("pos", "")), aw_dir, "locked")
 
 
+## Open every gate locked for this room's clear condition, updating the
+## minimap/area panel. Extracted from _check_room_clear.
+func _unlock_room_gates() -> void:
+	if _room_gates_locked.size() > 0:
+		SfxManager.play("res://assets/sfx/ui/door_unlocked.wav")
+	for gate in _room_gates_locked:
+		if is_instance_valid(gate):
+			gate.open()
+			var dir := _gate_direction(gate)
+			# Enable the gate's trigger
+			var trigger := _find_child_by_name(self, "GateTrigger_%s" % dir) as Area3D
+			if trigger:
+				trigger.monitoring = true
+			if _room_minimap and not dir.is_empty():
+				_room_minimap.set_gate_locked(dir, false)
+			if _area_map_panel and not dir.is_empty():
+				_area_map_panel.set_gate_state(str(_current_cell.get("pos", "")), dir, "open")
+	_room_gates_locked.clear()
+
+
+## Unlock every area-warp edge locked for this room (same pattern as gates).
+func _unlock_area_warps() -> void:
+	for node in _warp_edge_locked:
+		if is_instance_valid(node):
+			if node is AreaWarp:
+				node.element_state = "open"
+				node._apply_state()
+				var aw_dir: String = node.name.trim_prefix("AreaWarp_") if node.name.begins_with("AreaWarp_") else ""
+				if _room_minimap and not aw_dir.is_empty():
+					_room_minimap.set_gate_locked(aw_dir, false)
+				if _area_map_panel and not aw_dir.is_empty():
+					_area_map_panel.set_gate_state(str(_current_cell.get("pos", "")), aw_dir, "open")
+				_fdbg("[CellObjects] AreaWarp unlocked (room cleared) [dir=%s]" % aw_dir)
+			elif node is StaticBody3D:
+				node.queue_free()
+			elif node is Area3D:
+				node.monitoring = true
+	_warp_edge_locked.clear()
+
+
 ## Called when an enemy is defeated — check if all cleared.
 func _check_room_clear() -> void:
 	var alive_count: int = 0
@@ -1620,39 +1660,8 @@ func _check_room_clear() -> void:
 		return
 
 	_fdbg("[CellObjects] Room cleared! Opening %d locked gates" % _room_gates_locked.size())
-	if _room_gates_locked.size() > 0:
-		SfxManager.play("res://assets/sfx/ui/door_unlocked.wav")
-	for gate in _room_gates_locked:
-		if is_instance_valid(gate):
-			gate.open()
-			var dir := _gate_direction(gate)
-			# Enable the gate's trigger
-			var trigger := _find_child_by_name(self, "GateTrigger_%s" % dir) as Area3D
-			if trigger:
-				trigger.monitoring = true
-			if _room_minimap and not dir.is_empty():
-				_room_minimap.set_gate_locked(dir, false)
-			if _area_map_panel and not dir.is_empty():
-				_area_map_panel.set_gate_state(str(_current_cell.get("pos", "")), dir, "open")
-	_room_gates_locked.clear()
-
-	# Unlock area warps (same pattern as gates above)
-	for node in _warp_edge_locked:
-		if is_instance_valid(node):
-			if node is AreaWarp:
-				node.element_state = "open"
-				node._apply_state()
-				var aw_dir: String = node.name.trim_prefix("AreaWarp_") if node.name.begins_with("AreaWarp_") else ""
-				if _room_minimap and not aw_dir.is_empty():
-					_room_minimap.set_gate_locked(aw_dir, false)
-				if _area_map_panel and not aw_dir.is_empty():
-					_area_map_panel.set_gate_state(str(_current_cell.get("pos", "")), aw_dir, "open")
-				_fdbg("[CellObjects] AreaWarp unlocked (room cleared) [dir=%s]" % aw_dir)
-			elif node is StaticBody3D:
-				node.queue_free()
-			elif node is Area3D:
-				node.monitoring = true
-	_warp_edge_locked.clear()
+	_unlock_room_gates()
+	_unlock_area_warps()
 
 	# Drop key on room clear if configured. If the quest just completed,
 	# spawn a telepipe at the same drop position instead — the player has

--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -330,13 +330,13 @@ func _ready() -> void:
 func _setup_animations() -> void:
 	# Find the skeleton in the model
 	var model_node := $PlayerModel/Model
-	skeleton = _find_node_of_type(model_node, "Skeleton3D") as Skeleton3D
+	skeleton = NodeUtils.first_of_type(model_node, "Skeleton3D") as Skeleton3D
 
 	# Find the AnimationPlayer in the Animations node (scene-baked saber anims)
 	var anims_node := $PlayerModel/Animations
 	var source_anim_player: AnimationPlayer
 	if anims_node:
-		source_anim_player = _find_node_of_type(anims_node, "AnimationPlayer") as AnimationPlayer
+		source_anim_player = NodeUtils.first_of_type(anims_node, "AnimationPlayer") as AnimationPlayer
 
 	if not source_anim_player or not skeleton:
 		push_warning("Could not set up animations - skeleton: %s, anim_player: %s" % [skeleton != null, source_anim_player != null])
@@ -400,7 +400,7 @@ func _load_weapon_animations() -> void:
 		return
 
 	var anim_scene := packed.instantiate()
-	var source_player: AnimationPlayer = _find_node_of_type(anim_scene, "AnimationPlayer") as AnimationPlayer
+	var source_player: AnimationPlayer = NodeUtils.first_of_type(anim_scene, "AnimationPlayer") as AnimationPlayer
 	if not source_player:
 		push_warning("[Player] No AnimationPlayer found in animation GLB: %s" % anim_glb)
 		anim_scene.queue_free()
@@ -435,7 +435,7 @@ func _load_weapon_animations() -> void:
 	# Also load shared PSO locomotion from the scene-baked Animations node
 	var scene_anims_node := $PlayerModel/Animations
 	if scene_anims_node:
-		var scene_player: AnimationPlayer = _find_node_of_type(scene_anims_node, "AnimationPlayer") as AnimationPlayer
+		var scene_player: AnimationPlayer = NodeUtils.first_of_type(scene_anims_node, "AnimationPlayer") as AnimationPlayer
 		if scene_player:
 			for anim_name in ["pmsa_walk", "pmsa_run_pso"]:
 				if scene_player.has_animation(anim_name) and not lib.has_animation(anim_name):
@@ -758,11 +758,6 @@ func _resolve_footstep_clip() -> String:
 		race = "racast"
 	# Fall back to human if the specific race isn't labeled for this terrain yet.
 	return clips.get(race, clips.get("human", ""))
-
-
-func _find_node_of_type(root: Node, type_name: String) -> Node:
-	var hit := root.find_children("*", type_name, true, false)
-	return hit[0] if not hit.is_empty() else null
 
 
 func _load_character_model() -> void:

--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -761,15 +761,8 @@ func _resolve_footstep_clip() -> String:
 
 
 func _find_node_of_type(root: Node, type_name: String) -> Node:
-	if root.get_class() == type_name:
-		return root
-
-	for child in root.get_children():
-		var found := _find_node_of_type(child, type_name)
-		if found:
-			return found
-
-	return null
+	var hit := root.find_children("*", type_name, true, false)
+	return hit[0] if not hit.is_empty() else null
 
 
 func _load_character_model() -> void:
@@ -2552,33 +2545,14 @@ func _execute_attack_hit() -> void:
 func _enemies_in_hit_cone(config: Dictionary, extra_dist: float = 0.0, extra_angle: float = 0.0) -> Array:
 	if not is_inside_tree():
 		return []  # off-tree (unit tests) — no enemy group to scan
-	var h_dist: float = maxf(float(config.get("hit_h_dist", 2.4)), extra_dist)
-	var v_dist: float = float(config.get("hit_v_dist", 0.5))
-	var half_angle: float = maxf(float(config.get("hit_h_angle_deg", 30.0)), extra_angle)
-	var v_angle: float = float(config.get("hit_v_angle_deg", 40.0))
-	# The cone's origin is the weapon, not the feet; targets are tested at
-	# their hitbox center so the vertical slope reads naturally.
+	# Same geometry as the companion's swing (ConeTargeting.scan_enemies), with
+	# the technique-widened reach/angle layered onto the weapon cone. The cone's
+	# origin is the weapon, not the feet.
+	var widened: Dictionary = config.duplicate()
+	widened["hit_h_dist"] = maxf(float(config.get("hit_h_dist", 2.4)), extra_dist)
+	widened["hit_h_angle_deg"] = maxf(float(config.get("hit_h_angle_deg", 30.0)), extra_angle)
 	var origin: Vector3 = global_position + Vector3(0, 1.0, 0)
-	var found: Array = []
-	for enemy in get_tree().get_nodes_in_group("enemies"):
-		if not is_instance_valid(enemy):
-			continue
-		if not enemy.get("is_alive"):
-			continue
-		var radius: float = 0.5
-		var height: float = 1.5
-		var ed = enemy.get("enemy_data")
-		if ed != null:
-			radius = float(ed.collision_radius)
-			height = float(ed.collision_height)
-		var center: Vector3 = enemy.global_position + Vector3(0, height * 0.5, 0)
-		var d: float = ConeTargeting.distance_in_cone(
-			origin, player_rotation, h_dist, v_dist, half_angle, v_angle,
-			center, radius)
-		if d >= 0.0:
-			found.append({"enemy": enemy, "dist": d})
-	found.sort_custom(func(a, b): return a.dist < b.dist)
-	return found.map(func(c): return c.enemy)
+	return ConeTargeting.scan_enemies(get_tree().get_nodes_in_group("enemies"), origin, player_rotation, widened)
 
 
 func _fire_projectile(atk: Dictionary) -> void:
@@ -2910,7 +2884,3 @@ func _try_interact() -> void:
 		interacted_with.emit(target)
 		if is_instance_valid(target):
 			print("[Player] Interacted with: ", target.name)
-
-
-func get_nearest_interactable() -> Node3D:
-	return nearest_interactable

--- a/scripts/autoloads/armor_registry.gd
+++ b/scripts/autoloads/armor_registry.gd
@@ -6,8 +6,6 @@ const ARMORS_PATH = "res://data/armors/"
 
 var _armors: Dictionary = {}
 
-signal armors_loaded()
-
 
 func _ready() -> void:
 	_load_all_armors()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all_armors() -> void:
 	_RH.load_dir(ARMORS_PATH, _armors, "ArmorRegistry", "armors")
-	armors_loaded.emit()
 
 
 func get_armor(armor_id: String):

--- a/scripts/autoloads/class_registry.gd
+++ b/scripts/autoloads/class_registry.gd
@@ -1,12 +1,10 @@
 extends Node
 ## Autoload that provides access to all ClassData resources by ID.
 
-const _RU = preload("res://scripts/utils/resource_utils.gd")
+const _RH = preload("res://scripts/utils/registry_helper.gd")
 const CLASSES_PATH = "res://data/classes/"
 
 var _classes: Dictionary = {}
-
-signal classes_loaded()
 
 
 func _ready() -> void:
@@ -14,15 +12,8 @@ func _ready() -> void:
 
 
 func _load_all_classes() -> void:
-	_classes.clear()
-	for path in _RU.list_resources(CLASSES_PATH):
-		var class_res = load(path)
-		if class_res and not class_res.id.is_empty():
-			_classes[class_res.id] = class_res
-	if _classes.is_empty():
+	if _RH.load_dir(CLASSES_PATH, _classes, "ClassRegistry", "classes") == 0:
 		push_warning("[ClassRegistry] Could not load any classes from: ", CLASSES_PATH)
-	print("[ClassRegistry] Loaded ", _classes.size(), " classes")
-	classes_loaded.emit()
 
 
 func get_class_data(class_id: String):

--- a/scripts/autoloads/consumable_registry.gd
+++ b/scripts/autoloads/consumable_registry.gd
@@ -6,8 +6,6 @@ const CONSUMABLES_PATH = "res://data/consumables/"
 
 var _consumables: Dictionary = {}
 
-signal consumables_loaded()
-
 
 func _ready() -> void:
 	_load_all()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_RH.load_dir(CONSUMABLES_PATH, _consumables, "ConsumableRegistry", "consumables")
-	consumables_loaded.emit()
 
 
 func get_consumable(id: String):

--- a/scripts/autoloads/drop_registry.gd
+++ b/scripts/autoloads/drop_registry.gd
@@ -4,14 +4,12 @@ extends Node
 const _RH = preload("res://scripts/utils/registry_helper.gd")
 const DROPS_PATH = "res://data/drop_tables/"
 var _drops: Dictionary = {}
-signal drops_loaded()
 
 func _ready() -> void:
 	_load_all()
 
 func _load_all() -> void:
 	_RH.load_dir(DROPS_PATH, _drops, "DropRegistry", "drop tables")
-	drops_loaded.emit()
 
 func get_drop_table(difficulty: String):
 	return _drops.get(difficulty, null)

--- a/scripts/autoloads/enemy_registry.gd
+++ b/scripts/autoloads/enemy_registry.gd
@@ -6,8 +6,6 @@ const ENEMIES_PATH = "res://data/enemies/"
 
 var _enemies: Dictionary = {}
 
-signal enemies_loaded()
-
 
 func _ready() -> void:
 	_load_all_enemies()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all_enemies() -> void:
 	_RH.load_dir(ENEMIES_PATH, _enemies, "EnemyRegistry", "enemies")
-	enemies_loaded.emit()
 
 
 func get_enemy(enemy_id: String):

--- a/scripts/autoloads/game_state.gd
+++ b/scripts/autoloads/game_state.gd
@@ -109,15 +109,6 @@ func reset_game_state() -> void:
 	game_state_reset.emit()
 
 
-# Utility functions
-func heal(amount: int) -> void:
-	set_hp(hp + amount)
-
-
-func restore_mp(amount: int) -> void:
-	set_mp(mp + amount)
-
-
 func complete_mission(mission_id: String) -> void:
 	if mission_id not in completed_missions:
 		completed_missions.append(mission_id)

--- a/scripts/autoloads/inventory.gd
+++ b/scripts/autoloads/inventory.gd
@@ -416,14 +416,14 @@ func use_item(item_id: String) -> bool:
 		if GameState.hp >= GameState.max_hp:
 			return false  # Already full
 		var amount: int = int(float(GameState.max_hp) * percent)
-		GameState.heal(amount)
+		GameState.set_hp(GameState.hp + amount)
 		_last_use_type = "hp"
 		_last_use_amount = amount
 	elif effect_type == "pp":
 		if GameState.mp >= GameState.max_mp:
 			return false  # Already full
 		var amount: int = int(float(GameState.max_mp) * percent)
-		GameState.restore_mp(amount)
+		GameState.set_mp(GameState.mp + amount)
 		_last_use_type = "pp"
 		_last_use_amount = amount
 	else:

--- a/scripts/autoloads/item_registry.gd
+++ b/scripts/autoloads/item_registry.gd
@@ -9,9 +9,6 @@ const ITEMS_PATH = "res://data/items/"
 ## Dictionary of item_id -> ItemData
 var _items: Dictionary = {}
 
-## Signal emitted when all items are loaded
-signal items_loaded()
-
 
 func _ready() -> void:
 	_load_all_items()
@@ -28,7 +25,6 @@ func _load_all_items() -> void:
 		else:
 			push_warning("[ItemRegistry] Invalid item at: ", path)
 	print("[ItemRegistry] Loaded ", _items.size(), " items")
-	items_loaded.emit()
 
 
 ## Get an item by its ID, returns null if not found

--- a/scripts/autoloads/material_registry.gd
+++ b/scripts/autoloads/material_registry.gd
@@ -6,8 +6,6 @@ const MATERIALS_PATH = "res://data/materials/"
 
 var _materials: Dictionary = {}
 
-signal materials_loaded()
-
 
 func _ready() -> void:
 	_load_all()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_RH.load_dir(MATERIALS_PATH, _materials, "MaterialRegistry", "materials")
-	materials_loaded.emit()
 
 
 func get_material(id: String):

--- a/scripts/autoloads/modifier_registry.gd
+++ b/scripts/autoloads/modifier_registry.gd
@@ -6,8 +6,6 @@ const MODIFIERS_PATH = "res://data/modifiers/"
 
 var _modifiers: Dictionary = {}
 
-signal modifiers_loaded()
-
 
 func _ready() -> void:
 	_load_all()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_RH.load_dir(MODIFIERS_PATH, _modifiers, "ModifierRegistry", "modifiers")
-	modifiers_loaded.emit()
 
 
 func get_modifier(id: String):

--- a/scripts/autoloads/photon_art_registry.gd
+++ b/scripts/autoloads/photon_art_registry.gd
@@ -4,14 +4,12 @@ extends Node
 const _RH = preload("res://scripts/utils/registry_helper.gd")
 const ARTS_PATH = "res://data/photon_arts/"
 var _arts: Dictionary = {}
-signal arts_loaded()
 
 func _ready() -> void:
 	_load_all()
 
 func _load_all() -> void:
 	_RH.load_dir(ARTS_PATH, _arts, "PhotonArtRegistry", "photon arts")
-	arts_loaded.emit()
 
 func get_art(id: String):
 	return _arts.get(id, null)

--- a/scripts/autoloads/recipe_registry.gd
+++ b/scripts/autoloads/recipe_registry.gd
@@ -6,8 +6,6 @@ const RECIPES_PATH = "res://data/recipes/"
 
 var _recipes: Dictionary = {}
 
-signal recipes_loaded()
-
 
 func _ready() -> void:
 	_load_all()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_RH.load_dir(RECIPES_PATH, _recipes, "RecipeRegistry", "recipes")
-	recipes_loaded.emit()
 
 
 func get_recipe(id: String):

--- a/scripts/autoloads/save_manager.gd
+++ b/scripts/autoloads/save_manager.gd
@@ -105,11 +105,6 @@ func load_game() -> void:
 	game_loaded.emit()
 
 
-## Auto-save (called on key events)
-func auto_save() -> void:
-	save_game()
-
-
 ## Check if a save file exists
 func has_save() -> bool:
 	return FileAccess.file_exists(SAVE_PATH)

--- a/scripts/autoloads/set_bonus_registry.gd
+++ b/scripts/autoloads/set_bonus_registry.gd
@@ -6,8 +6,6 @@ const SET_BONUSES_PATH = "res://data/set_bonuses/"
 
 var _set_bonuses: Dictionary = {}
 
-signal set_bonuses_loaded()
-
 
 func _ready() -> void:
 	_load_all()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_RH.load_dir(SET_BONUSES_PATH, _set_bonuses, "SetBonusRegistry", "set bonuses")
-	set_bonuses_loaded.emit()
 
 
 func get_set_bonus(id: String):

--- a/scripts/autoloads/shop_registry.gd
+++ b/scripts/autoloads/shop_registry.gd
@@ -6,8 +6,6 @@ const SHOPS_PATH = "res://data/shops/"
 
 var _shops: Dictionary = {}
 
-signal shops_loaded()
-
 
 func _ready() -> void:
 	_load_all()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all() -> void:
 	_RH.load_dir(SHOPS_PATH, _shops, "ShopRegistry", "shops")
-	shops_loaded.emit()
 
 
 func get_shop(id: String):

--- a/scripts/autoloads/technique_manager.gd
+++ b/scripts/autoloads/technique_manager.gd
@@ -46,7 +46,6 @@ const RARE_LEVEL_BONUS := 3
 
 ## Techniques available in the shop (exclude advanced tier — field drops only)
 const SHOP_BASIC_TECHS := ["foie", "barta", "zonde", "grants", "megid", "resta", "anti", "shifta", "deband", "jellen", "zalure"]
-const SHOP_MID_TECHS: Array = []
 
 ## Base technique → charged variant (hold-to-charge).
 ## Support techs map to themselves — charge may boost potency later.
@@ -75,10 +74,8 @@ func get_charged_technique(base_id: String) -> String:
 
 
 func get_base_technique(technique_id: String) -> String:
-	for base_id in CHARGE_MAP:
-		if CHARGE_MAP[base_id] == technique_id:
-			return base_id
-	return technique_id
+	var base = CHARGE_MAP.find_key(technique_id)
+	return base if base != null else technique_id
 
 
 ## Get required player level to use a disk of a given level

--- a/scripts/autoloads/unit_registry.gd
+++ b/scripts/autoloads/unit_registry.gd
@@ -4,14 +4,12 @@ extends Node
 const _RH = preload("res://scripts/utils/registry_helper.gd")
 const UNITS_PATH = "res://data/units/"
 var _units: Dictionary = {}
-signal units_loaded()
 
 func _ready() -> void:
 	_load_all()
 
 func _load_all() -> void:
 	_RH.load_dir(UNITS_PATH, _units, "UnitRegistry", "units")
-	units_loaded.emit()
 
 func get_unit(id: String):
 	return _units.get(id, null)

--- a/scripts/autoloads/weapon_registry.gd
+++ b/scripts/autoloads/weapon_registry.gd
@@ -6,8 +6,6 @@ const WEAPONS_PATH = "res://data/weapons/"
 
 var _weapons: Dictionary = {}
 
-signal weapons_loaded()
-
 
 func _ready() -> void:
 	_load_all_weapons()
@@ -15,7 +13,6 @@ func _ready() -> void:
 
 func _load_all_weapons() -> void:
 	_RH.load_dir(WEAPONS_PATH, _weapons, "WeaponRegistry", "weapons")
-	weapons_loaded.emit()
 
 
 func get_weapon(weapon_id: String):

--- a/scripts/publish/lib/ardrive.ts
+++ b/scripts/publish/lib/ardrive.ts
@@ -10,7 +10,7 @@ export interface UploadResult {
 
 // Three public gateways pointing at the same Arweave tx. Listed in the
 // manifest so bootstrap.gd can try all of them if one lags propagation.
-function gatewayUrls(txId: string): string[] {
+export function gatewayUrls(txId: string): string[] {
   return [
     `https://arweave.net/${txId}`,
     `https://ar-io.dev/${txId}`,

--- a/scripts/publish/recover_publish.ts
+++ b/scripts/publish/recover_publish.ts
@@ -18,7 +18,7 @@ import { createHash } from "crypto";
 import { resolve, dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { loadWallet } from "./lib/wallet.js";
-import { uploadFileToArweave } from "./lib/ardrive.js";
+import { uploadFileToArweave, gatewayUrls } from "./lib/ardrive.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -31,14 +31,6 @@ const PCK_OUT = join(DIST_DIR, "assets.pck");
 const SIDECAR_OUT = join(DIST_DIR, "pack.manifest.json");
 
 const GODOT_VERSION = "4.5";
-
-function gatewayUrls(txId: string): string[] {
-  return [
-    `https://arweave.net/${txId}`,
-    `https://ar-io.dev/${txId}`,
-    `https://permagate.io/${txId}`,
-  ];
-}
 
 function parsePackTx(): string {
   const i = process.argv.indexOf("--pack-tx");

--- a/scripts/tools/quest_solver/lib/emit.ts
+++ b/scripts/tools/quest_solver/lib/emit.ts
@@ -9,29 +9,13 @@
 // path adds 5-10 new nodes and the graph explodes.
 
 import type { NavGrid } from "./grid.ts";
-import type { Tri2D } from "./floor.ts";
 import { solvePath } from "./pathfinder.ts";
 import type { StagePoint } from "./quest_walk.ts";
+import { GraphBuilder } from "./emit_common.ts";
+import type { EmittedGraph } from "./emit_common.ts";
 
-export interface EmittedWaypoint {
-	id: string;
-	position: [number, number, number];
-	kind: string;
-	label?: string;
-}
-
-export interface EmittedGraph {
-	waypoints: EmittedWaypoint[];
-	waypointEdges: [string, string][];
-	stats: {
-		stagePoints: number;
-		pathsAttempted: number;
-		pathsFailed: number;
-		pathsSolved: number;
-		uniqueWaypoints: number;
-		edges: number;
-	};
-}
+export type { EmittedWaypoint, EmittedGraph } from "./emit_common.ts";
+export { applyGraphToStageConfig as applyToStageConfig } from "./emit_common.ts";
 
 // Larger than the autopilot's 1.5m arrive radius so waypoints from different
 // A* runs (e.g. spawn→spawn and spawn→objective) snap into shared nodes.
@@ -47,36 +31,13 @@ export function solveStageGraph(
 ): EmittedGraph {
 	const mergeDist = opts.mergeDist ?? MERGE_DIST;
 	const decimate = opts.decimate ?? true;
-	const mergeDistSq = mergeDist * mergeDist;
 
-	const waypoints: EmittedWaypoint[] = [];
-	const edges = new Set<string>();
-	let nextAutoId = 0;
-
-	// First pass: seed the graph with the StagePoints themselves. These are
-	// the "anchored" waypoints (spawn/exit/objective) that must keep their
-	// stable IDs because the autopilot looks them up by kind.
-	for (const p of points) {
-		waypoints.push({ id: p.id, position: [p.x, 0, p.z], kind: p.kind, label: p.label });
-	}
-
-	const addEdge = (a: string, b: string) => {
-		if (a === b) return;
-		const k = a < b ? `${a}|${b}` : `${b}|${a}`;
-		edges.add(k);
-	};
-
-	const addOrMerge = (x: number, z: number): string => {
-		// Find any existing waypoint within mergeDist; if so, snap to it.
-		for (const w of waypoints) {
-			const dx = w.position[0] - x;
-			const dz = w.position[2] - z;
-			if (dx * dx + dz * dz < mergeDistSq) return w.id;
-		}
-		const id = `wp_auto_${nextAutoId++}_${stageId}`;
-		waypoints.push({ id, position: [x, 0, z], kind: "point" });
-		return id;
-	};
+	const builder = new GraphBuilder(stageId, mergeDist);
+	// Seed the graph with the StagePoints themselves — the "anchored"
+	// waypoints (spawn/exit/objective) that must keep their stable IDs
+	// because the autopilot looks them up by kind.
+	builder.seed(points);
+	const { addEdge, addOrMerge } = builder;
 
 	// Pair every spawn with every other useful point (spawn, exit, objective).
 	// Exit-to-exit pairs aren't useful (you don't walk between scene-change
@@ -128,35 +89,10 @@ export function solveStageGraph(
 		for (const o of objectives) trySolve(s, o);
 	}
 
-	return {
-		waypoints,
-		waypointEdges: [...edges].map((k) => k.split("|") as [string, string]),
-		stats: {
-			stagePoints: points.length,
-			pathsAttempted: attempted,
-			pathsFailed: failed,
-			pathsSolved: solved,
-			uniqueWaypoints: waypoints.length,
-			edges: edges.size,
-		},
-	};
-}
-
-/**
- * Merge an emitted graph into the existing unified-stage-configs entry.
- * Returns the new config block (caller writes it back to disk).
- */
-export function applyToStageConfig(
-	existing: any,
-	graph: EmittedGraph,
-): any {
-	const next = { ...existing };
-	next.waypoints = graph.waypoints.map((w) => ({
-		id: w.id,
-		position: w.position,
-		kind: w.kind,
-		...(w.label ? { label: w.label } : {}),
-	}));
-	next.waypointEdges = graph.waypointEdges;
-	return next;
+	return builder.finish({
+		stagePoints: points.length,
+		pathsAttempted: attempted,
+		pathsFailed: failed,
+		pathsSolved: solved,
+	});
 }

--- a/scripts/tools/quest_solver/lib/emit_common.ts
+++ b/scripts/tools/quest_solver/lib/emit_common.ts
@@ -1,0 +1,110 @@
+// Shared emit scaffolding for the three graph emitters (emit.ts,
+// emit_manhattan.ts, emit_recast.ts). They differ only in the per-pair
+// pathfinder and the file-specific path post-processing; the waypoint/edge
+// bookkeeping and the unified-stage-configs.json write-back are identical.
+
+import type { StagePoint } from "./quest_walk.ts";
+
+export interface EmittedWaypoint {
+	id: string;
+	position: [number, number, number];
+	kind: string;
+	label?: string;
+}
+
+export interface EmittedGraph {
+	waypoints: EmittedWaypoint[];
+	waypointEdges: [string, string][];
+	stats: {
+		stagePoints: number;
+		pathsAttempted: number;
+		pathsFailed: number;
+		pathsSolved: number;
+		uniqueWaypoints: number;
+		edges: number;
+	};
+}
+
+/**
+ * Accumulates the waypoint set + edge set for one stage graph.
+ *
+ * Seeds with the anchored StagePoints (kept by stable ID), then interior path
+ * waypoints are folded in via `addOrMerge` (snap to any existing node within
+ * mergeDist) and connected with `addEdge`. `finish` produces the EmittedGraph.
+ */
+export class GraphBuilder {
+	readonly waypoints: EmittedWaypoint[] = [];
+	private readonly edges = new Set<string>();
+	private nextAutoId = 0;
+	private readonly mergeDistSq: number;
+
+	constructor(
+		private readonly stageId: string,
+		mergeDist: number,
+	) {
+		this.mergeDistSq = mergeDist * mergeDist;
+	}
+
+	/** Seed the graph with the anchored StagePoints (stable IDs). */
+	seed(points: StagePoint[]): void {
+		for (const p of points) {
+			this.waypoints.push({ id: p.id, position: [p.x, 0, p.z], kind: p.kind, label: p.label });
+		}
+	}
+
+	// Arrow properties so destructured `const { addEdge, addOrMerge } = builder`
+	// keeps its binding when passed around the emitter's inner closures.
+	addEdge = (a: string, b: string): void => {
+		if (a === b) return;
+		const k = a < b ? `${a}|${b}` : `${b}|${a}`;
+		this.edges.add(k);
+	};
+
+	addOrMerge = (x: number, z: number): string => {
+		// Find any existing waypoint within mergeDist; if so, snap to it.
+		for (const w of this.waypoints) {
+			const dx = w.position[0] - x;
+			const dz = w.position[2] - z;
+			if (dx * dx + dz * dz < this.mergeDistSq) return w.id;
+		}
+		const id = `wp_auto_${this.nextAutoId++}_${this.stageId}`;
+		this.waypoints.push({ id, position: [x, 0, z], kind: "point" });
+		return id;
+	};
+
+	finish(counts: {
+		stagePoints: number;
+		pathsAttempted: number;
+		pathsFailed: number;
+		pathsSolved: number;
+	}): EmittedGraph {
+		return {
+			waypoints: this.waypoints,
+			waypointEdges: [...this.edges].map((k) => k.split("|") as [string, string]),
+			stats: {
+				stagePoints: counts.stagePoints,
+				pathsAttempted: counts.pathsAttempted,
+				pathsFailed: counts.pathsFailed,
+				pathsSolved: counts.pathsSolved,
+				uniqueWaypoints: this.waypoints.length,
+				edges: this.edges.size,
+			},
+		};
+	}
+}
+
+/**
+ * Merge an emitted graph into the existing unified-stage-configs entry.
+ * Returns the new config block (caller writes it back to disk).
+ */
+export function applyGraphToStageConfig(existing: any, graph: EmittedGraph): any {
+	const next = { ...existing };
+	next.waypoints = graph.waypoints.map((w) => ({
+		id: w.id,
+		position: w.position,
+		kind: w.kind,
+		...(w.label ? { label: w.label } : {}),
+	}));
+	next.waypointEdges = graph.waypointEdges;
+	return next;
+}

--- a/scripts/tools/quest_solver/lib/emit_manhattan.ts
+++ b/scripts/tools/quest_solver/lib/emit_manhattan.ts
@@ -9,26 +9,11 @@ import { solveManhattan } from "./manhattan.ts";
 import type { StagePoint } from "./quest_walk.ts";
 import type { Tri2D } from "./floor.ts";
 import { pointInTriangle } from "./floor.ts";
+import { GraphBuilder } from "./emit_common.ts";
+import type { EmittedGraph } from "./emit_common.ts";
 
-export interface EmittedWaypoint {
-	id: string;
-	position: [number, number, number];
-	kind: string;
-	label?: string;
-}
-
-export interface EmittedGraph {
-	waypoints: EmittedWaypoint[];
-	waypointEdges: [string, string][];
-	stats: {
-		stagePoints: number;
-		pathsAttempted: number;
-		pathsFailed: number;
-		pathsSolved: number;
-		uniqueWaypoints: number;
-		edges: number;
-	};
-}
+export type { EmittedWaypoint, EmittedGraph } from "./emit_common.ts";
+export { applyGraphToStageConfig as applyToStageConfigManhattan } from "./emit_common.ts";
 
 // MERGE_DIST collapses path corners onto existing waypoints if they're
 // closer than this. Keep it BELOW the grid resolution so we don't eat
@@ -58,7 +43,6 @@ export function solveStageGraphManhattan(
 ): EmittedGraph {
 	const mergeDist = opts.mergeDist ?? MERGE_DIST;
 	const maxLeg = opts.maxLeg ?? MAX_LEG;
-	const mergeDistSq = mergeDist * mergeDist;
 	// preSwitchGrid is the variant with closed fences stamped as obstacles.
 	// If absent we just route everything against the open grid (stages with
 	// no fences have nothing to vary). Spawn→switch and spawn↔spawn run on
@@ -93,30 +77,9 @@ export function solveStageGraphManhattan(
 		return null;
 	};
 
-	const waypoints: EmittedWaypoint[] = [];
-	const edges = new Set<string>();
-	let nextAutoId = 0;
-
-	for (const p of points) {
-		waypoints.push({ id: p.id, position: [p.x, 0, p.z], kind: p.kind, label: p.label });
-	}
-
-	const addEdge = (a: string, b: string) => {
-		if (a === b) return;
-		const k = a < b ? `${a}|${b}` : `${b}|${a}`;
-		edges.add(k);
-	};
-
-	const addOrMerge = (x: number, z: number): string => {
-		for (const w of waypoints) {
-			const dx = w.position[0] - x;
-			const dz = w.position[2] - z;
-			if (dx * dx + dz * dz < mergeDistSq) return w.id;
-		}
-		const id = `wp_auto_${nextAutoId++}_${stageId}`;
-		waypoints.push({ id, position: [x, 0, z], kind: "point" });
-		return id;
-	};
+	const builder = new GraphBuilder(stageId, mergeDist);
+	builder.seed(points);
+	const { addEdge, addOrMerge } = builder;
 
 	// Manhattan paths are already axis-aligned. Re-split any leg longer
 	// than maxLeg so the autopilot has frequent direction-correction
@@ -229,28 +192,10 @@ export function solveStageGraphManhattan(
 		}
 	}
 
-	return {
-		waypoints,
-		waypointEdges: [...edges].map((k) => k.split("|") as [string, string]),
-		stats: {
-			stagePoints: points.length,
-			pathsAttempted: attempted,
-			pathsFailed: failed,
-			pathsSolved: solved,
-			uniqueWaypoints: waypoints.length,
-			edges: edges.size,
-		},
-	};
-}
-
-export function applyToStageConfigManhattan(existing: any, graph: EmittedGraph): any {
-	const next = { ...existing };
-	next.waypoints = graph.waypoints.map((w) => ({
-		id: w.id,
-		position: w.position,
-		kind: w.kind,
-		...(w.label ? { label: w.label } : {}),
-	}));
-	next.waypointEdges = graph.waypointEdges;
-	return next;
+	return builder.finish({
+		stagePoints: points.length,
+		pathsAttempted: attempted,
+		pathsFailed: failed,
+		pathsSolved: solved,
+	});
 }

--- a/scripts/tools/quest_solver/lib/emit_recast.ts
+++ b/scripts/tools/quest_solver/lib/emit_recast.ts
@@ -6,26 +6,11 @@
 import type { NavMeshQuery } from "recast-navigation";
 import { solvePathRecast, isPointOnNavMesh } from "./recast_solver.ts";
 import type { StagePoint } from "./quest_walk.ts";
+import { GraphBuilder } from "./emit_common.ts";
+import type { EmittedGraph } from "./emit_common.ts";
 
-export interface EmittedWaypoint {
-	id: string;
-	position: [number, number, number];
-	kind: string;
-	label?: string;
-}
-
-export interface EmittedGraph {
-	waypoints: EmittedWaypoint[];
-	waypointEdges: [string, string][];
-	stats: {
-		stagePoints: number;
-		pathsAttempted: number;
-		pathsFailed: number;
-		pathsSolved: number;
-		uniqueWaypoints: number;
-		edges: number;
-	};
-}
+export type { EmittedWaypoint, EmittedGraph } from "./emit_common.ts";
+export { applyGraphToStageConfig as applyToStageConfigRecast } from "./emit_common.ts";
 
 const MERGE_DIST = 2.5;
 const MAX_LEG = 3.0; // re-split recast paths so no autopilot leg exceeds this
@@ -39,33 +24,10 @@ export function solveStageGraphRecast(
 	const lShape = opts.lShape ?? false;
 	const mergeDist = opts.mergeDist ?? MERGE_DIST;
 	const maxLeg = opts.maxLeg ?? MAX_LEG;
-	const mergeDistSq = mergeDist * mergeDist;
 
-	const waypoints: EmittedWaypoint[] = [];
-	const edges = new Set<string>();
-	let nextAutoId = 0;
-
-	// Seed graph with the anchored StagePoints (kept by stable ID).
-	for (const p of points) {
-		waypoints.push({ id: p.id, position: [p.x, 0, p.z], kind: p.kind, label: p.label });
-	}
-
-	const addEdge = (a: string, b: string) => {
-		if (a === b) return;
-		const k = a < b ? `${a}|${b}` : `${b}|${a}`;
-		edges.add(k);
-	};
-
-	const addOrMerge = (x: number, z: number): string => {
-		for (const w of waypoints) {
-			const dx = w.position[0] - x;
-			const dz = w.position[2] - z;
-			if (dx * dx + dz * dz < mergeDistSq) return w.id;
-		}
-		const id = `wp_auto_${nextAutoId++}_${stageId}`;
-		waypoints.push({ id, position: [x, 0, z], kind: "point" });
-		return id;
-	};
+	const builder = new GraphBuilder(stageId, mergeDist);
+	builder.seed(points);
+	const { addEdge, addOrMerge } = builder;
 
 	// Convert each diagonal leg into an L-shape: walk axis-aligned first
 	// (longest axis), then the perpendicular axis. The autopilot's camera-
@@ -186,31 +148,10 @@ export function solveStageGraphRecast(
 		}
 	}
 
-	return {
-		waypoints,
-		waypointEdges: [...edges].map((k) => k.split("|") as [string, string]),
-		stats: {
-			stagePoints: points.length,
-			pathsAttempted: attempted,
-			pathsFailed: failed,
-			pathsSolved: solved,
-			uniqueWaypoints: waypoints.length,
-			edges: edges.size,
-		},
-	};
-}
-
-export function applyToStageConfigRecast(
-	existing: any,
-	graph: EmittedGraph,
-): any {
-	const next = { ...existing };
-	next.waypoints = graph.waypoints.map((w) => ({
-		id: w.id,
-		position: w.position,
-		kind: w.kind,
-		...(w.label ? { label: w.label } : {}),
-	}));
-	next.waypointEdges = graph.waypointEdges;
-	return next;
+	return builder.finish({
+		stagePoints: points.length,
+		pathsAttempted: attempted,
+		pathsFailed: failed,
+		pathsSolved: solved,
+	});
 }

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -6584,12 +6584,12 @@ func test_valley_grid() -> void:
 	var gen := GridGen.new()
 
 	# Rotation system
-	assert_eq(gen.rotate_direction("north", 0), "north", "Rotate north by 0")
-	assert_eq(gen.rotate_direction("north", 90), "east", "Rotate north by 90")
-	assert_eq(gen.rotate_direction("north", 180), "south", "Rotate north by 180")
-	assert_eq(gen.rotate_direction("north", 270), "west", "Rotate north by 270")
-	assert_eq(gen.rotate_direction("east", 90), "south", "Rotate east by 90")
-	assert_eq(gen.rotate_direction("west", 180), "east", "Rotate west by 180")
+	assert_eq(StageRotation.rotate_dir("north", 0), "north", "Rotate north by 0")
+	assert_eq(StageRotation.rotate_dir("north", 90), "east", "Rotate north by 90")
+	assert_eq(StageRotation.rotate_dir("north", 180), "south", "Rotate north by 180")
+	assert_eq(StageRotation.rotate_dir("north", 270), "west", "Rotate north by 270")
+	assert_eq(StageRotation.rotate_dir("east", 90), "south", "Rotate east by 90")
+	assert_eq(StageRotation.rotate_dir("west", 180), "east", "Rotate west by 180")
 
 	# Rotated gates
 	var sa1_gates: Array[String] = gen.get_rotated_gates("s01a_sa1", 0)

--- a/scripts/utils/node_utils.gd
+++ b/scripts/utils/node_utils.gd
@@ -1,0 +1,11 @@
+extends RefCounted
+class_name NodeUtils
+## Small Node-tree helpers shared across the field/enemy/player scripts.
+
+## First descendant of `root` whose class (or script class_name) is `type_name`,
+## or null if none. Wraps Node.find_children with owned=false so it reaches
+## nodes under instanced scenes (e.g. a loaded GLB) whose owner isn't set —
+## the reason the hand-rolled recursive finders this replaces existed.
+static func first_of_type(root: Node, type_name: String) -> Node:
+	var hit := root.find_children("*", type_name, true, false)
+	return hit[0] if not hit.is_empty() else null

--- a/scripts/utils/node_utils.gd.uid
+++ b/scripts/utils/node_utils.gd.uid
@@ -1,0 +1,1 @@
+uid://cjylwt75e3p17

--- a/web/src/combat-room/CombatRoom.tsx
+++ b/web/src/combat-room/CombatRoom.tsx
@@ -476,7 +476,7 @@ export default function CombatRoom() {
     const limitIdx = Math.min(enteringStep - 2, t.turnLimitDeg.length - 1);
     const limit = deg2rad(t.turnLimitDeg[limitIdx] ?? 90);
     const delta = wrapAngle(sim.desiredYaw - sim.yaw);
-    const clamped = Math.max(-limit, Math.min(limit, delta));
+    const clamped = THREE.MathUtils.clamp(delta, -limit, limit);
     if (Math.abs(delta) > limit + 1e-4) {
       sim.ghostYaw = sim.desiredYaw;
       sim.ghostFade = 0.8;

--- a/web/src/quest-editor/constants.ts
+++ b/web/src/quest-editor/constants.ts
@@ -3,6 +3,9 @@
  * Asset paths use raw stage layout: /assets/stages/{subfolder}/{stageId}/lndmd/{stageId}_m.glb
  */
 import { assetUrl } from '../utils/assets';
+import { getStageSubfolder } from '../stage-editor/constants';
+
+export { getStageSubfolder };
 
 export const STANDARD_SUFFIXES = [
   'ga1', 'ib1', 'ib2', 'ic1', 'ic3', 'lb1', 'lb3', 'lc1', 'lc2',
@@ -26,12 +29,6 @@ export const STAGE_AREAS: Record<string, StageAreaConfig> = {
   shrine:   { name: 'Dark Shrine',       prefix: 's07', folder: 'shrine' },
   tower:    { name: 'Eternal Tower',     prefix: 's08', folder: 'tower' },
 };
-
-/** Derive the assets/stages/ subfolder from a mapId and area folder */
-export function getStageSubfolder(mapId: string, folder: string): string {
-  if (mapId.length >= 4) return `${folder}_${mapId[3]}`;
-  return folder;
-}
 
 /** Get the raw stage GLB path for a stage */
 export function getGlbPath(areaKey: string, mapId: string): string {

--- a/web/src/quest-editor/utils/quest-io.ts
+++ b/web/src/quest-editor/utils/quest-io.ts
@@ -7,6 +7,7 @@
 import type { QuestProject, QuestSection, EditorGridCell, CellObject, SectionType } from '../types';
 import { getProjectSections, EDITOR_AREAS } from '../types';
 import { AREA_KEY_TO_ID } from '../constants';
+import { getPortalRotation } from '../../stage-editor/directions';
 import {
   getRotatedGates,
   getNeighbor,
@@ -95,18 +96,6 @@ export type { FloorCollisionConfig, SvgSettings };
 // ============================================================================
 // Portal position helpers (matches ExportTab.tsx computePortalPositions)
 // ============================================================================
-
-// Outward vector = [-sin(r), -cos(r)]: north→-Z, south→+Z, east→+X, west→-X
-const DIRECTION_ROTATIONS: Record<string, number> = {
-  north: 0,
-  south: Math.PI,
-  east: -Math.PI / 2,
-  west: Math.PI / 2,
-};
-
-function getPortalRotation(portal: PortalConfig): number {
-  return (DIRECTION_ROTATIONS[portal.direction] ?? 0) + ((portal.rotationOffset || 0) * Math.PI) / 180;
-}
 
 type Vec3 = [number, number, number];
 
@@ -444,7 +433,6 @@ export async function projectToGodotQuest(project: QuestProject): Promise<object
 
   // Auto-compute entry/exit directions for sections that don't have them.
   // Two passes: first infer exits (from warp_edge / next entry), then entries (from prev exit).
-  const OPPOSITE_DIR: Record<string, string> = { north: 'south', south: 'north', east: 'west', west: 'east' };
 
   // Pass 1: infer exit_direction from end cell warp_edge or next section's entry
   for (let i = 0; i < godotSections.length; i++) {
@@ -460,8 +448,8 @@ export async function projectToGodotQuest(project: QuestProject): Promise<object
       } else {
         const next = godotSections[i + 1] as Record<string, unknown>;
         const nextEntry = next.entry_direction as string | undefined;
-        if (nextEntry && OPPOSITE_DIR[nextEntry]) {
-          sec.exit_direction = OPPOSITE_DIR[nextEntry];
+        if (nextEntry && oppositeDirection(nextEntry as Direction)) {
+          sec.exit_direction = oppositeDirection(nextEntry as Direction);
         }
       }
     }
@@ -473,8 +461,8 @@ export async function projectToGodotQuest(project: QuestProject): Promise<object
     if (!sec.entry_direction) {
       const prev = godotSections[i - 1] as Record<string, unknown>;
       const prevExit = prev.exit_direction as string | undefined;
-      if (prevExit && OPPOSITE_DIR[prevExit]) {
-        sec.entry_direction = OPPOSITE_DIR[prevExit];
+      if (prevExit && oppositeDirection(prevExit as Direction)) {
+        sec.entry_direction = oppositeDirection(prevExit as Direction);
       }
     }
   }

--- a/web/src/stage-editor/constants.ts
+++ b/web/src/stage-editor/constants.ts
@@ -8,7 +8,7 @@ export const STANDARD_SUFFIXES = [
 ];
 
 // Generate maps for a stage prefix (e.g., 's01' for valley)
-export function generateStageMaps(prefix: string, variants: string[] = ['a', 'b', 'e', 'z']): Record<string, string[]> {
+function generateStageMaps(prefix: string, variants: string[] = ['a', 'b', 'e', 'z']): Record<string, string[]> {
   const result: Record<string, string[]> = {};
   for (const variant of variants) {
     if (variant === 'e') {
@@ -143,58 +143,4 @@ export function getSkyboxPath(areaKey: string, mapId: string): string | null {
   const folder = area?.folder ?? 'valley';
   const subfolder = getStageSubfolder(mapId, folder);
   return assetUrl(`assets/stages/${subfolder}/${mapId}/lndmd/skybox/o0s_zsky.glb`);
-}
-
-// Calculate portal positions based on edge, offset along edge, and grid settings
-export function calculatePortalPositions(
-  edge: 'north' | 'south' | 'east' | 'west',
-  offsetAlongEdge: number,
-  gridSize: number,
-  gridOffset: [number, number]
-): { gate: [number, number, number]; spawn: [number, number, number]; trigger: [number, number, number]; rotation: number } {
-  const halfSize = gridSize / 2;
-  const spawnInset = 3;
-  const triggerOutset = 2;
-  const y = 1;
-
-  switch (edge) {
-    case 'north':
-      return {
-        gate: [gridOffset[0] + offsetAlongEdge, y, gridOffset[1] - halfSize],
-        spawn: [gridOffset[0] + offsetAlongEdge, y, gridOffset[1] - halfSize + spawnInset],
-        trigger: [gridOffset[0] + offsetAlongEdge, y, gridOffset[1] - halfSize - triggerOutset],
-        rotation: 0,
-      };
-    case 'south':
-      return {
-        gate: [gridOffset[0] + offsetAlongEdge, y, gridOffset[1] + halfSize],
-        spawn: [gridOffset[0] + offsetAlongEdge, y, gridOffset[1] + halfSize - spawnInset],
-        trigger: [gridOffset[0] + offsetAlongEdge, y, gridOffset[1] + halfSize + triggerOutset],
-        rotation: Math.PI,
-      };
-    case 'east':
-      return {
-        gate: [gridOffset[0] + halfSize, y, gridOffset[1] + offsetAlongEdge],
-        spawn: [gridOffset[0] + halfSize - spawnInset, y, gridOffset[1] + offsetAlongEdge],
-        trigger: [gridOffset[0] + halfSize + triggerOutset, y, gridOffset[1] + offsetAlongEdge],
-        rotation: -Math.PI / 2,
-      };
-    case 'west':
-      return {
-        gate: [gridOffset[0] - halfSize, y, gridOffset[1] + offsetAlongEdge],
-        spawn: [gridOffset[0] - halfSize + spawnInset, y, gridOffset[1] + offsetAlongEdge],
-        trigger: [gridOffset[0] - halfSize - triggerOutset, y, gridOffset[1] + offsetAlongEdge],
-        rotation: Math.PI / 2,
-      };
-  }
-}
-
-// Get gate rotation for visual display
-export function getGateRotation(edge: 'north' | 'south' | 'east' | 'west'): number {
-  switch (edge) {
-    case 'north': return Math.PI;
-    case 'south': return 0;
-    case 'east': return Math.PI / 2;
-    case 'west': return -Math.PI / 2;
-  }
 }

--- a/web/src/stage-editor/directions.ts
+++ b/web/src/stage-editor/directions.ts
@@ -1,0 +1,17 @@
+// Shared portal/gate rotation math. Single source of truth for
+// DIRECTION_ROTATIONS + getPortalRotation (previously duplicated in
+// stage-editor/types.ts and quest-editor/utils/quest-io.ts).
+
+// Rotation values for each direction (radians, Y-axis rotation)
+// Outward vector = [-sin(r), -cos(r)]: north→-Z, south→+Z, east→+X, west→-X
+export const DIRECTION_ROTATIONS: Record<string, number> = {
+  north: 0,
+  south: Math.PI,
+  east: -Math.PI / 2,
+  west: Math.PI / 2,
+};
+
+// Get effective rotation for a portal (base direction + optional offset)
+export function getPortalRotation(portal: { direction: string; rotationOffset?: number }): number {
+  return (DIRECTION_ROTATIONS[portal.direction] ?? 0) + ((portal.rotationOffset || 0) * Math.PI) / 180;
+}

--- a/web/src/stage-editor/tabs/ExportTab.tsx
+++ b/web/src/stage-editor/tabs/ExportTab.tsx
@@ -4,7 +4,7 @@ import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import JSZip from 'jszip';
 import type { UnifiedStageConfig, FloorTriangle, PortalData, SpawnPointData, TextureFix } from '../types';
-import { STAGE_AREAS, getGlbPath, getAreaFromMapId } from '../constants';
+import { STAGE_AREAS, getGlbPath, getAreaFromMapId, getStageSubfolder } from '../constants';
 import { DIRECTION_ROTATIONS, getPortalRotation } from '../types';
 import { loadGlobalFixes } from './TextureTab';
 import { loadAllConfigs } from '../useStageConfig';
@@ -947,14 +947,6 @@ export default function ExportTab({ config, stageScene, mapId }: ExportTabProps)
     link.click();
     URL.revokeObjectURL(url);
     setExportStatus(`Exported ${mapId}_config.json`);
-  };
-
-  // Derive the assets/stages/ subfolder from a mapId and area folder.
-  // e.g. mapId="s01a_ga1", folder="valley" → "valley_a"
-  //      mapId="s080_sa0", folder="tower"  → "tower_0"
-  const getStageSubfolder = (mid: string, folder: string): string => {
-    if (mid.length >= 4) return `${folder}_${mid[3]}`;
-    return folder;
   };
 
   // Export All - floor GLBs + SVGs organized to merge into assets/stages/

--- a/web/src/stage-editor/types.ts
+++ b/web/src/stage-editor/types.ts
@@ -3,8 +3,6 @@ import * as THREE from 'three';
 // =============== Core Types ===============
 
 export type GateDirection = 'north' | 'south' | 'east' | 'west';
-export type GateEdge = GateDirection; // Alias for compatibility
-export type GateType = 'Gate' | 'KeyGate' | 'AreaWarp'; // Still used for preview only
 export type PreviewModel = 'Gate' | 'AreaWarp';
 export type ObstacleType = 'box' | 'cylinder';
 export type EditorTab = 'floor' | 'portals' | 'textures' | 'obstacles' | 'scene' | 'waypoints' | 'svg' | 'export';
@@ -42,19 +40,8 @@ export interface SpawnPointData {
   direction: GateDirection;
 }
 
-// Rotation values for each direction (radians, Y-axis rotation)
-// Outward vector = [-sin(r), -cos(r)]: north→-Z, south→+Z, east→+X, west→-X
-export const DIRECTION_ROTATIONS: Record<GateDirection, number> = {
-  north: 0,
-  south: Math.PI,
-  east: -Math.PI / 2,
-  west: Math.PI / 2,
-};
-
-// Get effective rotation for a portal (base direction + optional offset)
-export function getPortalRotation(portal: PortalData): number {
-  return DIRECTION_ROTATIONS[portal.direction] + ((portal.rotationOffset || 0) * Math.PI) / 180;
-}
+// Portal rotation math lives in ./directions (shared with quest-io).
+export { DIRECTION_ROTATIONS, getPortalRotation } from './directions';
 
 // =============== Texture Fixes ===============
 
@@ -119,39 +106,6 @@ export interface UnifiedStageConfig {
   exportedAt?: string;
 }
 
-// =============== Editor State ===============
-
-export interface FloorEditorState {
-  hoveredTriangle: string | null;
-  selectedTriangles: Set<string>;
-  yTolerance: number;
-  meshFilter: string;
-}
-
-export interface PortalEditorState {
-  selectedPortal: string | null;
-  placementMode: boolean;
-  placementDirection: GateDirection;
-  previewModel: PreviewModel;
-}
-
-export interface ObstacleEditorState {
-  selectedObstacle: string | null;
-  placementType: ObstacleType | null;
-}
-
-export interface EditorState {
-  activeTab: EditorTab;
-  selectedMapId: string;
-  selectedArea: string;
-  floorState: FloorEditorState;
-  portalState: PortalEditorState;
-  obstacleState: ObstacleEditorState;
-  showFloorMesh: boolean;
-  showGrid: boolean;
-  zoom: number;
-}
-
 // =============== Stage Area Configuration ===============
 
 export interface StageAreaConfig {
@@ -159,26 +113,6 @@ export interface StageAreaConfig {
   prefix: string;
   folder: string;
   maps: Record<string, string[]>;
-}
-
-// =============== Export Options ===============
-
-export interface ExportOptions {
-  includeLambert: boolean;
-  includeFloorCollision: boolean;
-  includeObstacles: boolean;
-  includeMarkers: boolean;
-  stripSkinning: boolean;
-}
-
-export interface SvgOptions {
-  width: number;
-  height: number;
-  padding: number;
-  strokeWidth: number;
-  floorFill: string;
-  outlineColor: string;
-  gateColors: Record<GateType, string>;
 }
 
 // SVG Tab Settings (saved per-map)
@@ -196,28 +130,6 @@ export const DEFAULT_FLOOR_CONFIG: FloorCollisionConfig = {
   yTolerance: 0.25,
   excludedMeshPatterns: [],
   triangles: {},
-};
-
-export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
-  includeLambert: true,
-  includeFloorCollision: true,
-  includeObstacles: true,
-  includeMarkers: true,
-  stripSkinning: true,
-};
-
-export const DEFAULT_SVG_OPTIONS: SvgOptions = {
-  width: 512,
-  height: 512,
-  padding: 20,
-  strokeWidth: 2,
-  floorFill: '#2a2a4e',
-  outlineColor: '#ffffff',
-  gateColors: {
-    Gate: '#ff4444',
-    KeyGate: '#ffaa00',
-    AreaWarp: '#4444ff',
-  },
 };
 
 export const DEFAULT_SVG_SETTINGS: SvgSettings = {

--- a/web/src/title-screen/TitleScreen.tsx
+++ b/web/src/title-screen/TitleScreen.tsx
@@ -346,7 +346,7 @@ export default function TitleScreen() {
         return v / tot; // 0..1
       };
 
-      const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+      const lerp = THREE.MathUtils.lerp;
       // Color ramp: dark purple → mid purple → blue-purple → pale blue-white
       const ramp = (t: number): [number, number, number] => {
         t = Math.max(0, Math.min(1, t));
@@ -558,7 +558,7 @@ export default function TitleScreen() {
       const data = img.data;
       const n2 = createNoise2D();
       const n2b = createNoise2D();
-      const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+      const lerp = THREE.MathUtils.lerp;
       // Tileable noise: sample on a torus in 4D (approximated here by
       // blending two offset 2D noises with the domain wrapped).
       const tileNoise = (x: number, y: number, freq: number) => {


### PR DESCRIPTION
Whole-repo over-engineering / dead-code / dedupe pass implementing the [#517](https://github.com/kion-dgl/psz-godot/issues/517) audit. **Behavior-preserving only** — correctness/security/perf were explicitly out of scope for that audit.

Each pattern-match finding was grep-verified before cutting; several were skipped where the claim didn't hold (see below).

## Net: ~-808 lines (356 insertions, 1164 deletions), 0 deps removed

## Verification
- **GDScript**: `test_runner.tscn` → **2232 passed, 0 failed**; full `--headless --quit` load clean; no "Warning treated as error" (the #291 gate).
- **Web**: `tsc -b` rc=0; `vitest` → **604/604**.
- **quest_solver**: `tsc --noEmit` clean. **publish**: only pre-existing unrelated `publish_assets.ts` errors.

## What changed

**Field / HUD** — deleted dead `_QuestLogPanel` + its no-op `log_speech`/`log_entry` API (`_quest_log` was never assigned, so every call was a silent no-op) and the dead caller sites; factored the shared visibility loop out of the 5 debug toggles; dropped the `rotate_direction` alias.

**Elements / enemies / combat / player** — 7 recursive node finders → `Node.find_children`; reticle builder (dup 3×) → shared `TargetReticle`; NPC tables (dup 2×) → shared `NpcAssets`; `_enemies_in_hit_cone` → `ConeTargeting.scan_enemies` (widened config); deleted dead wrappers/signals/flags (`warp_base`/`gate`/`fence`/`step_switch`, `deactivated` signals, `_player_nearby`, `StoryProp.set_state` + never-restored state, `hp_before`, `Waypoint.mark_*`, `get_nearest_interactable`).

**Autoloads** — 14 dead `*_loaded` signals; `class_registry` → `RegistryHelper.load_dir`; `get_base_technique` → `Dictionary.find_key`; deleted `SHOP_MID_TECHS`; inlined `heal`/`restore_mp`/`auto_save`.

**2D / shops** — `character_select` hold-to-scroll → shared `NavRepeat`; deleted `weapon_shop` TIER3/4; merged `equipment_screen._notify_player_*`; inlined `blackjack` `DEALER_HITS_SOFT_17`.

**City** — deleted dead shop-cart code (only callsite was commented out).

**TS** — deduped emit scaffolding → `lib/emit_common.ts`; deleted dead stage-editor types/consts; `DIRECTION_ROTATIONS` → `directions.ts`; `OPPOSITE_DIR` → `oppositeDirection`; `getStageSubfolder` dedupe; hand-rolled `lerp`/`clamp` → `THREE.MathUtils`; dropped `generateStageMaps` export; `gatewayUrls` reused from `ardrive.ts`.

## Deliberately skipped (claim didn't hold)
- **pathfinder/manhattan `astar` merge** (the audit's own lowest-confidence item) — not a strict superset: pathfinder uses a **Euclidean** heuristic, manhattan `{eightConn:true}` uses **octile**, and pathfinder returns `costCells` that manhattan drops. Merging would change output paths. Left untouched.
- **`get_state` / `get_meseta` getters** — 12 / 6 call sites (mostly combat autopilot + tests); inlining a getter-over-public-field there is churn for ~0 net lines. Kept.
- **`item_registry` load loop** — does extra per-item validation `load_dir` lacks.
- **`DEFAULT_FLOOR_CONFIG`** — has a live internal caller (`createDefaultConfig`).
- The **`portal-export.test.ts`** copy of `DIRECTION_ROTATIONS` has east/west swapped vs the runtime copy — left as-is; flagging it as a possible latent bug better suited to `/code-review`.

## Remaining gate
This touches `.gd`, so per the working agreement the autopilot matrix / Mac verification is the human gate before merge. Behavior is unchanged and the full unit suite is green; happy to run the regression matrix if you'd like it on the PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)