### PR TITLE
Transitions: settle the new scene before fading in (#530)

### DIFF
--- a/scripts/autoloads/scene_manager.gd
+++ b/scripts/autoloads/scene_manager.gd
@@ -4,6 +4,13 @@ extends Node
 
 signal scene_changed(scene_path: String)
 
+## Transition settle timing (#530). change_scene_to_file() is deferred, so the
+## swap + the new scene's _ready run on a later frame; fading in too early
+## revealed the new scene's blank first frame. Wait (up to a cap) for the swap
+## to apply, then a few settled frames, before fading back in.
+const MAX_SWAP_WAIT_FRAMES := 30
+const SETTLE_FRAMES := 3
+
 var _scene_stack: Array[String] = []
 var _transition_data: Dictionary = {}
 var _transitioning: bool = false
@@ -178,12 +185,26 @@ func _fade_to_scene(scene_path: String) -> void:
 	tween.tween_property(_fade_rect, "color:a", 1.0, 0.15)
 	await tween.finished
 
-	# Change scene
+	# Change scene. change_scene_to_file() is DEFERRED: the swap + the new
+	# scene's _ready (player rig, interior lights, material fixes) run on the
+	# next idle frame, and that scene's first rendered frame can briefly show
+	# Godot's default/blank environment before its WorldEnvironment + lights
+	# settle. Fading in after a single frame (as before) revealed that flash (#530).
+	var prev_scene := get_tree().current_scene
 	get_tree().change_scene_to_file(scene_path)
 	scene_changed.emit(scene_path)
 
+	# Hold black until the deferred swap has actually applied (current_scene is
+	# no longer the old one), capped so a failed swap can't hang the transition…
+	var guard := 0
+	while get_tree().current_scene == prev_scene and guard < MAX_SWAP_WAIT_FRAMES:
+		await get_tree().process_frame
+		guard += 1
+	# …then let the new scene render a few settled frames before fading in.
+	for _i in range(SETTLE_FRAMES):
+		await get_tree().process_frame
+
 	# Fade in
-	await get_tree().process_frame
 	var tween2 := create_tween()
 	tween2.tween_property(_fade_rect, "color:a", 0.0, 0.15)
 	await tween2.finished

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -95,6 +95,7 @@ func _run_tests_core() -> void:
 	test_start_menu_data()
 	test_start_menu_palette_bg_cached()
 	test_scene_manager_fade_rect_full_size()
+	test_scene_manager_transition_settles()
 	test_hud_stats_persistent_panel()
 	test_ranger_playthrough()
 	test_technique_disks()
@@ -3178,6 +3179,25 @@ func test_scene_manager_fade_rect_full_size() -> void:
 	assert_true(fr.size.x > 0.0 and fr.size.y > 0.0, "fade rect has non-zero size (not 0,0)")
 	var vp: Vector2 = SceneManager.get_viewport().get_visible_rect().size
 	assert_true(fr.size.is_equal_approx(vp), "fade rect covers the full viewport (%s == %s)" % [fr.size, vp])
+	print("")
+
+
+# ── Transition settles before fading in (#530) ──
+# change_scene_to_file() is deferred, so the swap + the new scene's _ready run
+# on a later frame. Fading in after a single process_frame revealed the new
+# scene's blank first frame (default environment before its WorldEnvironment +
+# lights settle). The fix holds black for SETTLE_FRAMES rendered frames after
+# the swap applies. Guard the invariant statically — the async timing itself is
+# exercised by the autopilot city→field matrix — so the flash can't silently
+# return and a failed swap can't hang the transition.
+func test_scene_manager_transition_settles() -> void:
+	print("── SceneManager transition settle (#530) ──")
+	var sm: GDScript = load("res://scripts/autoloads/scene_manager.gd")
+	var consts: Dictionary = sm.get_script_constant_map()
+	assert_true(int(consts.get("SETTLE_FRAMES", 0)) >= 1,
+		"transition waits >=1 settled frame before fading in (no blank flash, #530)")
+	assert_true(int(consts.get("MAX_SWAP_WAIT_FRAMES", 0)) > 0,
+		"deferred-swap wait is capped so a failed swap can't hang the transition")
 	print("")
 
 


### PR DESCRIPTION
Closes #530.

## Problem
Moving between city areas (market → counter, office → counter) briefly flashed a blank/black "Godot atmosphere" frame — jarring. The fade-to-black already masks the swap, but `_fade_to_scene` faded back **in** after a single `await get_tree().process_frame`. `change_scene_to_file()` is **deferred**, so that one frame can land on the new scene's very first rendered frame — before its `WorldEnvironment` + interior lights settle — and the 0.15s fade-in reveals it.

## Fix
Hold black through the settle:
1. Wait until the deferred swap has actually applied (`current_scene` changed), capped at `MAX_SWAP_WAIT_FRAMES` so a failed swap can't hang the transition.
2. Then wait `SETTLE_FRAMES` (3) rendered frames so the environment + lights are up before fading in.

Adds ~3 frames of black — imperceptible next to the swap stall itself — and the blank flash is gone. Contained entirely to `scene_manager.gd`.

Pairs with #531 (the player-rig cache, [#542](https://github.com/kion-dgl/psz-godot/pull/542)) which shrinks the synchronous per-transition stall; this hides what remains.

## Verification
- **Unit (new):** `test_scene_manager_transition_settles` guards `SETTLE_FRAMES >= 1` (so the flash can't silently return) and the swap-wait cap.
- **Full suite:** 2280 passed, 0 failed; complexity + asset gates green.
- **Integration:** the autopilot city→field matrix drives real transitions through this path (a hang would time it out) — your matrix/Mac run.
- **Visual (your Mac step):** transitions should fade cleanly with no blank frame — easy to spot via `dev mode with transcription` walking the Dairon loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)