### PR TITLE
Camera: shoulder-height, closer framing to match the original

### DIFF
--- a/scripts/3d/camera/orbit_camera.gd
+++ b/scripts/3d/camera/orbit_camera.gd
@@ -7,8 +7,8 @@ extends Node3D
 ## Player movement is camera-relative (handled in player.gd via get_viewport().get_camera_3d()).
 
 # Camera settings
-@export var distance: float = 6.0
-@export var height: float = 3.0
+@export var distance: float = 4.5
+@export var height: float = 1.9
 @export var rotation_speed: float = 0.05
 @export var mouse_sensitivity: float = 0.005
 ## Min/max pitch as offset from the default look angle (which is set by


### PR DESCRIPTION
## Why
Play-testing the original, its camera frames the player from close behind at **shoulder/head height, looking nearly level** — not down at the character. Our orbit camera sat higher and further back (`height 3.0` / `distance 6.0`), giving an ~18° downward look that read as looking down at the player.

## What
Two `@export` default tweaks in `scripts/3d/camera/orbit_camera.gd`:
- `distance` 6.0 → **4.5** (closer behind)
- `height` 3.0 → **1.9** (shoulder height, much shallower downward angle)

Nothing else changes — the pitch clamps, orbit radius, and recenter-behind logic all derive from these two values, so they recompute automatically. No scene or instance-site overrides exist (`city_area_base`, `valley_field_controller`, `autopilot` just instantiate the camera scene).

## Verification
Human play-tested on the macOS dev build (in-tree assets), iterating the values live against the original's feel (landed after a "slightly up / slightly further" pass). No test pins the old values, and camera framing doesn't affect the movement basis, so autopilot pathing is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)