### PR TITLE
Fix #469: player damage-immune across the defeat→return-to-city window

### DIFF
--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -164,6 +164,16 @@ var current_state: PlayerState = PlayerState.IDLE
 var player_rotation: float = 0.0
 var walk_timer: float = 0.0
 
+# Defeat immunity (#469, spec /states/player-death). Set true the moment the
+# player is defeated (HP 0 / died emitted); makes take_damage() a hard no-op
+# for the whole defeat window — modal up, "Yes" pressed, and the scene
+# transition back to the city. Decoupled from HP on purpose: the defeat
+# transaction revives to full HP synchronously on Yes-press (SessionManager
+# .defeat_return_to_city), so an HP-coupled guard stops firing while the
+# field Player still lives on for the transition frames. Cleared implicitly
+# by the city spawning a fresh Player (this flag defaults false).
+var _is_defeated: bool = false
+
 # Combo system — three-tier timing (#155, spec /mechanics/combos). Windows
 # are FRACTIONS of the current swing's animation, from per-weapon
 # WeaponComboConfig data. A press in a window QUEUES the next step, which
@@ -1035,6 +1045,10 @@ func _respawn() -> void:
 	player_rotation = 0.0
 	if model:
 		model.rotation.y = 0.0
+	# Defensive: this fall-out-of-world respawn restores the player to a live
+	# IDLE state in place, so clear the defeat immunity too (#469) — a genuine
+	# revive-in-place path, unlike the defeat exit which swaps to a fresh Player.
+	_is_defeated = false
 	transition_to(PlayerState.IDLE)
 
 
@@ -2508,6 +2522,14 @@ func _on_animation_finished(_anim_name: String) -> void:
 
 # Public API for external systems
 func take_damage(damage: int, _knockback: Vector3 = Vector3.ZERO) -> void:
+	# Defeated — hard no-op for the whole defeat window (#469, spec
+	# /states/player-death). Decoupled from HP so it survives the full-HP
+	# revive the defeat transaction applies on "Yes"; the field Player stays
+	# immune through the return-to-city transition. Cleared by the city
+	# spawning a fresh Player.
+	if _is_defeated:
+		return
+
 	# Already dead — ignore further hits
 	if current_state == PlayerState.DOWN and GameState.hp <= 0:
 		return
@@ -2532,8 +2554,10 @@ func take_damage(damage: int, _knockback: Vector3 = Vector3.ZERO) -> void:
 
 	if GameState.hp <= 0:
 		# Death: knockdown into lying-down loop, then raise the defeat screen.
-		# The "already dead" guard at the top of take_damage() makes this fire
-		# exactly once (spec /states/player-death).
+		# Latch the defeat flag so the immune-window guard at the top of
+		# take_damage() makes death fire exactly once AND stays a no-op through
+		# the full-HP revive + return-to-city transition (spec /states/player-death).
+		_is_defeated = true
 		play_animation(_anim_prefix + "_dam_d", false)
 		transition_to(PlayerState.DOWN)
 		died.emit()

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -31,6 +31,7 @@ func _ready() -> void:
 # drops, and the combat-adjacent regression tests.
 func _run_tests_combat() -> void:
 	test_player_states()
+	test_player_defeat_invulnerable()
 	test_player_anim_library_cache()
 	test_player_model_y_damping()
 	test_action_commitment()
@@ -709,6 +710,45 @@ func test_player_states() -> void:
 	assert_eq(p._charging_slot, -1, "entering DODGING releases the charge")
 	assert_eq(released, [2], "tech_charge_released fired with the charged slot")
 	p.free()
+	print("")
+
+
+# ── Defeat damage-immunity (#469, spec /states/player-death) ──
+# Between HP hitting 0 and the return-to-city load completing the field player
+# MUST be damage-immune — take_damage() a hard no-op, no HP change, no further
+# `died`. The immunity is HP-DECOUPLED via the _is_defeated flag: the defeat
+# transaction revives to full HP synchronously on "Yes", so an HP-coupled guard
+# alone (current_state==DOWN and hp<=0) stops firing while the field player
+# lives on for the transition frames — the exact bug this pins. Off-tree
+# instance; take_damage's flag return fires before any tree-dependent call.
+func test_player_defeat_invulnerable() -> void:
+	print("── Player defeat — damage immunity across the return-to-city window (#469) ──")
+	const PlayerScript := preload("res://scripts/3d/player/player.gd")
+	var p = PlayerScript.new()
+
+	# Count `died` emissions so we can assert no re-fire during the immune window.
+	var died_count := [0]
+	p.died.connect(func() -> void: died_count[0] += 1)
+
+	# Defeated: flag latched, HP already at 0 (the state right after death).
+	var full: int = GameState.max_hp
+	p._is_defeated = true
+	GameState.set_hp(0)
+	p.take_damage(25)
+	assert_eq(GameState.hp, 0, "defeated player takes no damage (HP stays 0)")
+	assert_eq(died_count[0], 0, "no further `died` while defeated")
+
+	# THE REGRESSION: the defeat transaction revives to full HP synchronously on
+	# "Yes" (before the scene swaps), so GameState.hp is no longer <= 0. The
+	# HP-coupled guard would now STOP firing — but _is_defeated is still true, so
+	# the still-live field player stays immune through the transition frames.
+	GameState.set_hp(full)
+	p.take_damage(25)
+	assert_eq(GameState.hp, full, "post-revive, still-defeated player is immune (HP unchanged) — the #469 window")
+	assert_eq(died_count[0], 0, "no `died` re-fire after the revive while defeated")
+
+	p.free()
+	GameState.set_hp(full)
 	print("")
 
 

