### PR TITLE
Player: cache the built animation library across city transitions (#531)

### DIFF
--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -65,6 +65,14 @@ var _walk_anim: String = "pmsa_walk"
 var _run_anim: String = "pmsa_run_pso"
 var _is_female: bool = false
 
+# Cache of built animation libraries, keyed by "<anim_glb>|<skeleton_name>".
+# Building a library duplicates + track-remaps ~26 clips; the result is identical
+# for a given (GLB, skeleton) and is safe to share across player instances
+# (libraries are read-only during playback). This is the dominant per-transition
+# cost when the city rebuilds the player rig on every area load (#531) — build
+# once, reuse thereafter.
+static var _anim_lib_cache: Dictionary = {}
+
 # Default asset paths (fallback when no character data)
 const DEFAULT_TEXTURE_PATH := "res://assets/player/pc_000/textures/pc_000_000.png"
 
@@ -394,17 +402,55 @@ func _load_weapon_animations() -> void:
 		_anim_prefix = DEFAULT_ANIM_PREFIX_M
 		_is_female = false
 
+	# Build the remapped library once per (GLB, skeleton) and reuse it — the
+	# instantiate + per-clip duplicate/remap below is the dominant cost the city
+	# otherwise pays on every area transition (#531). Keyed by skeleton.name
+	# because _remap_animation rewrites every track NodePath to target it.
+	var cache_key := anim_glb + "|" + skeleton.name
+	var lib: AnimationLibrary = _anim_lib_cache.get(cache_key, null)
+	if lib == null:
+		lib = _build_animation_library(anim_glb)
+		if lib == null:
+			return
+		_anim_lib_cache[cache_key] = lib
+		print("[Player] Built animation library: %s (%d clips)" % [anim_glb, lib.get_animation_list().size()])
+	else:
+		print("[Player] Reused cached animation library: %s" % anim_glb)
+
+	# Set gender-aware walk/run animation names
+	if _is_female:
+		_walk_anim = "pwsa_walk" if lib.has_animation("pwsa_walk") else "pmsa_walk"
+		_run_anim = "pwsa_run_pso" if lib.has_animation("pwsa_run_pso") else "pmsa_run_pso"
+	else:
+		_walk_anim = "pmsa_walk"
+		_run_anim = "pmsa_run_pso"
+	print("[Player] Walk=%s, Run=%s" % [_walk_anim, _run_anim])
+
+	# Replace existing library
+	if animation_player.has_animation_library(""):
+		animation_player.remove_animation_library("")
+	animation_player.add_animation_library("", lib)
+
+	var anim_list := animation_player.get_animation_list()
+	print("[Player] Loaded %d animations: %s" % [anim_list.size(), anim_list])
+
+
+## Build the remapped AnimationLibrary for an animation GLB. Split out from
+## _load_weapon_animations so the result can be cached (see _anim_lib_cache):
+## the per-clip duplicate + track-path remap is the expensive part, and it's
+## identical for a given (GLB, skeleton). Returns null on failure.
+func _build_animation_library(anim_glb: String) -> AnimationLibrary:
 	var packed: PackedScene = load(anim_glb) as PackedScene
 	if packed == null:
 		push_warning("[Player] Failed to load animation GLB: %s" % anim_glb)
-		return
+		return null
 
 	var anim_scene := packed.instantiate()
 	var source_player: AnimationPlayer = NodeUtils.first_of_type(anim_scene, "AnimationPlayer") as AnimationPlayer
 	if not source_player:
 		push_warning("[Player] No AnimationPlayer found in animation GLB: %s" % anim_glb)
 		anim_scene.queue_free()
-		return
+		return null
 
 	# Looping animations: weapon-specific idle/wait + shared locomotion
 	var looping_suffixes := ["_wait", "_run", "_run_pso", "_walk", "_stp_fb", "_stp_lr"]
@@ -444,24 +490,8 @@ func _load_weapon_animations() -> void:
 					new_anim.loop_mode = Animation.LOOP_LINEAR
 					lib.add_animation(anim_name, new_anim)
 
-	# Set gender-aware walk/run animation names
-	if _is_female:
-		_walk_anim = "pwsa_walk" if lib.has_animation("pwsa_walk") else "pmsa_walk"
-		_run_anim = "pwsa_run_pso" if lib.has_animation("pwsa_run_pso") else "pmsa_run_pso"
-	else:
-		_walk_anim = "pmsa_walk"
-		_run_anim = "pmsa_run_pso"
-	print("[Player] Walk=%s, Run=%s" % [_walk_anim, _run_anim])
-
-	# Replace existing library
-	if animation_player.has_animation_library(""):
-		animation_player.remove_animation_library("")
-	animation_player.add_animation_library("", lib)
-
-	var anim_list := animation_player.get_animation_list()
-	print("[Player] Loaded %d animations: %s" % [anim_list.size(), anim_list])
-
 	anim_scene.queue_free()
+	return lib
 
 
 ## Call this after equipment changes to update the 3D weapon model.

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -31,6 +31,7 @@ func _ready() -> void:
 # drops, and the combat-adjacent regression tests.
 func _run_tests_combat() -> void:
 	test_player_states()
+	test_player_anim_library_cache()
 	test_action_commitment()
 	test_combo_three_tier()
 	test_combo_chain_lifecycle()
@@ -702,6 +703,44 @@ func test_player_states() -> void:
 	assert_eq(p._charging_slot, -1, "entering DODGING releases the charge")
 	assert_eq(released, [2], "tech_charge_released fired with the charged slot")
 	p.free()
+	print("")
+
+
+# ── Player animation-library cache (#531) ──
+# The player rig was rebuilt on every city area transition; the expensive part
+# is instantiate + per-clip duplicate/track-remap of ~26 animations. That build
+# is now split into _build_animation_library() and memoized on a static cache
+# keyed by (anim_glb, skeleton.name), so it runs once and the library resource
+# is shared across player instances. (The full build path needs the model GLB —
+# only in the pack — so this locks the cache CONTRACT; the autopilot city→field
+# probe exercises the real build+reuse.)
+func test_player_anim_library_cache() -> void:
+	print("── Player Anim Library Cache ──")
+	const PlayerScript := preload("res://scripts/3d/player/player.gd")
+	var p1 = PlayerScript.new()
+	var p2 = PlayerScript.new()
+	assert_true(p1.has_method("_build_animation_library"),
+		"library build split into _build_animation_library() so it can be cached")
+
+	# Shared static store: an entry written via one instance is visible to another.
+	p1._anim_lib_cache.clear()
+	var lib := AnimationLibrary.new()
+	var key := "res://assets/player/animations/saver_m.glb|GeneralSkeleton"
+	p1._anim_lib_cache[key] = lib
+	assert_true(p2._anim_lib_cache.has(key),
+		"anim library cache is a shared static store across player instances")
+
+	# A hit hands back the identical resource — reused, not rebuilt.
+	assert_true(is_same(p2._anim_lib_cache[key], lib),
+		"a cache hit returns the same AnimationLibrary instance (no rebuild)")
+
+	# Key captures the GLB, so a different animation set is a distinct entry.
+	assert_true(not p1._anim_lib_cache.has("res://assets/player/animations/sword_m.glb|GeneralSkeleton"),
+		"a different animation GLB is a different cache key")
+
+	p1._anim_lib_cache.clear()
+	p1.free()
+	p2.free()
 	print("")
 
 

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -723,9 +723,11 @@ func test_player_anim_library_cache() -> void:
 		"library build split into _build_animation_library() so it can be cached")
 
 	# Shared static store: an entry written via one instance is visible to another.
