### PR TITLE
Fix stair-descent jitter: camera + player vertical smoothing (#538)

### DIFF
--- a/scripts/3d/camera/orbit_camera.gd
+++ b/scripts/3d/camera/orbit_camera.gd
@@ -33,6 +33,16 @@ var _mouse_dragging := false
 # Set false to pause camera rotation (e.g. gate nudge mode)
 var input_enabled := true
 
+# Vertical follow smoothing (#538). The player's Y picks up a per-step sawtooth
+# descending stairs (no step-down snap, so it walks off each edge and re-grounds);
+# hard-assigning the camera Y every frame passed that 1:1 into the view as shake.
+# Damp ONLY the follow Y — horizontal orbit stays instant — and snap on a large
+# jump so the camera doesn't slide across a warp/respawn.
+const CAM_Y_SMOOTH_TAU: float = 0.12   # seconds; larger = smoother but laggier
+const CAM_Y_SNAP_DIST: float = 3.0     # gap beyond which we snap instead of damp
+var _follow_y: float = 0.0
+var _follow_y_valid: bool = false
+
 # Node references
 @onready var camera: Camera3D = $Camera3D
 
@@ -46,10 +56,10 @@ func _ready() -> void:
 	camera.set_as_top_level(true)
 
 	if target:
-		_update_camera_position()
+		_update_camera_position(0.0)
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
 	if input_enabled and not PsoStartMenu.is_open():
 		var dir: float = 1.0 if InputConfig.invert_camera_x else -1.0
 		if Input.is_action_pressed("camera_left"):
@@ -68,7 +78,7 @@ func _process(_delta: float) -> void:
 			_center_behind_player()
 
 	if target and camera:
-		_update_camera_position()
+		_update_camera_position(delta)
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -86,12 +96,22 @@ func _unhandled_input(event: InputEvent) -> void:
 		camera_rotation += motion.relative.x * mouse_sensitivity
 
 
-func _update_camera_position() -> void:
+func _update_camera_position(delta: float) -> void:
 	if not target:
 		return
 
 	var target_pos := target.global_position
-	var look_at_pos := Vector3(target_pos.x, target_pos.y + 1.0, target_pos.z)
+
+	# Damp only the vertical follow (#538): absorbs the stair-descent Y sawtooth
+	# so it doesn't shake the view, while x/z track the player instantly. First
+	# frame (and large jumps, via the helper) snap so there's no startup slide.
+	if not _follow_y_valid:
+		_follow_y = target_pos.y
+		_follow_y_valid = true
+	else:
+		_follow_y = _damp_follow_y(_follow_y, target_pos.y, delta)
+
+	var look_at_pos := Vector3(target_pos.x, _follow_y + 1.0, target_pos.z)
 
 	# Sphere-orbit: derive a single radius + base pitch from the
 	# exported `distance`/`height` so pitch=0 reproduces the original
@@ -110,12 +130,21 @@ func _update_camera_position() -> void:
 
 	var cam_pos := Vector3(
 		target_pos.x + sin(camera_rotation) * horiz,
-		target_pos.y + vert,
+		_follow_y + vert,
 		target_pos.z + cos(camera_rotation) * horiz,
 	)
 
 	camera.global_position = cam_pos
 	camera.look_at(look_at_pos)
+
+
+## Frame-rate-independent exponential damping of the follow Y toward target_y.
+## Snaps (returns target_y) when delta is non-positive or the gap exceeds
+## CAM_Y_SNAP_DIST, so a warp/respawn doesn't slide and a settled frame is exact.
+static func _damp_follow_y(current: float, target_y: float, delta: float) -> float:
+	if delta <= 0.0 or absf(target_y - current) > CAM_Y_SNAP_DIST:
+		return target_y
+	return lerp(current, target_y, 1.0 - exp(-delta / CAM_Y_SMOOTH_TAU))
 
 
 func _center_behind_player() -> void:

--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -20,6 +20,15 @@ var fall_respawn_y: float = -10.0
 # Spawn tracking
 var spawn_position: Vector3 = Vector3.ZERO
 
+# Visual Y smoothing for the model mesh (#538). The collision capsule snaps
+# discretely down each stair step; damping the *mesh* Y toward the body turns
+# those per-step pops into a smooth glide. Physics/collision is untouched — only
+# the visible model lags. Snaps on a large drop (a real fall) so it never floats.
+const MODEL_Y_SMOOTH_TAU: float = 0.07
+const MODEL_Y_SNAP_DIST: float = 0.9
+var _model_world_y: float = 0.0
+var _model_y_valid: bool = false
+
 # Player state machine
 enum PlayerState {
 	IDLE,
@@ -888,6 +897,14 @@ func _cache_model_materials() -> void:
 					_cached_materials.append(mat)
 
 
+func _process(delta: float) -> void:
+	# Smooth the model's vertical position at RENDER rate (not the 60 Hz physics
+	# tick) so stair-descent stepping is gone on high-refresh displays too — the
+	# same reason the orbit camera smooths in _process (#538).
+	if model:
+		_smooth_model_y(delta)
+
+
 func _physics_process(delta: float) -> void:
 	FrameProfiler.mark("player_start")
 	# Check for fall and respawn
@@ -895,8 +912,17 @@ func _physics_process(delta: float) -> void:
 		_respawn()
 		return
 
-	# Apply gravity
-	if not is_on_floor():
+	# Gravity, and a grounded vertical settle. While on the floor, clear any
+	# residual DOWNWARD velocity: descending stairs the capsule briefly leaves
+	# each step edge, gravity accumulates velocity.y, and (since it was never
+	# reset on re-grounding) that downward speed compounds and fights the floor
+	# snap every step — the character jerks down each riser (#538). Zeroing it
+	# lets floor_snap_length ride the body down each step smoothly. Only downward
+	# motion is cleared, so nothing that launches the player upward is stomped.
+	if is_on_floor():
+		if velocity.y < 0.0:
+			velocity.y = 0.0
+	else:
 		velocity.y -= GRAVITY * delta
 
 	# Handle state-specific logic
@@ -923,7 +949,7 @@ func _physics_process(delta: float) -> void:
 	# place. See the s03a_ib2 plank case in static_in_the_snow.
 	_apply_step_up()
 
-	# Update model rotation
+	# Update model rotation (vertical smoothing runs in _process, at render rate)
 	if model:
 		model.rotation.y = player_rotation
 
@@ -1218,6 +1244,29 @@ func _has_floor_at(check_pos: Vector3) -> bool:
 
 	var result := space_state.intersect_ray(query)
 	return not result.is_empty()
+
+
+# Damp the visible model's Y toward the physics body so the discrete per-step
+# floor snaps descending stairs (#538) glide instead of popping. Only the mesh is
+# offset (model is a child of the body); the collision capsule is unaffected.
+# Snaps on a large gap (a real fall) so the mesh never floats away from the body.
+func _smooth_model_y(delta: float) -> void:
+	var body_y := global_position.y
+	if not _model_y_valid:
+		_model_world_y = body_y
+		_model_y_valid = true
+	else:
+		_model_world_y = _damp_scalar(_model_world_y, body_y, MODEL_Y_SMOOTH_TAU, MODEL_Y_SNAP_DIST, delta)
+	model.position.y = _model_world_y - body_y
+
+
+## Frame-rate-independent exponential damping of a scalar toward target. Snaps
+## (returns target) on non-positive delta or a gap beyond snap_dist, so a real
+## fall / teleport tracks instantly instead of floating. Pure — unit-testable.
+static func _damp_scalar(current: float, target: float, tau: float, snap_dist: float, delta: float) -> float:
+	if delta <= 0.0 or absf(target - current) > snap_dist:
+		return target
+	return lerp(current, target, 1.0 - exp(-delta / tau))
 
 
 # After move_and_slide: if we hit a wall while trying to move horizontally and

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -179,6 +179,7 @@ func _run_tests_systems() -> void:
 	test_minimap_enemy_markers()
 	test_script_parse()
 	test_autoloads_avoid_packonly_classscope_preloads()
+	test_orbit_camera_follow_y_damping()
 
 
 func assert_true(condition: bool, label: String) -> void:
@@ -8375,6 +8376,32 @@ func test_autoloads_avoid_packonly_classscope_preloads() -> void:
 		for v in violations:
 			print("  FAIL: %s — resolves only from the .pck, but autoloads boot before bootstrap mounts it" % v)
 		_fail += violations.size()
+
+
+# ── Orbit camera vertical follow damping (#538) ──
+# The camera hard-assigned its Y from the player every frame, so the per-step Y
+# sawtooth from descending stairs shook the view. _damp_follow_y damps only the
+# follow Y (frame-rate independent) and snaps on a large jump so warps don't
+# slide. The visual result is verified in-game; this locks the damping contract.
+func test_orbit_camera_follow_y_damping() -> void:
+	print("── Orbit Camera Y Damping ──")
+	const OrbitCam := preload("res://scripts/3d/camera/orbit_camera.gd")
+	# delta<=0 (init / settled frame) snaps exactly to target.
+	assert_eq(OrbitCam._damp_follow_y(0.0, 2.0, 0.0), 2.0, "delta<=0 snaps to target")
+	# A large gap (warp / respawn) snaps so the camera doesn't slide across it.
+	assert_eq(OrbitCam._damp_follow_y(0.0, 10.0, 0.016), 10.0, "gap > CAM_Y_SNAP_DIST snaps to target")
+	# A small step damps only partway in one frame — that's what absorbs the sawtooth.
+	var one_frame: float = OrbitCam._damp_follow_y(0.0, 1.0, 0.016)
+	assert_true(one_frame > 0.0 and one_frame < 1.0, "small gap damps partway, not instant (%f)" % one_frame)
+	# Frame-rate independent: a larger delta moves further toward the target.
+	assert_true(OrbitCam._damp_follow_y(0.0, 1.0, 0.1) > OrbitCam._damp_follow_y(0.0, 1.0, 0.016),
+		"larger delta damps further toward target")
+	# Repeated frames converge on the target (no permanent offset).
+	var y: float = 0.0
+	for _i in range(180):
+		y = OrbitCam._damp_follow_y(y, 1.0, 0.016)
+	assert_true(absf(1.0 - y) < 0.01, "repeated damping converges to target (%f)" % y)
+	print("")
 
 
 # res:// script paths of the project's autoloads (project.godot [autoload]).

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -32,6 +32,7 @@ func _ready() -> void:
 func _run_tests_combat() -> void:
 	test_player_states()
 	test_player_anim_library_cache()
+	test_player_model_y_damping()
 	test_action_commitment()
 	test_combo_three_tier()
 	test_combo_chain_lifecycle()
@@ -705,6 +706,32 @@ func test_player_states() -> void:
 	assert_eq(p._charging_slot, -1, "entering DODGING releases the charge")
 	assert_eq(released, [2], "tech_charge_released fired with the charged slot")
 	p.free()
+	print("")
+
+
+# ── Player model vertical-follow damping (#538) ──
+# The collision capsule snaps discretely down each stair step; _smooth_model_y
+# damps the visible mesh's Y toward the body (via _damp_scalar) so those per-step
+# pops glide, while physics stays exact. Snaps on a real fall so the mesh never
+# floats. Locks the damping contract; the buttery result is verified in-game.
+func test_player_model_y_damping() -> void:
+	print("── Player Model Y Damping ──")
+	const PlayerScript := preload("res://scripts/3d/player/player.gd")
+	# delta<=0 (init / settled frame) snaps exactly to target.
+	assert_eq(PlayerScript._damp_scalar(0.0, 2.0, 0.07, 0.9, 0.0), 2.0, "delta<=0 snaps to target")
+	# A gap beyond snap_dist (a real fall) snaps so the mesh doesn't float.
+	assert_eq(PlayerScript._damp_scalar(0.0, 5.0, 0.07, 0.9, 0.016), 5.0, "gap > snap_dist snaps to target")
+	# A small step (a stair riser) damps only partway in one frame.
+	var one_frame: float = PlayerScript._damp_scalar(0.0, 0.3, 0.07, 0.9, 0.008)
+	assert_true(one_frame > 0.0 and one_frame < 0.3, "small gap damps partway, not instant (%f)" % one_frame)
+	# Frame-rate independent: a larger delta moves further toward target.
+	assert_true(PlayerScript._damp_scalar(0.0, 0.3, 0.07, 0.9, 0.016) > PlayerScript._damp_scalar(0.0, 0.3, 0.07, 0.9, 0.008),
+		"larger delta damps further toward target")
+	# Repeated frames converge on the target (no permanent mesh offset).
+	var y: float = 0.0
+	for _i in range(240):
+		y = PlayerScript._damp_scalar(y, 0.3, 0.07, 0.9, 0.008)
+	assert_true(absf(0.3 - y) < 0.001, "repeated damping converges to target (%f)" % y)
 	print("")
 
 


### PR DESCRIPTION
Closes #538.

Descending the teleporter stairs was jittery (ascent was smooth). Root cause was a per-step vertical sawtooth in the player, made visible in two places. Fixed both; **confirmed "buttery smooth" in a dev-session playtest.**

## 1. Camera — vertical follow damping
`orbit_camera` hard-assigned `camera.global_position` from the player every render frame, so any Y wobble passed 1:1 into the view. Now damps **only** the follow Y (frame-rate-independent, `tau 0.12s`); `x`/`z` stay instant so horizontal orbit is unchanged. Snaps on a large gap so warps/respawns don't slide. Pure static helper `_damp_follow_y`.

## 2. Player — the actual sawtooth
With the camera calm, the character itself jerked down each step: the capsule leaves each step edge, gravity accumulates `velocity.y`, then hard re-grounds.
- **Grounded settle:** zero residual *downward* velocity while `is_on_floor()` so it stops compounding across steps (standard hygiene; only downward motion cleared).
- **Model Y smoothing:** damp the *visible mesh's* Y toward the physics body (`_smooth_model_y` → `_damp_scalar`), run in **`_process` at render rate** — the 60 Hz physics tick left visible stepping on 120 Hz displays. Only the mesh is offset; the collision capsule stays exact. Snaps on a large gap (a real fall) so the mesh never floats.

## Verification
- **Unit:** `test_orbit_camera_follow_y_damping` + `test_player_model_y_damping` — snap cases, partial per-frame damping, frame-rate independence, convergence.
- **Full suite:** 2290 passed, 0 failed; complexity + asset gates green.
- **In-game:** camera confirmed smooth, then character confirmed **buttery smooth** descending the teleporter stairs across four dev-session iterations (`dev-sessions/20260721-07*`). Normal walking + real ledge drops still snap instantly (only stair-sized drops are smoothed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)