--- a/spec/src/pages/states/player-death.astro
+++ b/spec/src/pages/states/player-death.astro
@@ -42,6 +42,29 @@ const chart = `stateDiagram-v2
     animation.</li>
   </ul>
 
+  <h2>Damage immunity during the defeat window</h2>
+  <ul>
+    <li>From the moment the player is defeated — HP reaches <strong>0</strong>
+    and <code>died</code> is emitted — through the return-to-city transition
+    <em>completing</em>, the player <strong>MUST</strong> be
+    <strong>damage-immune</strong>. This covers the entire window: the
+    knockdown, the red overlay and "You were defeated" prompt, the moment
+    <strong>Yes</strong> is pressed, and every frame of the scene transition
+    until the city has loaded a fresh player.</li>
+    <li>While immune, <code>take_damage()</code> <strong>MUST</strong> be a
+    no-op: no HP or PP change <strong>MUST</strong> occur, no hit reaction or
+    knockdown <strong>MUST</strong> play, and <code>died</code>
+    <strong>MUST NOT</strong> be emitted again. The player's hurtbox
+    <strong>MUST NOT</strong> register further hits from any source (enemy
+    melee, projectiles, techniques).</li>
+    <li>Immunity <strong>MUST NOT</strong> be coupled to current HP. The defeat
+    transaction revives the player to full HP <em>synchronously</em> when
+    <strong>Yes</strong> is pressed, before the scene swaps — so an
+    HP-based guard alone would stop firing while the still-live field player
+    remains hittable for the transition frames. Immunity <strong>MUST</strong>
+    persist across that full-HP revive.</li>
+  </ul>
+
   <h2>The defeat screen</h2>
   <ul>
     <li>On defeat a translucent <strong>red</strong> overlay <strong>MUST</strong>
@@ -109,7 +132,10 @@ const chart = `stateDiagram-v2
   <ul>
     <li><code>scripts/3d/player/player.gd</code> (Player) — emits
     <code>died</code> when <code>take_damage()</code> drives HP to 0; the
-    field controller listens for it.</li>
+    field controller listens for it. The <code>_is_defeated</code> flag is
+    latched on that death branch and gates the top of <code>take_damage()</code>
+    to a no-op for the whole defeat window, enforcing the damage-immunity
+    contract above (HP-decoupled, survives the full-HP revive).</li>
     <li><code>scripts/3d/ui/defeat_screen.gd</code> (DefeatScreen) — the red
     overlay + "You were defeated" prompt (Yes/No), mounted below the HUD. On
     <strong>Yes</strong> it runs the defeat transaction and routes to the city


### PR DESCRIPTION
Closes #469.

## Why
On defeat, the player could still take damage between pressing **Yes** and the city load completing — enemies kept landing real hits on an already-defeated player during the transition. From the [playtest report](https://psz.onl/reports/2026-07-03T04-06-31-684Z-ee41cccb): *"When you are already dead and press Yes to respawn back to Dairon City, you can still take damage as you are respawning."*

Root cause is an **ordering bug**. The only "already dead" guard in `Player.take_damage()` was HP-coupled:

```gdscript
if current_state == PlayerState.DOWN and GameState.hp <= 0:
    return
```

But `SessionManager.defeat_return_to_city()` revives the player to **full HP synchronously** the instant "Yes" is pressed — *before* the scene swaps. That flips `GameState.hp <= 0` back to false, so the guard stops firing while the still-live field `Player` (state still `DOWN`) lives on for the transition frames. `take_damage()` is the universal damage choke point (enemy melee, projectiles, techs all funnel through it), so those transition-frame hits register as real damage.

## The fix
Decouple immunity from HP with a per-instance `_is_defeated` flag:
- Latched `true` on the death branch of `take_damage()` (the branch that drives HP to 0 and emits `died`).
- Checked as a hard no-op at the **very top** of `take_damage()` (augments, does not replace, the existing HP-coupled guard).

Because it isn't tied to HP, it survives the full-HP revive and stays immune through the whole defeat window (modal up, Yes pressed, scene transition). Clearing is implicit: `DefeatScreen.confirm_return()` does a full scene swap to the city counter — the field Player is freed and the city spawns a fresh Player (`_is_defeated` defaults false); the city has no combat. A defensive `_is_defeated = false` also lives on the `_respawn()` fall-out-of-world in-place revive path.

Orthogonal to the DefeatScreen modal_stack and the #413 meseta transaction — neither is touched.

## Spec
`spec/src/pages/states/player-death.astro` gains a normative **RFC-2119 damage-immunity clause**: from the moment of defeat (HP 0 / `died` emitted) through the return-to-city transition completing, the player MUST be damage-immune — `take_damage()` MUST be a no-op (no HP/PP change, no re-`died`), and immunity MUST NOT be coupled to HP (it must survive the full-HP revive). `_is_defeated` + the `take_damage` gate are added to "Implemented by".

## Tests
- **Unit (this PR):** `test_player_defeat_invulnerable()` in `test_runner.gd` mirrors the dodge-i-frame template — off-tree `PlayerScript.new()`, sets `_is_defeated`, asserts `GameState.hp` unchanged and zero `died` re-fires. Crucially it reproduces the ordering bug directly: revive to full HP with `_is_defeated` still true → `take_damage(25)` is still a no-op (the exact regression). Full suite green: `RESULTS: 2314 passed, 0 failed`, zero warnings-as-errors (#291 gate clean).
- **Autopilot (coordinator):** the two-layer `PSZ_AUTOPILOT_DEFEAT` / `record_defeat.sh` probe — extended to fire a hit during the post-Yes transition — will be run by the coordinator; not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)