+	# (Synthetic keys — real "<glb>|<skeleton>" keys with res:// paths would trip
+	# check_asset_refs; the dict semantics are what matter here.)
 	p1._anim_lib_cache.clear()
 	var lib := AnimationLibrary.new()
-	var key := "res://assets/player/animations/saver_m.glb|GeneralSkeleton"
+	var key := "saver_m|GeneralSkeleton"
 	p1._anim_lib_cache[key] = lib
 	assert_true(p2._anim_lib_cache.has(key),
 		"anim library cache is a shared static store across player instances")
@@ -735,7 +737,7 @@ func test_player_anim_library_cache() -> void:
 		"a cache hit returns the same AnimationLibrary instance (no rebuild)")
 
 	# Key captures the GLB, so a different animation set is a distinct entry.
-	assert_true(not p1._anim_lib_cache.has("res://assets/player/animations/sword_m.glb|GeneralSkeleton"),
+	assert_true(not p1._anim_lib_cache.has("sword_m|GeneralSkeleton"),
 		"a different animation GLB is a different cache key")
 
 	p1._anim_lib_cache.clear()


### PR DESCRIPTION
Closes #531.

## Problem
The player rig was fully rebuilt on **every** city area transition — the session log from the narrated dev-session (`dev-sessions/20260719-154050`) showed `[Player] Loaded 26 animations` on each of market → counter → office → counter. The dominant cost is `packed.instantiate()` of the animation GLB plus a per-clip `duplicate()` + track-NodePath remap across ~26 clips (`_remap_animation`), all synchronous on the main thread during the swap — the stall behind the jarring blank frame (#530).

## Fix
The built `AnimationLibrary` is **identical** for a given `(anim_glb, skeleton.name)` — constant across city player instances — so memoize it:

- Split the build into `_build_animation_library()`.
- Cache its result on a `static var _anim_lib_cache` keyed by `"<anim_glb>|<skeleton_name>"`.
- First load builds; every later load (city→city, and weapon swaps that reuse a GLB) **reuses the shared library resource**.

Safe to share because the library is **read-only during playback**: every `loop_mode` / `track_set_path` / `add_animation` write happens inside the build, and nothing mutates the animations per-instance afterward (grep-verified). Behavior is unchanged — same library content, just no redundant rebuild.

Logs now read `[Player] Built animation library: …` once, then `[Player] Reused cached animation library: …` on subsequent loads — a visible signal you can confirm in a dev-session transcript.

## Scope / follow-ups (noted on #531)
This targets the dominant cost (the 26-clip rebuild). The model `instantiate()` and the per-transition material/light/NPC rebuilds remain — those need the larger persistent-player-reparent approach.

## Verification
- **Unit (new):** `test_player_anim_library_cache` locks the contract — shared static store across instances, a hit returns the identical resource (reused, not rebuilt), distinct GLBs are distinct keys.
- **Full suite:** `godot --headless … test_runner.tscn` → **2278 passed, 0 failed**, no parse errors, no warnings-as-errors.
- **Complexity gate:** `code_graph.py --check` → complex 63 (0 new); the function split introduced no new hotspot, no baseline change.
- **No runtime mutation** of the shared animations (verified).
- **Integration layer:** the autopilot city→field matrix (and a Mac playthrough) exercises actual animation playback + the build→reuse path — that's your pull-and-test step. A quick way to see it: run `dev mode with transcription`, walk the same Dairon loop, and the log should show one `Built` then `Reused` on each following area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)