### PR TITLE
texture_fix_shader: render double-sided (cull_disabled) (#537)

### DIFF
--- a/scripts/3d/field/texture_fix_shader.gdshader
+++ b/scripts/3d/field/texture_fix_shader.gdshader
@@ -1,5 +1,10 @@
 shader_type spatial;
-render_mode cull_back, vertex_lighting;
+// cull_disabled: the stage materials this shader replaces are authored
+// double-sided (glTF doubleSided → CULL_DISABLED), so culling back faces here
+// dropped the far side of double-sided geometry — e.g. the back of the Dairon
+// quest counter read as "missing triangles" (#537). Matches every sibling fix
+// shader (waterfall, uv_dressing, mirror_repeat_alpha), which are all cull_disabled.
+render_mode cull_disabled, vertex_lighting;
 
 uniform sampler2D albedo_texture : source_color, filter_linear_mipmap, repeat_enable;
 uniform vec4 albedo_color : source_color = vec4(1.0);

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -177,6 +177,7 @@ func _run_tests_systems() -> void:
 	test_minimap_enemy_markers()
 	test_script_parse()
 	test_autoloads_avoid_packonly_classscope_preloads()
+	test_texture_fix_shader_double_sided()
 
 
 func assert_true(condition: bool, label: String) -> void:
@@ -8314,6 +8315,24 @@ func test_autoloads_avoid_packonly_classscope_preloads() -> void:
 		for v in violations:
 			print("  FAIL: %s — resolves only from the .pck, but autoloads boot before bootstrap mounts it" % v)
 		_fail += violations.size()
+
+
+# ── Texture-fix shader stays double-sided (#537) ──
+# city_area_base._fix_materials_recursive swaps mirror-wrapped stage surfaces to
+# texture_fix_shader. Those source materials are authored double-sided (glTF
+# doubleSided → CULL_DISABLED), so the shader must not re-cull back faces — that
+# dropped the far side of double-sided geometry (the Dairon counter's back read
+# as "missing triangles"). Every sibling fix shader is cull_disabled; guard it.
+func test_texture_fix_shader_double_sided() -> void:
+	print("── Texture-Fix Shader Cull Mode ──")
+	var shader: Shader = load("res://scripts/3d/field/texture_fix_shader.gdshader")
+	assert_true(shader != null, "texture_fix_shader loads")
+	var code: String = shader.code if shader else ""
+	assert_true("cull_disabled" in code,
+		"texture_fix_shader renders double-sided (cull_disabled) so back faces survive (#537)")
+	assert_true(not ("cull_back" in code),
+		"texture_fix_shader no longer force-culls back faces")
+	print("")
 
 
 # res:// script paths of the project's autoloads (project.godot [autoload]).


### PR DESCRIPTION
Closes #537.

## Problem
`city_area_base._fix_materials_recursive` swaps mirror-wrapped stage surfaces to `scripts/3d/field/texture_fix_shader.gdshader`. Those source stage materials are authored **double-sided** (glTF `doubleSided` → `CULL_DISABLED`), but the shader hard-coded `render_mode cull_back` — re-enabling backface culling and dropping the far side of double-sided geometry.

That's the **"missing triangles/polygons" on the back of the Dairon quest counter** (#537) — and because the shader is applied to every mirror-wrapped surface, it was a **game-wide** regression, not a counter-only asset problem. (This is why the reporter's Blender/freelancer instinct wasn't needed — the geometry was fine; the shader was culling it.)

## Fix
One line: `cull_back` → `cull_disabled`. The whole sibling family of fix-shaders already renders double-sided —

| shader | render_mode |
|---|---|
| waterfall_shader | `cull_disabled` |
| uv_dressing | `cull_disabled` |
| mirror_repeat_alpha | `cull_disabled` |
| title_ground | `cull_disabled` |
| **texture_fix_shader** | ~~`cull_back`~~ → `cull_disabled` |

`texture_fix_shader` was the lone outlier. This matches it to both the source materials and the rest of the family. The non-shader fallback path in `_fix_materials_recursive` already preserves cull mode (it `duplicate()`s the `StandardMaterial3D`), so only this shader path was wrong.

No geometry or asset-pack change — purely the shader render mode, so no republish.

## Verification
- **Unit (new):** `test_texture_fix_shader_double_sided` loads the shader and asserts `cull_disabled` present / `cull_back` absent — a regression guard tied to #537.
- **Full suite:** 2277 passed, 0 failed; complexity + check-asset-refs gates green.
- **Visual (your Mac step):** the definitive check is eyes-on — walk behind the Dairon quest counter and confirm the back faces now render. A quick way: `dev mode with transcription`, visit the counter, and it should read solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)