### PR TITLE
Per-archetype enemy locomotion: ground movers (#494)

### DIFF
--- a/scripts/3d/enemies/enemy_base.gd
+++ b/scripts/3d/enemies/enemy_base.gd
@@ -76,6 +76,17 @@ const TELEGRAPH_HOLD: float = 0.7
 var _telegraphing: bool = false
 var _telegraph_rising: bool = false
 var _telegraph_timer: float = 0.0
+
+## Per-archetype locomotion (#494, spec /states/enemies). `_archetype` selects the chase
+## behavior (quadruped arc-circle, quad_machine/shooter/roller standoff-hold, else the
+## baseline straight chase); `_fsm` carries standoff_range etc. `_arc_side` (±1) is the
+## circling/strafe side, re-picked on `_arc_timer`; `_chase_mode` is the quadruped
+## arc↔dash sub-mode. Movement math is ported in EnemyLocomotionLogic (fsm.ts).
+var _archetype: String = "simple_melee"
+var _fsm: Dictionary = {}
+var _arc_side: float = 1.0
+var _arc_timer: float = 0.0
+var _chase_mode: String = "arc"
 ## Player collision radius used by the arc test (the target's radius). Real value isn't
 ## exposed cheaply; melee reach dwarfs it, so a constant is fine.
 ## ponytail: constant player radius, read the real shape if arc precision ever matters.
@@ -189,6 +200,8 @@ func _ready() -> void:
 	if enemy_data:
 		_sfx = ENEMY_SFX.get(enemy_data.model_id, {})
 		_attacks = EnemyAttackRegistry.get_attacks(enemy_data.id, enemy_data.attack_range)
+		_archetype = EnemyAttackRegistry.get_archetype(enemy_data.id)
+		_fsm = EnemyAttackRegistry.get_fsm(enemy_data.id)
 
 	_rng.randomize()
 	_apply_difficulty()
@@ -489,59 +502,150 @@ func _process_chasing(_delta: float) -> void:
 
 	var dist := global_position.distance_to(target.global_position)
 
-	# Check if in attack range
 	var attack_range := 2.0
 	if enemy_data:
 		attack_range = enemy_data.attack_range
 
-	# Gate: cooldown ready AND some non-berserk attack band contains the distance
-	# (spec /mechanics/enemy-attacks "Selection"). Falls back to the flat attack_range
-	# only when this enemy has no attack table.
+	# Gate FIRST (every archetype): cooldown ready AND some non-berserk attack band
+	# contains the distance (spec /mechanics/enemy-attacks "Selection"). Keeps kiters
+	# firing from their bands. Falls back to the flat attack_range with no attack table.
 	if attack_cooldown_timer <= 0 and not _stun_no_attack and _has_attack_in_band(dist, attack_range):
 		current_state = EnemyState.ATTACKING
 		_begin_telegraph()
 		return
 
-	# Determine if charging (close to target) or walking (far from target)
-	var charge_range := attack_range * CHARGE_RANGE_MULT
-	var is_charging := dist <= charge_range
+	# Per-archetype locomotion (#494, spec /states/enemies). Distinct ground movers circle
+	# or hold a standoff; every baseline archetype chases straight. Math: EnemyLocomotionLogic.
+	var radial := _radial_to_target()
+	match _archetype:
+		"quadruped":
+			_chase_quadruped(dist, radial, attack_range)
+		"quad_machine", "shooter", "roller":
+			_chase_standoff(_archetype, dist, radial)
+		_:
+			_chase_baseline(dist, attack_range)
 
-	# Use appropriate animation and speed
-	if is_charging:
-		_play_animation("run")
-	else:
-		_play_animation("wlk")
 
-	# Calculate direction to target (horizontal only, properly normalized)
+## Baseline straight-line chase (simple_melee and every non-distinct archetype): walk
+## beyond the charge ring, run inside it, nav-pathing around obstacles.
+func _chase_baseline(dist: float, attack_range: float) -> void:
+	var is_charging := dist <= attack_range * CHARGE_RANGE_MULT
+	_play_animation("run" if is_charging else "wlk")
+
 	var to_target := target.global_position - global_position
 	var horizontal_dir := Vector3(to_target.x, 0, to_target.z)
 	var direction := horizontal_dir.normalized() if horizontal_dir.length() > 0.1 else Vector3.ZERO
 
-	# Try navigation if available (update path every 10th frame to save CPU)
+	# Nav pathing (refresh every 10th frame, staggered per instance)
 	if Engine.get_physics_frames() % 10 == (get_index() % 10):
 		nav_agent.target_position = target.global_position
 	if not nav_agent.is_navigation_finished():
 		var next_pos := nav_agent.get_next_path_position()
-		var nav_dir := (next_pos - global_position)
+		var nav_dir := next_pos - global_position
 		nav_dir.y = 0
-		# Only use nav direction if it's valid (not pointing at ourselves)
 		if nav_dir.length() > 0.5:
 			direction = nav_dir.normalized()
 
-	# Apply movement - walk normally, run when charging
-	var base_speed := 3.0
-	if enemy_data:
-		base_speed = enemy_data.move_speed
-
-	var speed := base_speed * WALK_SPEED_MULT
-	if is_charging:
-		speed = base_speed * CHARGE_SPEED_MULT
-
-	# Apply movement toward target
+	var speed := _base_move_speed() * (CHARGE_SPEED_MULT if is_charging else WALK_SPEED_MULT)
 	if direction.length() > 0.1 and _can_move_to(direction):
 		velocity.x = direction.x * speed
 		velocity.z = direction.z * speed
 		_face_direction(direction)
+
+
+## Quadruped arc-circler (fsm.ts:689-725): circles on an arc (wlk_l/wlk_r by side) and
+## only dashes straight (stt) to close inside the charge ring when armed.
+func _chase_quadruped(dist: float, radial: Vector3, attack_range: float) -> void:
+	var charge_range := attack_range * CHARGE_RANGE_MULT
+	if _chase_mode != "dash" and dist <= charge_range and attack_cooldown_timer <= 0.0:
+		_chase_mode = "dash"
+	if _chase_mode == "dash" and dist > charge_range * 1.5:
+		_chase_mode = "arc"
+	var dashing := _chase_mode == "dash"
+	if not dashing:
+		_tick_arc_side(2.0, 3.0, 0.35)
+	var m := EnemyLocomotionLogic.quadruped_move(radial, _arc_side, dashing)
+	if m["dash"]:
+		_apply_move(m["dir"], _base_move_speed() * CHARGE_SPEED_MULT, m["dir"], "stt")
+	else:
+		_apply_move(m["dir"], _base_move_speed() * WALK_SPEED_MULT, m["dir"],
+			"wlk_l" if m["side_left"] else "wlk_r")
+
+
+## Standoff holder (fsm.ts:736-767/894-915/924-948): quad_machine kites & strafes facing
+## the target, shooter holds radial-only and stops to fire, roller sidles facing its
+## movement. All hold fsm.standoff_range.
+func _chase_standoff(kind: String, dist: float, radial: Vector3) -> void:
+	var standoff := float(_fsm.get("standoff_range", 6.0))
+	var near_mult := 0.85
+	var far_mult := 1.25
+	var strafe := true
+	var faces_target := true
+	if kind == "shooter":
+		near_mult = 0.8
+		far_mult = 1.2
+		strafe = false
+	elif kind == "roller":
+		near_mult = 0.75
+		far_mult = 1.3
+		faces_target = false
+	if strafe:
+		_tick_arc_side(1.5, 2.5, 0.4)
+	var m := EnemyLocomotionLogic.standoff_move(dist, standoff, radial, _arc_side, near_mult, far_mult, strafe)
+	var mode := String(m["mode"])
+	# Retreat is fast (charge mult) for the kiters; the roller walks everywhere.
+	var speed := _base_move_speed() * WALK_SPEED_MULT
+	if mode == "retreat" and kind != "roller":
+		speed = _base_move_speed() * CHARGE_SPEED_MULT
+	var face: Vector3 = radial if faces_target else m["dir"]
+	_apply_move(m["dir"], speed, face, _standoff_clip(kind, mode, bool(m["side_left"])))
+
+
+func _standoff_clip(kind: String, mode: String, side_left: bool) -> String:
+	if kind == "shooter":
+		return "wat" if mode == "hold" else "run"
+	if kind == "roller":
+		return "wlk"
+	# quad_machine: clip matches movement relative to the target-facing body.
+	if mode == "retreat":
+		return "wlk_b"
+	if mode == "close":
+		return "wlk_f"
+	return "wlk_l" if side_left else "wlk_r"
+
+
+## Resolve a movement intent to velocity: move along `dir` at `speed` when the floor
+## ahead holds (else stop), face `face_dir`, play `clip`. Shared by the archetype chases.
+func _apply_move(dir: Vector3, speed: float, face_dir: Vector3, clip: String) -> void:
+	if dir.length() > 0.1 and _can_move_to(dir):
+		velocity.x = dir.x * speed
+		velocity.z = dir.z * speed
+	else:
+		velocity.x = 0.0
+		velocity.z = 0.0
+	if face_dir.length() > 0.1:
+		_face_direction(face_dir)
+	if not clip.is_empty():
+		_play_animation(clip)
+
+
+func _radial_to_target() -> Vector3:
+	var to := target.global_position - global_position
+	to.y = 0.0
+	return to.normalized() if to.length() > 0.001 else Vector3.FORWARD
+
+
+func _base_move_speed() -> float:
+	return float(enemy_data.move_speed) if enemy_data else 3.0
+
+
+## Tick the circling/strafe-side timer; re-pick the side after a random interval.
+func _tick_arc_side(base: float, span: float, flip_chance: float) -> void:
+	_arc_timer -= get_physics_process_delta_time()
+	if _arc_timer <= 0.0:
+		_arc_timer = base + _rng.randf() * span
+		if _rng.randf() < flip_chance:
+			_arc_side = -_arc_side
 
 
 func _process_attacking(delta: float) -> void:

--- a/scripts/3d/enemies/enemy_locomotion_logic.gd
+++ b/scripts/3d/enemies/enemy_locomotion_logic.gd
@@ -1,0 +1,38 @@
+class_name EnemyLocomotionLogic
+## Pure, side-effect-free per-archetype locomotion decisions — the Godot port of the
+## chase branches in the normative reference `web/src/enemy-room/fsm.ts`. Kept static +
+## node-free so test_runner can pin the geometry directly (spec /states/enemies, #494).
+## The functions return a movement INTENT (world direction on XZ + which side); EnemyBase
+## maps that to speed tier / clip per rig and applies the physics (floor guard, facing).
+
+
+## Standoff 3-band kite decision — shared by quad_machine / shooter / roller
+## (fsm.ts:736-767, 894-915, 924-948). `radial` is the unit XZ vector toward the target.
+## Returns {mode, dir, side_left}: retreat (too close, back out along -radial),
+## close (too far, in along radial), strafe (in band, lateral tangent by arc_side), or
+## hold (in band with strafe off — stand and act). `dir` is a unit XZ vector (ZERO for hold).
+static func standoff_move(dist: float, standoff: float, radial: Vector3, arc_side: float,
+		near_mult: float, far_mult: float, strafe: bool) -> Dictionary:
+	if dist < standoff * near_mult:
+		return {"mode": "retreat", "dir": -radial, "side_left": false}
+	if dist > standoff * far_mult:
+		return {"mode": "close", "dir": radial, "side_left": false}
+	if not strafe:
+		return {"mode": "hold", "dir": Vector3.ZERO, "side_left": false}
+	var tangent := Vector3(-radial.z * arc_side, 0.0, radial.x * arc_side)
+	# left-of-facing (y-up) = (facing.z, -facing.x); which side the tangent leans.
+	var left_dot := tangent.x * radial.z + tangent.z * (-radial.x)
+	return {"mode": "strafe", "dir": tangent, "side_left": left_dot > 0.0}
+
+
+## Quadruped arc/dash decision (fsm.ts:689-725). Quadrupeds (head-turned rigs) MUST NOT
+## walk straight while circling — only the `dash` closes straight. Arc = tangent blended
+## with a gentle 0.45 inward spiral. Returns {dir, dash, side_left}; side_left picks
+## wlk_l vs wlk_r by which side of the enemy's heading the target sits.
+static func quadruped_move(radial: Vector3, arc_side: float, dash: bool) -> Dictionary:
+	if dash:
+		return {"dir": radial, "dash": true, "side_left": false}
+	var tangent := Vector3(-radial.z * arc_side, 0.0, radial.x * arc_side)
+	var dir := (tangent + radial * 0.45).normalized()
+	var left_dot := radial.x * dir.z + radial.z * (-dir.x)
+	return {"dir": dir, "dash": false, "side_left": left_dot > 0.0}

--- a/scripts/3d/enemies/enemy_locomotion_logic.gd.uid
+++ b/scripts/3d/enemies/enemy_locomotion_logic.gd.uid
@@ -1,0 +1,1 @@
+uid://dh8n00mg7wkkj

--- a/scripts/autoloads/autopilot.gd
+++ b/scripts/autoloads/autopilot.gd
@@ -284,6 +284,10 @@ var _enemy_attack_probe := false    # #509 frame-tied attack-model probe
 var _enemy_attack_triggered := false
 var _enemy_attack_id := "reyhound"  # basic melee rig to spawn
 
+var _enemy_kite_probe := false      # #494 kiter-locomotion probe
+var _enemy_kite_triggered := false
+var _enemy_kite_id := "izhirak_s6"  # quad_machine (standoff 6.0) to spawn
+
 # Companion-combat probe (spec /states/companion-combat): when
 # PSZ_AUTOPILOT_COMPANION_COMBAT=1, the first field cell spawns a companion
 # and an enemy near it and requires the companion to land a hit on its own —
@@ -390,6 +394,12 @@ func _parse_probe_flags() -> void:
 		if atk_val != "" and atk_val != "1":
 			_enemy_attack_id = atk_val
 		print("[sanity] autopilot ENEMY-ATTACK probe enabled (%s must damage the player through the windup→arc window)" % _enemy_attack_id)
+	_enemy_kite_probe = OS.has_environment("PSZ_AUTOPILOT_ENEMY_KITE")
+	if _enemy_kite_probe:
+		var kite_val := OS.get_environment("PSZ_AUTOPILOT_ENEMY_KITE")
+		if kite_val != "" and kite_val != "1":
+			_enemy_kite_id = kite_val
+		print("[sanity] autopilot ENEMY-KITE probe enabled (%s must back off to hold its standoff, not close to melee)" % _enemy_kite_id)
 	_companion_combat_probe = OS.has_environment("PSZ_AUTOPILOT_COMPANION_COMBAT")
 	if _companion_combat_probe:
 		var comp_val := OS.get_environment("PSZ_AUTOPILOT_COMPANION_COMBAT")
@@ -2551,6 +2561,51 @@ func _enemy_attack_watch(enemy: EnemyBase, seen: Dictionary, tick: int) -> void:
 	_after(0.2, func() -> void: _enemy_attack_watch(enemy, seen, tick + 1))
 
 
+func _enemy_kite_fail(msg: String) -> void:
+	_fail_and_quit("enemy-kite probe — %s" % msg)
+
+
+## PSZ_AUTOPILOT_ENEMY_KITE=1: spawn a kiter (quad_machine) in contact with the player
+## and require it to BACK OFF toward its standoff_range instead of closing to melee like
+## a baseline chaser (#494 per-archetype locomotion, spec /states/enemies §quad-machine).
+func _run_enemy_kite_probe(attempt: int = 0) -> void:
+	var players: Array = get_tree().get_nodes_in_group("player")
+	if players.is_empty():
+		if attempt < 60:
+			_after(STEP_DELAY, func() -> void: _run_enemy_kite_probe(attempt + 1))
+		else:
+			_enemy_kite_fail("no player in field")
+		return
+	var p: Node3D = players[0]
+	var enemy := _spawn_probe_enemy(p, _enemy_kite_id)
+	if enemy == null:
+		_enemy_kite_fail("%s missing from EnemyRegistry" % _enemy_kite_id)
+		return
+	var d0: float = enemy.global_position.distance_to(p.global_position)
+	print("[sanity] checkpoint: enemy-kite probe — %s spawned at %.1fm from player" % [_enemy_kite_id, d0])
+	_enemy_kite_watch(enemy, p, d0, 0)
+
+
+## Poll ~5/s: the kiter must open the gap to near its standoff. Success = distance grows
+## past 4m (it was spawned ~1.2m away). Fail if it closes to melee or never backs off.
+func _enemy_kite_watch(enemy: EnemyBase, p: Node3D, best: float, tick: int) -> void:
+	if not is_instance_valid(enemy) or not is_instance_valid(p):
+		_enemy_kite_fail("enemy or player freed mid-probe")
+		return
+	var d: float = enemy.global_position.distance_to(p.global_position)
+	best = maxf(best, d)
+	if best >= 4.0:
+		print("[sanity] checkpoint: enemy-kite probe — held standoff (backed off to %.1fm)" % best)
+		enemy.queue_free()
+		print("[sanity] DONE ok")
+		_after(QUIT_GRACE, func() -> void: get_tree().quit(0))
+		return
+	if tick >= 100:
+		_enemy_kite_fail("never opened the gap (best=%.1fm) — closed to melee like a baseline chaser" % best)
+		return
+	_after(0.2, func() -> void: _enemy_kite_watch(enemy, p, best, tick + 1))
+
+
 ## PSZ_AUTOPILOT_COMPANION_COMBAT=1: in the first field cell, spawn a companion
 ## and an enemy near it and require the companion to land a hit ON ITS OWN
 ## (spec /states/companion-combat phase 1). Runs instead of the cell plan and
@@ -2656,6 +2711,10 @@ func _try_run_first_cell_probe() -> bool:
 	if _enemy_attack_probe and not _enemy_attack_triggered:
 		_enemy_attack_triggered = true
 		_run_enemy_attack_probe()
+		return true
+	if _enemy_kite_probe and not _enemy_kite_triggered:
+		_enemy_kite_triggered = true
+		_run_enemy_kite_probe()
 		return true
 	if _companion_combat_probe and not _companion_combat_triggered:
 		_companion_combat_triggered = true

--- a/scripts/autoloads/enemy_attack_registry.gd
+++ b/scripts/autoloads/enemy_attack_registry.gd
@@ -39,6 +39,22 @@ func get_attacks(enemy_id: String, attack_range: float = 2.0) -> Array:
 	return out
 
 
+## Behavior archetype for an enemy id (drives the per-archetype locomotion dispatch,
+## #494). Defaults to "simple_melee" (the baseline straight-line chase).
+func get_archetype(enemy_id: String) -> String:
+	return str(_enemies.get(enemy_id, {}).get("archetype", "simple_melee"))
+
+
+## Resolved fsm params for an enemy id (its `fsm` merged over defaults.fsm) —
+## standoff_range, hover_height, reveal_range, stationary, walk/charge mults, etc.
+func get_fsm(enemy_id: String) -> Dictionary:
+	var out: Dictionary = _defaults.get("fsm", {}).duplicate(true)
+	var entry: Dictionary = _enemies.get(enemy_id, {})
+	for k in entry.get("fsm", {}):
+		out[k] = entry["fsm"][k]
+	return out
+
+
 func get_enemy_count() -> int:
 	return _enemies.size()
 

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -46,6 +46,7 @@ func _run_tests_combat() -> void:
 	test_enemy_attack_arc()
 	test_enemy_attack_timeline()
 	test_enemy_telegraph()
+	test_enemy_locomotion()
 	test_enemy_difficulty_scaling()
 	test_combat_math()
 	test_combat_drops()
@@ -1060,6 +1061,34 @@ func test_enemy_difficulty_scaling() -> void:
 	assert_eq(eh._aggro_cadence, EnemyBase.AGGRO_SCALING["hard"]["cadence"], "hard sets cadence mult")
 	eh.queue_free()
 	SessionManager.enter_field("gurhacia-valley", prev_diff if prev_diff != "" else "normal")
+	print("")
+
+
+func test_enemy_locomotion() -> void:
+	print("── Enemy per-archetype locomotion (#494) ──")
+	var fwd := Vector3(0, 0, 1)  # unit vector toward the target
+
+	# Standoff 3-band (quad_machine / shooter / roller share this geometry).
+	var r := EnemyLocomotionLogic.standoff_move(3.0, 6.0, fwd, 1.0, 0.85, 1.25, true)
+	assert_eq(r["mode"], "retreat", "inside standoff -> retreat")
+	assert_true(r["dir"].dot(fwd) < -0.99, "retreat backs straight away from target")
+	r = EnemyLocomotionLogic.standoff_move(8.0, 6.0, fwd, 1.0, 0.85, 1.25, true)
+	assert_eq(r["mode"], "close", "beyond standoff -> close")
+	assert_true(r["dir"].dot(fwd) > 0.99, "close moves straight toward target")
+	r = EnemyLocomotionLogic.standoff_move(6.0, 6.0, fwd, 1.0, 0.85, 1.25, true)
+	assert_eq(r["mode"], "strafe", "in band + strafe -> lateral strafe")
+	assert_true(abs(r["dir"].dot(fwd)) < 0.01, "strafe is perpendicular to the target line")
+	r = EnemyLocomotionLogic.standoff_move(6.0, 6.0, fwd, 1.0, 0.8, 1.2, false)
+	assert_eq(r["mode"], "hold", "in band + no strafe (shooter) -> hold")
+	assert_true(r["dir"].length() < 0.001, "hold has zero move direction")
+
+	# Quadruped arc vs dash.
+	var q := EnemyLocomotionLogic.quadruped_move(fwd, 1.0, true)
+	assert_true(q["dash"] and q["dir"].dot(fwd) > 0.99, "quadruped dash goes straight at target")
+	q = EnemyLocomotionLogic.quadruped_move(fwd, 1.0, false)
+	assert_true(not q["dash"], "quadruped arc is not a dash")
+	assert_true(q["dir"].dot(fwd) < 0.95, "quadruped arc never walks straight at the target")
+	assert_true(abs(q["dir"].x) > 0.1, "quadruped arc has a lateral (circling) component")
 	print("")
 
 


### PR DESCRIPTION
## Why
After the attack model (#509) + telegraph (#525), enemies *attack* well but all *move* identically — one generic straight-line chase. The normative `#/enemy-room` reference (`web/src/enemy-room/fsm.ts`) defines distinct locomotion per archetype; `/states/enemies` carries the contracts. This ports the **4 ground-based archetypes**.

## What
- **quadruped** (wolves/hyenas/deer/tiger — 5 rigs): circles in on an arc (`wlk_l`/`wlk_r` by which side the target is on), only **dashing straight** (`stt`) to close inside the charge ring. Never beelines.
- **quad_machine** (kiter): body faces the target, holds `fsm.standoff_range`, **strafes** (`wlk_f/b/l/r`); retreats fast when you close — cornering it is the intended counterplay (no wall-aware escape).
- **shooter**: holds standoff radial-only, **stops** (`wat`) to fire from its band.
- **roller**: sidles at standoff facing its movement direction.
- Every other archetype keeps the **baseline** straight chase (correct per the reference).

Architecture mirrors #509: a pure, node-free `EnemyLocomotionLogic` (seed-testable geometry — `standoff_move` / `quadruped_move`) + an `archetype` **dispatch** in `enemy_base.gd _process_chasing`. `EnemyAttackRegistry` re-exposes `get_archetype`/`get_fsm`. The attack-band gate stays first, so kiters still fire from their bands (via the #509 interim). No new physics (ground only).

## Testing (two layers)
- **Seeded** `test_enemy_locomotion` — 12 assertions ported from the `fsm.ts` geometry (standoff retreat/close/strafe/hold at the right distances; quadruped arc never straight + dash straight). **RESULTS: 2274 passed, 0 failed**, `code_graph.py --check` clean.
- **Autopilot probe** `PSZ_AUTOPILOT_ENEMY_KITE` — spawned a `quad_machine` in contact; it **backed off 1.2m → 4.1m** to hold its standoff instead of closing to melee → `DONE ok`.
- Play-test to follow (wolves circling, quad kiting, roller sidling; baseline enemies unchanged).

## Scope
Part of **#494**. Deferred follow-ups: `flyer_combo` (airborne hover-orbit — needs gravity-off / hover-height physics), `box_mimic` (idle dormancy + `reveal_range`), `stationary`/poison-lily (data-driven port replacing the `poison_lily.gd` subclass). The spec contracts in `/states/enemies` already existed — no spec change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)