### PR TITLE
Item shop NPC: revert to the low-poly PSZ model (#535)

### DIFF
--- a/scripts/3d/city/city_market_controller.gd
+++ b/scripts/3d/city/city_market_controller.gd
@@ -33,22 +33,19 @@ func _ready() -> void:
 	_add_floor_collision(Vector3(0, 0, 40), Vector3(50, 0.2, 70))
 
 	# NPCs
+	# Low-poly PSZ shopkeeper. Reverted from the VRM-derived item_shop.glb
+	# (#535): the VRM model stuck out as the lone high-poly figure next to the
+	# low-poly cast — better to keep the roster consistent until every NPC can
+	# be upgraded together. The high-poly asset + VRM anims (assets/npcs/
+	# item_shop/, npc_idles_vrm.glb) stay in the repo for that future pass.
+	# pso_f_sh_stand is the original PSZ shopkeeper idle; the VRM-only vrm_idle/
+	# vrm_bow clips don't retarget onto the PSZ skeleton, so they're dropped.
 	_add_npc(
 		"ShopNPC", Vector3(-10.34, 0, 27.67), 1.4207,
-		"res://assets/npcs/item_shop/item_shop.glb",
+		"res://assets/npcs/np_003_00_0/np_003_00_0.glb",
 		"Item Shop",
 		"res://scenes/2d/shops/item_shop.tscn",
-		# VRM-targeted retargeted idle. See web/scripts/bake-retarget-vrm.mjs
-		# and assets/player/animations/npc_idles_vrm.glb.
-		# Idle: Blender-authored breathing motion (item_shop_anims.glb).
-		# Geometric, looks natural; doesn't rely on PSO retargeting.
-		"vrm_idle",
-		"",                          # no hat
-		# Interact response: Blender-authored 3s bow (vrm_bow). Was
-		# vrma_greeting before but that's a 7.27s bend+stand+wave —
-		# too long for a quick interaction beat; the player walks into
-		# the shop UI a couple seconds in and never sees the wave.
-		"vrm_bow",
+		"pso_f_sh_stand",
 	)
 	_add_npc(
 		"WeaponShopNPC", Vector3(-6.78, 0, 21.81), 0.7835,


### PR DESCRIPTION
Closes #535.

## Why
The item-shop NPC was swapped to a VRM-derived model (`assets/npcs/item_shop/item_shop.glb`, ~7.7 MB) in b32c16b5. In the city it reads as the **lone high-poly figure** beside the low-poly cast — every other city NPC (weapon/grind shop, counter) is a ~16 KB PSZ model. One odd-one-out looks worse than a consistent low-poly roster, so revert until the whole roster can be upgraded together.

## Change
One `_add_npc` call in `city_market_controller.gd`:
- model `item_shop.glb` → `np_003_00_0/np_003_00_0.glb` (the original low-poly shopkeeper, still in the pack)
- idle → `pso_f_sh_stand` (the original PSZ shopkeeper idle)
- drop the VRM-only `vrm_idle` / `vrm_bow` clips — they don't retarget onto the PSZ skeleton anyway

Display name ("Item Shop") and shop target scene are unchanged. The high-poly asset + VRM anims stay in the repo (`assets/npcs/item_shop/`, `npc_idles_vrm.glb`) for the future roster-wide upgrade pass.

## Verification
- No pack change — `np_003_00_0.glb` is already in `asset_tree.txt`; `check-asset-refs` resolves all 298 refs.
- Full suite 2278 passed, 0 failed; complexity gate green.
- Visual (your Mac step): the item-shop keeper should now match the other shopkeepers' style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)