### PR TITLE
Fix companion run/walk animation flap with a hysteresis band (#463)

### DIFF
--- a/scripts/3d/elements/companion_combat.gd
+++ b/scripts/3d/elements/companion_combat.gd
@@ -69,6 +69,20 @@ static func locomotion_clip(intent_moving: bool, planar_speed: float, current_cl
 	return "run" if planar_speed > RUN_ENTER else "walk"
 
 
+## Commanded FOLLOW speed (spec /states/companion): the companion holds `ring`
+## metres behind the player, and its speed is a CONTINUOUS ramp of how far it sits
+## OUTSIDE that ring — 0 at/inside the ring, climbing linearly over `ramp` metres to
+## `cap`. Continuity is the whole point: fed through locomotion_clip, this eases the
+## gait wait→walk→run and back with no dead zone and no flap (the run/walk swing the
+## old measured-displacement path produced when the companion caught up and stalled).
+## `cap` is set just above player run so the trailing gap holds instead of growing.
+## Pure — test_runner pins the ramp off-tree.
+static func follow_speed(distance: float, ring: float, ramp: float, cap: float) -> float:
+	if ramp <= 0.0:
+		return cap if distance > ring else 0.0
+	return cap * clampf((distance - ring) / ramp, 0.0, 1.0)
+
+
 ## True when pos is within LEASH_RADIUS (XZ) of the player.
 static func within_leash(pos: Vector3, player_pos: Vector3) -> bool:
 	return Vector2(pos.x - player_pos.x, pos.z - player_pos.z).length() <= LEASH_RADIUS

--- a/scripts/3d/elements/companion_combat.gd
+++ b/scripts/3d/elements/companion_combat.gd
@@ -30,9 +30,14 @@ const COMPANION_WEAPON_TYPES: Dictionary = {
 
 ## Locomotion clip thresholds (m/s of the companion's OWN measured planar
 ## speed). The pure selector below and companion_npc's tripwire share them so
-## there is a single source (spec /states/companion).
-const IDLE_EPS: float = 0.15  # below this the companion plays "wait"
-const RUN_EPS: float = 4.0    # above this the companion plays "run"
+## there is a single source (spec /states/companion). RUN_ENTER/RUN_EXIT form a
+## hysteresis band: measured speed is a noisy per-frame displacement, so a single
+## run/walk threshold flaps the clip when it hovers there (#463). The 1 m/s
+## deadband against the ~6 m/s steady follow speed is the one value worth
+## confirming on-device.
+const IDLE_EPS: float = 0.15   # below this the companion plays "wait"
+const RUN_ENTER: float = 4.0   # walk→run only when measured speed climbs ABOVE this
+const RUN_EXIT: float = 3.0    # run→walk only when measured speed drops BELOW this
 
 
 static func weapon_type_for(companion_id: String) -> int:
@@ -44,12 +49,24 @@ static func weapon_type_for(companion_id: String) -> int:
 ## /states/companion-combat). intent_moving=false always yields "wait"; and even
 ## when the FSM intends to move, a measured planar speed below IDLE_EPS still
 ## yields "wait" — the #420 veto, so a body pinned by geometry or the personal-
-## space cap never plays a locomotion clip while standing still. Above RUN_EPS
-## is "run", between is "walk". Pure so test_runner pins it off-tree.
-static func locomotion_clip(intent_moving: bool, planar_speed: float) -> String:
+## space cap never plays a locomotion clip while standing still.
+##
+## The walk↔run split uses a hysteresis band (#463): measured planar_speed is a
+## noisy per-frame displacement, and a single threshold makes it flap when it
+## hovers there. So the caller threads in current_clip (the clip playing now):
+## enter "run" only ABOVE RUN_ENTER, drop back to "walk" only BELOW RUN_EXIT, and
+## in the RUN_EXIT..RUN_ENTER band HOLD the current clip. Coming out of "wait"
+## (or any non-"run" clip) uses the enter threshold, so a body that is genuinely
+## moving picks walk/run sensibly. Pure so test_runner pins it off-tree.
+static func locomotion_clip(intent_moving: bool, planar_speed: float, current_clip: String) -> String:
 	if not intent_moving or planar_speed < IDLE_EPS:
 		return "wait"
-	return "run" if planar_speed > RUN_EPS else "walk"
+	if current_clip == "run":
+		# Already running: hold "run" through the deadband; only a clear drop
+		# below RUN_EXIT falls back to "walk".
+		return "walk" if planar_speed < RUN_EXIT else "run"
+	# walk / wait / anything else: only a clear climb above RUN_ENTER enters "run".
+	return "run" if planar_speed > RUN_ENTER else "walk"
 
 
 ## True when pos is within LEASH_RADIUS (XZ) of the player.

--- a/scripts/3d/elements/companion_npc.gd
+++ b/scripts/3d/elements/companion_npc.gd
@@ -12,6 +12,16 @@ const STOP_DISTANCE: float = 1.8
 const START_DISTANCE: float = 3.0  # Must exceed START to begin moving (hysteresis)
 const CATCHUP_DISTANCE: float = 5.0
 const TELEPORT_DISTANCE: float = 20.0
+# Arrival-follow tuning (spec /states/companion). The companion holds ~FOLLOW_DISTANCE
+# behind the player; its speed is a smooth function of how far OUTSIDE that ring it is
+# — zero at the ring, ramping up over FOLLOW_SLOW_RADIUS to FOLLOW_MAX_SPEED (just
+# above player run 6.0, so it keeps pace without the gap growing). Because commanded
+# speed is CONTINUOUS in distance, the gait eases run -> walk -> wait (a real walk) and
+# never flaps. The clip is driven by this commanded speed, not noisy per-frame
+# displacement. All three are feel knobs.
+const FOLLOW_MAX_SPEED: float = 6.5
+const FOLLOW_SLOW_RADIUS: float = 1.5
+const FOLLOW_DISTANCE: float = 2.5
 
 ## Fallback colors for NPCs without GLB models
 const COMPANION_COLORS: Dictionary = {
@@ -85,14 +95,12 @@ var _move_intent: bool = false  # Set true by whichever state is steering this f
 
 var _was_moving: bool = false  # Track delayed state transitions
 var _stationary_anim_time: float = 0.0  # autopilot tripwire accumulator (#420)
-var _resume_blend: float = 0.0  # Blend from frozen pos to trail pos on resume
-var _frozen_pos: Vector3 = Vector3.ZERO  # Position when companion froze
-const RESUME_BLEND_SPEED: float = 3.0  # Seconds to fully blend back to trail
+var _follow_cmd_speed: float = -1.0  # FOLLOW's commanded speed this frame; drives the clip (< 0 = not FOLLOW)
 var _dismissed: bool = false  # When true, stop following and idle in place
 
 ## Trail replay — record every physics frame, interpolate on playback
 var _trail: Array = []  # [{pos: Vector3, rot: float, state: int, time: float}]
-const TRAIL_DELAY: float = 0.5  # Seconds behind the player
+const TRAIL_DELAY: float = 0.3  # Seconds behind the player (tighter = less lag)
 const TRAIL_MAX_ENTRIES: int = 150  # ~2.5s at 60fps
 
 ## Combat FSM (spec /states/companion-combat). FOLLOW is the trail-replay
@@ -475,6 +483,7 @@ func _physics_process(delta: float) -> void:
 	# below — like the player's single per-frame animation update.
 	var prev_pos: Vector3 = global_position
 	_move_intent = false
+	_follow_cmd_speed = -1.0
 	if _combat_state == CombatState.FOLLOW:
 		_process_follow(delta)
 		_tick_combat_scan(delta)
@@ -489,7 +498,16 @@ func _physics_process(delta: float) -> void:
 func _update_locomotion_anim(intent_moving: bool, prev_pos: Vector3, delta: float) -> void:
 	if _swing_elapsed >= 0.0:
 		return
-	var clip: String = _select_locomotion_anim(prev_pos, global_position, delta) if intent_moving else "wait"
+	# FOLLOW drives the clip from its commanded speed (smooth arrival ramp) so the
+	# gait can't flap on noisy per-frame displacement; combat states use measured
+	# displacement. IDLE_EPS still vetoes to "wait" when barely moving.
+	var clip: String
+	if _follow_cmd_speed >= 0.0:
+		clip = CompanionCombat.locomotion_clip(_follow_cmd_speed >= CompanionCombat.IDLE_EPS, _follow_cmd_speed, _current_anim)
+	elif intent_moving:
+		clip = _select_locomotion_anim(prev_pos, global_position, delta)
+	else:
+		clip = "wait"
 	_play_companion_anim(clip)
 	_autopilot_anim_tripwire(prev_pos, global_position, delta)
 
@@ -589,50 +607,31 @@ func _process_follow(_delta: float) -> void:
 
 	var interp_pos: Vector3 = entry_a["pos"].lerp(entry_b["pos"], t)
 	var interp_rot: float = lerp_angle(entry_a["rot"], entry_b["rot"], t)
-	var delayed_state: int = entry_a["state"]
-
-	# Position MAY consult the delayed player state — but ONLY the true
-	# locomotion states (WALKING=1, RUNNING=2) advance the trail. A rooted
-	# player state (ATTACKING=3, DAMAGED, DOWN, …) is >= 1 too, so the old
-	# `delayed_state >= 1` made the companion try to follow a stationary player
-	# and then fall into the `run` branch — running in place (#420). Restrict
-	# the follow-move to actual locomotion.
-	var is_moving: bool = delayed_state == 1 or delayed_state == 2
-
-	if is_moving:
-		# Player was moving — follow the interpolated trail
-		# But cap position so we never get closer than 1.5 units to the player
-		var candidate_pos := Vector3(interp_pos.x, _player_ref.global_position.y, interp_pos.z)
-		var to_player := _player_ref.global_position - candidate_pos
-		to_player.y = 0
-		if to_player.length() < 1.5:
-			var away_dir := -to_player.normalized() if to_player.length() > 0.01 else Vector3(-sin(player_rot), 0, -cos(player_rot))
-			candidate_pos = _player_ref.global_position + away_dir * 1.5
-			candidate_pos.y = _player_ref.global_position.y
-
-		# Smooth blend from frozen position when resuming movement
-		if not _was_moving:
-			_frozen_pos = global_position
-			_resume_blend = 0.0
-		if _resume_blend < 1.0:
-			_resume_blend = minf(_resume_blend + RESUME_BLEND_SPEED * _delta, 1.0)
-			candidate_pos = _frozen_pos.lerp(candidate_pos, _resume_blend)
-
-		global_position = candidate_pos
+	# Head toward the delayed trail point (your route) at a speed set by how far
+	# OUTSIDE the FOLLOW_DISTANCE ring we are — zero at the ring, ramping up over
+	# FOLLOW_SLOW_RADIUS to FOLLOW_MAX_SPEED. `desired` is continuous in distance, so
+	# the gait eases run -> walk -> wait with a real walk and never flaps: no dead
+	# zone, no resume-blend, no hard proximity clamp (those shoved the old measured
+	# speed across the thresholds). The clip is driven by `desired` (set below). A
+	# rooted player (#420) sits at the ring → desired 0 → wait, no run-in-place.
+	var target := Vector3(interp_pos.x, _player_ref.global_position.y, interp_pos.z)
+	var to_target := target - global_position
+	to_target.y = 0.0
+	var gap := to_target.length()
+	var dist_now := global_position.distance_to(_player_ref.global_position)
+	var desired: float = CompanionCombat.follow_speed(dist_now, FOLLOW_DISTANCE, FOLLOW_SLOW_RADIUS, FOLLOW_MAX_SPEED)
+	if desired > 0.001 and gap > 0.001:
+		var step := minf(desired * _delta, gap)
+		global_position += (to_target / gap) * step
 		rotation.y = interp_rot
-		_was_moving = true
 		_move_intent = true
 	else:
-		# Player was idle (or rooted) — freeze in place, face player's direction
-		global_position.y = _player_ref.global_position.y
 		rotation.y = lerp_angle(rotation.y, player_rot, 5.0 * _delta)
-		_was_moving = false
 		_move_intent = false
-	# The locomotion clip is resolved centrally in _physics_process from
-	# _move_intent + this frame's measured displacement (spec /states/companion):
-	# intent gates out the combat-transition slide, the measured-speed veto gates
-	# out the #420 run-in-place, and the resume-from-freeze blend naturally ramps
-	# walk -> run as the measured speed climbs.
+	global_position.y = _player_ref.global_position.y
+	_follow_cmd_speed = maxf(desired, 0.0)
+	# Locomotion clip resolved centrally in _physics_process from _follow_cmd_speed
+	# (spec /states/companion) — the smooth arrival ramp yields run/walk/wait directly.
 
 
 func _teleport_behind_player() -> void:

--- a/scripts/3d/elements/companion_npc.gd
+++ b/scripts/3d/elements/companion_npc.gd
@@ -76,7 +76,8 @@ const ANIM_HOLD_TIME: float = 0.3
 ## Locomotion clip = f(movement INTENT, own measured planar speed). The FSM sets
 ## _move_intent each frame (steering states true, frozen/rooted false); the clip
 ## is resolved centrally in _physics_process (spec /states/companion). Thresholds
-## live on CompanionCombat (IDLE_EPS / RUN_EPS) so there is a single source. The
+## live on CompanionCombat (IDLE_EPS / RUN_ENTER / RUN_EXIT) so there is a single
+## source; the walk↔run split runs a hysteresis band (#463) off the current clip. The
 ## measured-speed veto keeps a stationary companion out of a locomotion clip
 ## (the #420 run-in-place invariant), and the intent layer keeps a moving one
 ## out of "wait" (the combat-transition slide).
@@ -302,8 +303,9 @@ func _play_companion_anim(anim_name: String) -> void:
 		return
 	if not _anim_player.has_animation(anim_name):
 		return
-	# Debounce ONLY the walk<->run borderline, so a companion hovering near
-	# RUN_EPS can't flicker frame to frame. Transitions to/from "wait" (and into
+	# Debounce ONLY the walk<->run borderline, as a backstop to the selector's
+	# hysteresis band (#463), so a companion hovering near the run threshold can't
+	# flicker frame to frame. Transitions to/from "wait" (and into
 	# "atk1") apply immediately, so the clip never lags the body: a moving
 	# companion is never stuck mid-"wait" (the combat-transition slide) and a
 	# stopped one is never stuck mid-"run" (the #420 run-in-place). Previously
@@ -330,8 +332,10 @@ func _select_locomotion_anim(prev_pos: Vector3, curr_pos: Vector3, delta: float)
 	var planar_speed: float = Vector2(moved.x, moved.z).length() / delta
 	# Measured-speed selector (intent-to-move assumed here; the intent gate is
 	# applied by the caller). Shares the pure clip mapping + thresholds with the
-	# unit tests via CompanionCombat.
-	return CompanionCombat.locomotion_clip(true, planar_speed)
+	# unit tests via CompanionCombat. _current_anim is threaded in as the current
+	# clip so the walk↔run split applies its hysteresis band (#463) — a near-
+	# threshold measured speed holds the current clip instead of flapping.
+	return CompanionCombat.locomotion_clip(true, planar_speed, _current_anim)
 
 
 ## Autopilot-only regression oracle for #420. Silent in normal play (gated on

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -139,6 +139,7 @@ func _run_tests_core() -> void:
 	test_player_defeat_return()
 	test_companion_anim_from_measured_speed()
 	test_companion_anim_walk_run_hysteresis()
+	test_companion_follow_speed_ramp()
 
 
 # Build/bootstrap, warp, scene/screen smoke, fields, quests, difficulty, misc.
@@ -6345,6 +6346,38 @@ func test_companion_anim_walk_run_hysteresis() -> void:
 	assert_eq(CompanionCombat.locomotion_clip(true, 0.0, "walk"), "wait",
 		"drop: 0 m/s -> wait")
 
+	print("")
+
+
+# ── #463 arrival gait: the FOLLOW speed ramp that drives the clip. Continuity
+# (monotonic, no dead zone) is what removes the run/walk/wait flap the old
+# measured-displacement path produced when the companion caught up and stalled.
+func test_companion_follow_speed_ramp() -> void:
+	print("── Companion FOLLOW speed ramp (#463 arrival gait) ──")
+	var ring := 2.5   # companion_npc FOLLOW_DISTANCE
+	var ramp := 1.5   # companion_npc FOLLOW_SLOW_RADIUS
+	var cap := 6.5    # companion_npc FOLLOW_MAX_SPEED
+	# At/inside the ring the companion holds station -> 0 (gait settles to wait).
+	assert_eq(CompanionCombat.follow_speed(ring, ring, ramp, cap), 0.0, "at the ring -> 0")
+	assert_eq(CompanionCombat.follow_speed(1.0, ring, ramp, cap), 0.0, "inside the ring -> 0")
+	# Just outside -> moving (a small speed = walk once fed through locomotion_clip).
+	assert_true(CompanionCombat.follow_speed(ring + 0.3, ring, ramp, cap) > 0.0, "just outside -> moving")
+	# Linear across the ramp: half the ramp -> half the cap.
+	assert_eq(CompanionCombat.follow_speed(ring + ramp * 0.5, ring, ramp, cap), cap * 0.5, "half ramp -> half cap")
+	# Full ramp and beyond -> capped (no runaway; keeps a bounded trailing gap).
+	assert_eq(CompanionCombat.follow_speed(ring + ramp, ring, ramp, cap), cap, "full ramp -> cap")
+	assert_eq(CompanionCombat.follow_speed(ring + ramp + 10.0, ring, ramp, cap), cap, "far out -> still cap")
+	# THE anti-flap property: monotonic non-decreasing in distance (no dead zone).
+	var prev := -1.0
+	for d in [0.0, 1.0, 2.5, 2.8, 3.0, 3.25, 4.0, 5.0, 20.0]:
+		var s: float = CompanionCombat.follow_speed(d, ring, ramp, cap)
+		assert_true(s >= prev, "monotonic at d=%.2f (%.3f >= %.3f)" % [d, s, prev])
+		prev = s
+	# Cap above player run (MOVE_SPEED 6.0) so the trailing gap can't grow.
+	assert_true(cap > 6.0, "cap above player run -> keeps pace")
+	# Degenerate ramp (0) can't divide-by-zero — clean step at the ring.
+	assert_eq(CompanionCombat.follow_speed(ring + 0.1, ring, 0.0, cap), cap, "ramp=0 -> cap outside ring")
+	assert_eq(CompanionCombat.follow_speed(ring, ring, 0.0, cap), 0.0, "ramp=0 -> 0 at ring")
 	print("")
 
 

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -6205,11 +6205,11 @@ func test_companion_anim_from_measured_speed() -> void:
 	assert_eq(c._select_locomotion_anim(Vector3.ZERO, Vector3(0.002, 0, 0), dt), "wait",
 		"sub-threshold jitter -> wait")
 
-	# 0.02 m/frame = 1.2 m/s — between IDLE_EPS and RUN_EPS -> walk.
+	# 0.02 m/frame = 1.2 m/s — between IDLE_EPS and RUN_ENTER -> walk.
 	assert_eq(c._select_locomotion_anim(Vector3.ZERO, Vector3(0.02, 0, 0), dt), "walk",
 		"0.02 m/frame (1.2 m/s) -> walk")
 
-	# 0.1 m/frame = 6 m/s — above RUN_EPS (4.0) -> run.
+	# 0.1 m/frame = 6 m/s — above RUN_ENTER (4.0) -> run.
 	assert_eq(c._select_locomotion_anim(Vector3.ZERO, Vector3(0, 0, 0.1), dt), "run",
 		"0.1 m/frame (6 m/s) -> run")
 
@@ -6225,15 +6225,74 @@ func test_companion_anim_from_measured_speed() -> void:
 	# intent selects wait vs locomote, the measured speed selects walk vs run.
 	# intent=false is ALWAYS wait, even at run speed (rooted/frozen states never
 	# slide); intent=true still yields wait below IDLE_EPS (the #420 veto — a
-	# blocked-but-steering companion never plays a locomotion clip in place).
-	assert_eq(CompanionCombat.locomotion_clip(false, 6.0), "wait",
+	# blocked-but-steering companion never plays a locomotion clip in place). The
+	# current clip is threaded in for the walk↔run hysteresis (exercised below);
+	# the wait cases must win regardless of what is playing.
+	assert_eq(CompanionCombat.locomotion_clip(false, 6.0, "run"), "wait",
 		"intent=false -> wait even at run speed (no slide)")
-	assert_eq(CompanionCombat.locomotion_clip(true, 0.05), "wait",
-		"intent=true but sub-IDLE_EPS -> wait (#420 veto)")
-	assert_eq(CompanionCombat.locomotion_clip(true, 1.2), "walk",
+	assert_eq(CompanionCombat.locomotion_clip(true, 0.05, "run"), "wait",
+		"intent=true but sub-IDLE_EPS -> wait (#420 veto, beats run-hold)")
+	assert_eq(CompanionCombat.locomotion_clip(true, 1.2, "walk"), "walk",
 		"intent=true, mid speed -> walk")
-	assert_eq(CompanionCombat.locomotion_clip(true, 6.0), "run",
-		"intent=true, above RUN_EPS -> run")
+	assert_eq(CompanionCombat.locomotion_clip(true, 6.0, "walk"), "run",
+		"intent=true, above RUN_ENTER -> run")
+
+	# ── #463: walk↔run hysteresis band (RUN_EXIT 3.0 .. RUN_ENTER 4.0) ──
+	# The bug: measured planar_speed is a noisy per-frame displacement. With a
+	# single threshold, a speed hovering at ~4 m/s flapped run↔walk every frame;
+	# the 0.3s _play_companion_anim debounce only rate-limited the flap to ~3 Hz
+	# because the SELECTOR's output still oscillated. The fix holds the current
+	# clip inside the band.
+	#
+	# Enter run ONLY above RUN_ENTER; below it (but still in the band) a walker
+	# stays walk.
+	assert_eq(CompanionCombat.locomotion_clip(true, 3.9, "walk"), "walk",
+		"walk + 3.9 m/s (in band, below RUN_ENTER) -> stay walk")
+	assert_eq(CompanionCombat.locomotion_clip(true, 4.1, "walk"), "run",
+		"walk + 4.1 m/s (above RUN_ENTER) -> enter run")
+	# Exit run ONLY below RUN_EXIT; inside the band a runner HOLDS run.
+	assert_eq(CompanionCombat.locomotion_clip(true, 3.9, "run"), "run",
+		"run + 3.9 m/s (in band, above RUN_EXIT) -> hold run")
+	assert_eq(CompanionCombat.locomotion_clip(true, 3.1, "run"), "run",
+		"run + 3.1 m/s (in band, above RUN_EXIT) -> hold run")
+	assert_eq(CompanionCombat.locomotion_clip(true, 2.9, "run"), "walk",
+		"run + 2.9 m/s (below RUN_EXIT) -> exit to walk")
+	# Coming out of wait picks by the enter threshold (no phantom run at band speed).
+	assert_eq(CompanionCombat.locomotion_clip(true, 3.5, "wait"), "walk",
+		"wait + 3.5 m/s (in band) -> walk, not run (enter threshold)")
+
+	# THE anti-regression assertion: an oscillating speed sequence that straddles
+	# the band, threading the returned clip back in as current_clip each step,
+	# must STOP changing the clip once it has settled into run. Under the old
+	# single-threshold selector this list produced run,walk,run,walk,walk,run… —
+	# a per-frame flap. With hysteresis, once 4.1 crosses RUN_ENTER the clip is
+	# "run" and every subsequent band-dip (3.9, 3.5, 3.1) holds it.
+	var flap_speeds: Array = [3.9, 4.1, 3.9, 4.1, 3.5, 4.2, 3.1, 3.8, 3.9]
+	var clip: String = "walk"  # start below the band
+	var run_since := -1
+	var transitions_after_settle := 0
+	for i in range(flap_speeds.size()):
+		var next_clip: String = CompanionCombat.locomotion_clip(true, flap_speeds[i], clip)
+		if run_since >= 0 and next_clip != clip:
+			transitions_after_settle += 1
+		if next_clip == "run" and run_since < 0:
+			run_since = i
+		clip = next_clip
+	assert_true(run_since >= 0, "oscillating sequence entered run once it crossed RUN_ENTER")
+	assert_eq(transitions_after_settle, 0,
+		"#463: no clip flapping once settled in run — band dips (3.0..4.0) hold run")
+	assert_eq(clip, "run", "sequence ends in run (never fell out through the band)")
+
+	# Honest transitions still work: a clear climb 0→5 gives run; a clear drop
+	# 5→0 gives walk then wait (each threaded through the current clip).
+	assert_eq(CompanionCombat.locomotion_clip(true, 0.0, "wait"), "wait",
+		"climb start: 0 m/s -> wait")
+	assert_eq(CompanionCombat.locomotion_clip(true, 5.0, "walk"), "run",
+		"climb: 5 m/s well above RUN_ENTER -> run")
+	assert_eq(CompanionCombat.locomotion_clip(true, 2.0, "run"), "walk",
+		"drop: 2 m/s well below RUN_EXIT -> walk")
+	assert_eq(CompanionCombat.locomotion_clip(true, 0.0, "walk"), "wait",
+		"drop: 0 m/s -> wait")
 
 	c.free()
 	print("")

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -138,6 +138,7 @@ func _run_tests_core() -> void:
 	test_field_quest_decouple()
 	test_player_defeat_return()
 	test_companion_anim_from_measured_speed()
+	test_companion_anim_walk_run_hysteresis()
 
 
 # Build/bootstrap, warp, scene/screen smoke, fields, quests, difficulty, misc.
@@ -6277,6 +6278,16 @@ func test_companion_anim_from_measured_speed() -> void:
 	assert_eq(CompanionCombat.locomotion_clip(true, 6.0, "walk"), "run",
 		"intent=true, above RUN_ENTER -> run")
 
+	c.free()
+	print("")
+
+
+# ── #463 hysteresis, split from the selector test above so each stays under the
+# code-health size/cx bound. Pure CompanionCombat.locomotion_clip statics
+# (data-in/data-out) — no companion instance needed.
+func test_companion_anim_walk_run_hysteresis() -> void:
+	print("── Companion walk↔run hysteresis band (#463) ──")
+
 	# ── #463: walk↔run hysteresis band (RUN_EXIT 3.0 .. RUN_ENTER 4.0) ──
 	# The bug: measured planar_speed is a noisy per-frame displacement. With a
 	# single threshold, a speed hovering at ~4 m/s flapped run↔walk every frame;
@@ -6334,7 +6345,6 @@ func test_companion_anim_from_measured_speed() -> void:
 	assert_eq(CompanionCombat.locomotion_clip(true, 0.0, "walk"), "wait",
 		"drop: 0 m/s -> wait")
 
-	c.free()
 	print("")
 
 

--- a/spec/src/pages/states/companion.astro
+++ b/spec/src/pages/states/companion.astro
@@ -5,27 +5,27 @@ import Mermaid from '../../components/Mermaid.astro';
 const chart = `stateDiagram-v2
   [*] --> wait
 
-  wait --> walk: planar speed >= IDLE_EPS (below RUN_ENTER)
-  wait --> run: planar speed > RUN_ENTER
-  walk --> run: planar speed > RUN_ENTER
-  run --> walk: planar speed < RUN_EXIT
-  walk --> wait: planar speed < IDLE_EPS
-  run --> wait: planar speed < IDLE_EPS
+  wait --> walk: speed >= IDLE_EPS (below RUN_ENTER)
+  wait --> run: speed > RUN_ENTER
+  walk --> run: speed > RUN_ENTER
+  run --> walk: speed < RUN_EXIT
+  walk --> wait: speed < IDLE_EPS
+  run --> wait: speed < IDLE_EPS
 
   note right of walk
     walk↔run uses a HYSTERESIS band:
     enter run above RUN_ENTER (4.0),
     exit run below RUN_EXIT (3.0), hold
-    the current clip in 3.0..4.0 so a
-    noisy measured speed can't flap it.
+    the current clip in 3.0..4.0.
   end note
 
   note right of wait
-    The clip is chosen ONLY from the
-    companion's own measured planar
-    displacement. The player's
-    PlayerState (incl. ATTACKING) has
-    NO edge into walk or run.
+    The clip is chosen from the companion's
+    own speed — its commanded arrival speed
+    while following, its measured displacement
+    in combat. The player's PlayerState
+    (incl. ATTACKING) has NO edge into
+    walk or run.
   end note
 `;
 ---
@@ -35,61 +35,64 @@ const chart = `stateDiagram-v2
 
   <p>The key words <strong>MUST</strong>, <strong>MUST NOT</strong>, <strong>REQUIRED</strong>, <strong>SHOULD</strong>, <strong>MAY</strong>, and <strong>OPTIONAL</strong> below are used as in RFC 2119.</p>
 
-  <p>A companion NPC (<code>CompanionNpc</code>, a <code>CharacterBody3D</code>) follows the player through field exploration by replaying a delayed copy of the player's recorded path — a <em>trail</em> sampled every physics frame and played back <code>TRAIL_DELAY</code> (0.5&nbsp;s) behind. This page defines the contract for which locomotion animation the companion plays while following. The trail-replay behavior defined here is the <code>FOLLOW</code> state of the combat FSM — see <a href="/states/companion-combat">Companion Combat</a> for the <code>ENGAGE</code>/<code>ATTACK</code>/<code>REGROUP</code> states layered on top; this page's animation invariants hold in every state where a locomotion clip plays.</p>
+  <p>A companion NPC (<code>CompanionNpc</code>, a <code>CharacterBody3D</code>) follows the player through field exploration. It steers toward a delayed copy of the player's recorded path — a <em>trail</em> sampled every physics frame, read <code>TRAIL_DELAY</code> (0.3&nbsp;s) behind — using an <strong>arrival controller</strong>: it holds roughly <code>FOLLOW_DISTANCE</code> behind the player and moves at a speed that ramps <em>continuously</em> with how far outside that follow-ring it is. This page defines the contract for which locomotion animation the companion plays while following. The trail-follow behavior defined here is the <code>FOLLOW</code> state of the combat FSM — see <a href="/states/companion-combat">Companion Combat</a> for the <code>ENGAGE</code>/<code>ATTACK</code>/<code>REGROUP</code> states layered on top; this page's animation invariants hold in every state where a locomotion clip plays.</p>
 
   <h2>The position / animation split</h2>
 
-  <p>There are two separate decisions every follow frame, and they have <strong>different inputs</strong>:</p>
+  <p>There are two separate decisions every follow frame:</p>
 
   <ul>
-    <li><strong>Where the companion moves</strong> (the follow-position decision) <strong>MAY</strong> consult the delayed player state: the companion only advances along the trail when the delayed sample is a true locomotion state — <code>WALKING</code> or <code>RUNNING</code>. When the delayed player is in any non-locomotion state (<code>IDLE</code>, <code>ATTACKING</code>, <code>DAMAGED</code>, <code>DOWN</code>, <code>DODGING</code>, <code>CUTSCENE</code>, …) the companion freezes in place and faces the player. (See <a href="/states/player-state">Player State Machine</a> for the enum this references.)</li>
-    <li><strong>Which clip the companion plays</strong> (the animation decision) is a function of the companion's own per-frame <strong>movement intent</strong> reconciled with its own <strong>measured planar displacement</strong>. The intent is set by whichever behavior state is driving the body this frame — like the player, whose clip follows its <em>own</em> locomotion state. The clip <strong>MUST NOT</strong> be selected by reading a <code>PlayerState</code> value directly.</li>
+    <li><strong>Where the companion moves</strong> (the follow-position decision) is an arrival controller: it heads toward the delayed trail point at a <em>commanded speed</em> <code>follow_speed(distance_to_player, FOLLOW_DISTANCE, FOLLOW_SLOW_RADIUS, FOLLOW_MAX_SPEED)</code> that is <strong>0 at or inside the follow-ring</strong> and ramps up over <code>FOLLOW_SLOW_RADIUS</code> to <code>FOLLOW_MAX_SPEED</code>. There is <strong>no</strong> per-state freeze: a delayed player in any non-locomotion state (<code>IDLE</code>, <code>ATTACKING</code>, <code>DAMAGED</code>, <code>DOWN</code>, …) simply stops advancing the trail, so the companion arrives at the ring and its commanded speed falls to 0. (See <a href="/states/player-state">Player State Machine</a> for the enum.)</li>
+    <li><strong>Which clip the companion plays</strong> (the animation decision) is a function of the companion's own <strong>speed</strong>, never a <code>PlayerState</code> read. In <code>FOLLOW</code> that speed is the <em>commanded arrival speed</em> above; in the combat states it is the companion's own <em>measured planar displacement</em>. Both are fed through the one pure classifier <code>CompanionCombat.locomotion_clip</code>.</li>
   </ul>
 
-  <p>The reconciliation is the whole point, and it is asymmetric: <strong>intent can only ever suppress a locomotion clip, never force one.</strong> A companion plays a locomotion clip only when it <em>both</em> intends to move <em>and</em> actually moved this frame. That single rule kills both failure modes — a body that translates while a non-locomotion pose plays (<em>sliding</em>), and a body that plays a locomotion clip while standing still (<em>run-in-place</em>, <a href="https://github.com/kion-dgl/psz-godot/issues/420">#420</a>).</p>
+  <p>Driving the <code>FOLLOW</code> clip from the <strong>commanded</strong> speed rather than raw per-frame displacement is what removes the run/walk/wait flap: because <code>follow_speed</code> is continuous in distance (no dead zone, monotonic), the gait eases <code>wait</code>&nbsp;→&nbsp;<code>walk</code>&nbsp;→&nbsp;<code>run</code> and back through a real walk band instead of snapping between stand and sprint as the companion caught up and stalled.</p>
+
+  <h2>FOLLOW arrival speed (#463)</h2>
+
+  <p>Let <code>d</code> be the companion's planar distance to the player. The pure ramp <code>CompanionCombat.follow_speed(d, ring, ramp, cap)</code> <strong>MUST</strong> return <code>0</code> for <code>d &le; ring</code>, <code>cap</code> for <code>d &ge; ring + ramp</code>, and a linear interpolation <code>cap · (d − ring) / ramp</code> between — clamped to <code>[0, cap]</code>, and <code>cap</code> for <code>d &gt; ring</code> when <code>ramp &le; 0</code> (no divide-by-zero). It <strong>MUST</strong> be monotonic non-decreasing in <code>d</code>; that continuity is the anti-flap property. <code>cap</code> (<code>FOLLOW_MAX_SPEED</code>, 6.5&nbsp;m/s) sits just above the player's run (<code>MOVE_SPEED</code> 6.0) so the trailing gap holds steady rather than growing into visible lag; <code>ring</code> (<code>FOLLOW_DISTANCE</code>, 2.5&nbsp;m) and <code>ramp</code> (<code>FOLLOW_SLOW_RADIUS</code>, 1.5&nbsp;m) are feel knobs. A <code>TELEPORT_DISTANCE</code> (20&nbsp;m) backstop reels the companion in if it is ever separated outright.</p>
 
   <h2>Intent × speed → clip table</h2>
 
-  <p>Let <code>moved</code> be <code>global_position − prev_pos</code> over a frame of length <code>delta</code> (<code>prev_pos</code> captured before the state steers the body), and <code>planar_speed = Vector2(moved.x, moved.z).length() / delta</code> (the vertical component is excluded so gravity and the height-snap to the player's <code>y</code> never read as locomotion). Let <code>intent_moving</code> be the frame's movement intent and <code>current_clip</code> the clip currently playing. The pure selector <code>CompanionCombat.locomotion_clip(intent_moving, planar_speed, current_clip)</code> <strong>MUST</strong> return:</p>
+  <p>Let <code>speed</code> be the companion's speed for the frame (the commanded arrival speed in <code>FOLLOW</code>; else <code>planar_speed = Vector2(moved.x, moved.z).length() / delta</code> for <code>moved = global_position − prev_pos</code>, the vertical component excluded so gravity and the height-snap never read as locomotion). Let <code>intent_moving</code> be the frame's movement intent and <code>current_clip</code> the clip currently playing. The pure selector <code>CompanionCombat.locomotion_clip(intent_moving, speed, current_clip)</code> <strong>MUST</strong> return:</p>
 
   <table>
     <thead><tr><th>Condition</th><th>Clip</th></tr></thead>
     <tbody>
       <tr><td><code>intent_moving == false</code> (any speed)</td><td><code>wait</code></td></tr>
-      <tr><td><code>delta &le; 0</code></td><td><code>wait</code> (no div-by-zero)</td></tr>
-      <tr><td><code>planar_speed &lt; IDLE_EPS</code> (0.15&nbsp;m/s)</td><td><code>wait</code> (the #420 veto)</td></tr>
-      <tr><td><code>current_clip == "run"</code> and <code>planar_speed &lt; RUN_EXIT</code> (3.0&nbsp;m/s)</td><td><code>walk</code> (exit run)</td></tr>
-      <tr><td><code>current_clip == "run"</code> and <code>planar_speed &ge; RUN_EXIT</code></td><td><code>run</code> (hold run)</td></tr>
-      <tr><td>otherwise, <code>planar_speed &gt; RUN_ENTER</code> (4.0&nbsp;m/s)</td><td><code>run</code> (enter run)</td></tr>
-      <tr><td>otherwise (<code>IDLE_EPS &le; planar_speed &le; RUN_ENTER</code>)</td><td><code>walk</code></td></tr>
+      <tr><td><code>speed &lt; IDLE_EPS</code> (0.15&nbsp;m/s)</td><td><code>wait</code> (the #420 veto)</td></tr>
+      <tr><td><code>current_clip == "run"</code> and <code>speed &lt; RUN_EXIT</code> (3.0&nbsp;m/s)</td><td><code>walk</code> (exit run)</td></tr>
+      <tr><td><code>current_clip == "run"</code> and <code>speed &ge; RUN_EXIT</code></td><td><code>run</code> (hold run)</td></tr>
+      <tr><td>otherwise, <code>speed &gt; RUN_ENTER</code> (4.0&nbsp;m/s)</td><td><code>run</code> (enter run)</td></tr>
+      <tr><td>otherwise (<code>IDLE_EPS &le; speed &le; RUN_ENTER</code>)</td><td><code>walk</code></td></tr>
     </tbody>
   </table>
 
   <h2>Walk↔run hysteresis (#463)</h2>
 
-  <p>The measured <code>planar_speed</code> is a noisy per-frame displacement, so near a single walk/run threshold it flaps the clip run↔walk from frame to frame. The <code>ANIM_HOLD_TIME</code> debounce below only <em>rate-limits</em> that flap (its input still oscillates) — it does not stop it. Therefore the walk↔run selection <strong>MUST</strong> use a <strong>hysteresis band</strong>: the selector switches <code>walk</code>&nbsp;→&nbsp;<code>run</code> only when <code>planar_speed</code> rises <strong>above <code>RUN_ENTER</code></strong> (4.0&nbsp;m/s) and switches <code>run</code>&nbsp;→&nbsp;<code>walk</code> only when it falls <strong>below <code>RUN_EXIT</code></strong> (3.0&nbsp;m/s); for a <code>planar_speed</code> inside the <code>RUN_EXIT</code>&nbsp;…&nbsp;<code>RUN_ENTER</code> band the selector <strong>MUST</strong> return <code>current_clip</code> unchanged (hold). A measured speed hovering at the boundary therefore cannot flap the animation — once the companion has genuinely reached run speed it stays running through the band's dips, and vice-versa. The <code>IDLE_EPS</code> → <code>wait</code> veto is unconditional and takes precedence over the hold. Coming out of <code>wait</code> (or any non-<code>run</code> clip) the enter threshold applies, so a body merely drifting through the band picks <code>walk</code>, never a phantom <code>run</code>. The chosen 1&nbsp;m/s band sits below the ~6&nbsp;m/s steady follow speed; its width is the one tuning value worth confirming on-device.</p>
+  <p>The walk↔run selection <strong>MUST</strong> use a <strong>hysteresis band</strong>: the selector switches <code>walk</code>&nbsp;→&nbsp;<code>run</code> only when <code>speed</code> rises <strong>above <code>RUN_ENTER</code></strong> (4.0&nbsp;m/s) and switches <code>run</code>&nbsp;→&nbsp;<code>walk</code> only when it falls <strong>below <code>RUN_EXIT</code></strong> (3.0&nbsp;m/s); for a <code>speed</code> inside the <code>RUN_EXIT</code>&nbsp;…&nbsp;<code>RUN_ENTER</code> band the selector <strong>MUST</strong> return <code>current_clip</code> unchanged (hold). This is a backstop: with the <code>FOLLOW</code> clip now driven by the continuous commanded speed, the band is rarely straddled, but it still guards the combat states (whose input is the noisier measured displacement) against boundary flap. The <code>IDLE_EPS</code> → <code>wait</code> veto is unconditional and takes precedence over the hold. Coming out of <code>wait</code> (or any non-<code>run</code> clip) the enter threshold applies, so a body merely drifting through the band picks <code>walk</code>, never a phantom <code>run</code>.</p>
 
-  <p>The clip is resolved once per frame, centrally, from the intent each state set — the companion's equivalent of the player's single per-frame animation update. It is then handed to <code>_play_companion_anim</code>, whose <code>ANIM_HOLD_TIME</code> (0.30&nbsp;s) debounce applies <strong>only to the <code>walk</code>↔<code>run</code> borderline</strong> as a backstop to the selector's hysteresis band, so a companion hovering near the run threshold cannot flicker frame to frame. Transitions to or from <code>wait</code> (and into the swing clip <code>atk1</code>) <strong>MUST</strong> apply immediately — the debounce <strong>MUST NOT</strong> hold a <code>wait</code>↔locomotion switch, because that lag is exactly what let the clip fall out of sync with the body during fast combat-state transitions (the sliding regression).</p>
+  <p>The clip is resolved once per frame, centrally — the companion's equivalent of the player's single per-frame animation update — then handed to <code>_play_companion_anim</code>, whose <code>ANIM_HOLD_TIME</code> (0.30&nbsp;s) debounce applies <strong>only to the <code>walk</code>↔<code>run</code> borderline</strong>. Transitions to or from <code>wait</code> (and into the swing clip <code>atk1</code>) <strong>MUST</strong> apply immediately — the debounce <strong>MUST NOT</strong> hold a <code>wait</code>↔locomotion switch, because that lag is exactly what let the clip fall out of sync with the body during fast combat-state transitions (the sliding regression).</p>
 
   <h2>Invariants</h2>
   <ul>
-    <li><strong>MUST NOT run while stationary.</strong> A companion whose planar displacement is below <code>IDLE_EPS</code> <strong>MUST</strong> play <code>wait</code>, regardless of intent or the player's state. In particular, a rooted player attack (<code>PlayerState.ATTACKING</code>) — which leaves the companion's follow-position unchanged — <strong>MUST NOT</strong> produce a <code>walk</code>/<code>run</code> clip (the <a href="https://github.com/kion-dgl/psz-godot/issues/420">#420</a> run-in-place regression). The measured-speed veto guarantees this independently of intent.</li>
-    <li><strong>MUST NOT slide.</strong> A companion that is actually moving (planar displacement &ge; <code>IDLE_EPS</code>) under its own movement intent <strong>MUST</strong> play the matching <code>walk</code>/<code>run</code> clip that same frame — the debounce <strong>MUST NOT</strong> hold it in <code>wait</code>. A body translating under a <code>wait</code> pose is the sliding defect.</li>
-    <li>The clip selector <code>locomotion_clip(intent_moving, planar_speed, current_clip)</code> takes <strong>no</strong> <code>PlayerState</code> argument; the movement intent is the companion's own FSM decision. A locomotion clip requires <em>both</em> <code>intent_moving</code> and <code>planar_speed &ge; IDLE_EPS</code>; either alone yields <code>wait</code>. The <code>current_clip</code> argument feeds only the walk↔run hysteresis and never overrides the <code>wait</code> veto.</li>
-    <li>Only <code>WALKING</code> / <code>RUNNING</code> delayed samples advance the follow-position (and hence set <code>intent_moving</code> in <code>FOLLOW</code>); every other state freezes the companion.</li>
+    <li><strong>MUST NOT run while stationary.</strong> A companion whose speed is below <code>IDLE_EPS</code> <strong>MUST</strong> play <code>wait</code>, regardless of intent or the player's state. In particular, a rooted player attack (<code>PlayerState.ATTACKING</code>) leaves the companion sitting at the follow-ring, so its commanded speed is 0 and it <strong>MUST NOT</strong> produce a <code>walk</code>/<code>run</code> clip (the <a href="https://github.com/kion-dgl/psz-godot/issues/420">#420</a> run-in-place regression).</li>
+    <li><strong>MUST NOT slide.</strong> A companion that is actually moving under its own movement intent <strong>MUST</strong> play the matching <code>walk</code>/<code>run</code> clip that same frame — the debounce <strong>MUST NOT</strong> hold it in <code>wait</code>. A body translating under a <code>wait</code> pose is the sliding defect.</li>
+    <li><strong>FOLLOW speed MUST be continuous.</strong> <code>follow_speed</code> <strong>MUST</strong> be 0 at/inside the ring and monotonic non-decreasing in distance — no dead zone in which small movements toggle the companion between stand and sprint. Its <code>cap</code> <strong>MUST</strong> sit at or above the player's run so the trailing gap cannot grow without bound (short of the teleport backstop).</li>
+    <li>The clip selector <code>locomotion_clip(intent_moving, speed, current_clip)</code> takes <strong>no</strong> <code>PlayerState</code> argument; the movement intent is the companion's own FSM decision. A locomotion clip requires <em>both</em> <code>intent_moving</code> and <code>speed &ge; IDLE_EPS</code>; either alone yields <code>wait</code>. The <code>current_clip</code> argument feeds only the walk↔run hysteresis and never overrides the <code>wait</code> veto.</li>
     <li>Vertical-only motion is never locomotion — the planar projection excludes <code>y</code>.</li>
   </ul>
 
-  <h2>Why intent × measured speed</h2>
-  <p>The measured-speed term keeps the clip honest about where the body <em>is</em>: held back by the &ge;1.5&nbsp;unit personal-space cap, mid-blend resuming from a freeze, or rooted while the player attacks — the clip always reflects the distance actually travelled, so it can never run in place. The intent term keeps the clip honest about what the body is <em>doing</em>: when a behavior state is steering, the switch out of <code>wait</code> is immediate rather than lagging a debounce, so a companion accelerating out of an attack or a regroup never slides. The resume-from-freeze blend still ramps <code>walk</code>&nbsp;→&nbsp;<code>run</code> naturally as the measured speed climbs.</p>
+  <h2>Why commanded speed in FOLLOW, measured speed in combat</h2>
+  <p>In <code>FOLLOW</code> the companion's motion is fully authored by the arrival controller, so its <em>commanded</em> speed is the truest, least noisy signal of what the body is doing — feeding it to the clip selector gives a smooth <code>run</code>&nbsp;→&nbsp;<code>walk</code>&nbsp;→&nbsp;<code>wait</code> gait with no flap. In the combat states the body is steered by approach/regroup logic and can be repositioned abruptly, so there the clip reads the <em>measured</em> displacement — honest about where the body actually went, so a slide or a teleport can never leave a locomotion pose playing over a still body.</p>
 
   <h2>Autopilot oracle</h2>
-  <p>Under <code>PSZ_AUTOPILOT</code>, <code>_autopilot_anim_tripwire</code> watches for the regression: if the companion holds a <code>walk</code>/<code>run</code> clip while its measured planar speed stays below <code>IDLE_EPS</code> for longer than the <code>ANIM_HOLD_TIME</code> debounce window, it pushes a <code>[sanity] FAIL: companion '&lt;id&gt;' holds '&lt;clip&gt;' while stationary …</code> error. It is silent in normal play. No current autopilot phase spawns a companion, so exercising this end-to-end needs a companion-bearing run on real hardware.</p>
+  <p>Under <code>PSZ_AUTOPILOT</code>, <code>_autopilot_anim_tripwire</code> watches for the regression: if the companion holds a <code>walk</code>/<code>run</code> clip while its measured planar speed stays below <code>IDLE_EPS</code> for longer than the <code>ANIM_HOLD_TIME</code> window, it pushes a <code>[sanity] FAIL: companion '&lt;id&gt;' holds '&lt;clip&gt;' while stationary …</code> error. It is silent in normal play. The companion is exercised end-to-end by the <code>PSZ_AUTOPILOT_COMPANION_COMBAT</code> probe and by any full-quest run (Search and Rescue spawns a following companion in every field cell).</p>
 
   <h2>Implemented by</h2>
   <ul>
-    <li><code>scripts/3d/elements/companion_combat.gd</code> (<code>CompanionCombat</code>) — <code>locomotion_clip(intent_moving, planar_speed, current_clip)</code>, the pure intent×speed selector with the walk↔run hysteresis band, and the <code>IDLE_EPS</code> / <code>RUN_ENTER</code> / <code>RUN_EXIT</code> thresholds (single source, shared with the tripwire).</li>
-    <li><code>scripts/3d/elements/companion_npc.gd</code> (<code>CompanionNpc</code>) — the per-frame <code>prev_pos</code> capture and central <code>_update_locomotion_anim</code> call in <code>_physics_process</code>; each behavior state setting <code>_move_intent</code>; <code>_play_companion_anim</code> (the <code>walk</code>↔<code>run</code>-only debounce); and <code>_autopilot_anim_tripwire</code> (the oracle).</li>
+    <li><code>scripts/3d/elements/companion_combat.gd</code> (<code>CompanionCombat</code>) — <code>locomotion_clip(intent_moving, speed, current_clip)</code>, the pure clip selector with the walk↔run hysteresis band; <code>follow_speed(d, ring, ramp, cap)</code>, the pure arrival ramp; and the <code>IDLE_EPS</code> / <code>RUN_ENTER</code> / <code>RUN_EXIT</code> thresholds (single source, shared with the tripwire).</li>
+    <li><code>scripts/3d/elements/companion_npc.gd</code> (<code>CompanionNpc</code>) — the arrival controller in <code>_process_follow</code> (the <code>FOLLOW_DISTANCE</code> / <code>FOLLOW_SLOW_RADIUS</code> / <code>FOLLOW_MAX_SPEED</code> / <code>TRAIL_DELAY</code> knobs and the <code>_follow_cmd_speed</code> it commands each frame); the central <code>_update_locomotion_anim</code> in <code>_physics_process</code> (commanded speed in <code>FOLLOW</code>, measured displacement otherwise); <code>_play_companion_anim</code> (the <code>walk</code>↔<code>run</code>-only debounce); and <code>_autopilot_anim_tripwire</code> (the oracle).</li>
   </ul>
-  <p>Pinned by <code>test_companion_anim_from_measured_speed</code> in <code>scripts/tools/test_runner.gd</code>, which asserts the measured-speed cases (zero displacement, sub-threshold jitter, walk-speed, run-speed, pure-vertical, <code>delta == 0</code>) via <code>_select_locomotion_anim</code>, plus the intent-gate cases (intent-false → <code>wait</code> even at run speed; intent-true sub-<code>IDLE_EPS</code> → <code>wait</code>; walk; run) and the #463 hysteresis cases (enter run only above <code>RUN_ENTER</code>, exit run only below <code>RUN_EXIT</code>, hold in the band, and an oscillating band-straddling sequence that must stop flapping once settled in run) directly against <code>CompanionCombat.locomotion_clip</code> — no scene or <code>AnimationPlayer</code> needed.</p>
+  <p>Pinned by <code>test_companion_anim_from_measured_speed</code> (the measured-speed + intent-gate cases via <code>_select_locomotion_anim</code>), <code>test_companion_anim_walk_run_hysteresis</code> (enter above <code>RUN_ENTER</code>, exit below <code>RUN_EXIT</code>, hold in the band, and an oscillating band-straddling sequence that must stop flapping once settled in run), and <code>test_companion_follow_speed_ramp</code> (the arrival ramp: 0 at/inside the ring, linear across, capped, monotonic, divide-by-zero-safe) in <code>scripts/tools/test_runner.gd</code> — all against the pure statics, no scene or <code>AnimationPlayer</code> needed.</p>
 </Concept>

--- a/spec/src/pages/states/companion.astro
+++ b/spec/src/pages/states/companion.astro
@@ -5,11 +5,20 @@ import Mermaid from '../../components/Mermaid.astro';
 const chart = `stateDiagram-v2
   [*] --> wait
 
-  wait --> walk: planar speed >= IDLE_EPS
-  walk --> run: planar speed > RUN_EPS
-  run --> walk: planar speed <= RUN_EPS
+  wait --> walk: planar speed >= IDLE_EPS (below RUN_ENTER)
+  wait --> run: planar speed > RUN_ENTER
+  walk --> run: planar speed > RUN_ENTER
+  run --> walk: planar speed < RUN_EXIT
   walk --> wait: planar speed < IDLE_EPS
   run --> wait: planar speed < IDLE_EPS
+
+  note right of walk
+    walk↔run uses a HYSTERESIS band:
+    enter run above RUN_ENTER (4.0),
+    exit run below RUN_EXIT (3.0), hold
+    the current clip in 3.0..4.0 so a
+    noisy measured speed can't flap it.
+  end note
 
   note right of wait
     The clip is chosen ONLY from the
@@ -41,7 +50,7 @@ const chart = `stateDiagram-v2
 
   <h2>Intent × speed → clip table</h2>
 
-  <p>Let <code>moved</code> be <code>global_position − prev_pos</code> over a frame of length <code>delta</code> (<code>prev_pos</code> captured before the state steers the body), and <code>planar_speed = Vector2(moved.x, moved.z).length() / delta</code> (the vertical component is excluded so gravity and the height-snap to the player's <code>y</code> never read as locomotion). Let <code>intent_moving</code> be the frame's movement intent. The pure selector <code>CompanionCombat.locomotion_clip(intent_moving, planar_speed)</code> <strong>MUST</strong> return:</p>
+  <p>Let <code>moved</code> be <code>global_position − prev_pos</code> over a frame of length <code>delta</code> (<code>prev_pos</code> captured before the state steers the body), and <code>planar_speed = Vector2(moved.x, moved.z).length() / delta</code> (the vertical component is excluded so gravity and the height-snap to the player's <code>y</code> never read as locomotion). Let <code>intent_moving</code> be the frame's movement intent and <code>current_clip</code> the clip currently playing. The pure selector <code>CompanionCombat.locomotion_clip(intent_moving, planar_speed, current_clip)</code> <strong>MUST</strong> return:</p>
 
   <table>
     <thead><tr><th>Condition</th><th>Clip</th></tr></thead>
@@ -49,18 +58,24 @@ const chart = `stateDiagram-v2
       <tr><td><code>intent_moving == false</code> (any speed)</td><td><code>wait</code></td></tr>
       <tr><td><code>delta &le; 0</code></td><td><code>wait</code> (no div-by-zero)</td></tr>
       <tr><td><code>planar_speed &lt; IDLE_EPS</code> (0.15&nbsp;m/s)</td><td><code>wait</code> (the #420 veto)</td></tr>
-      <tr><td><code>IDLE_EPS &le; planar_speed &le; RUN_EPS</code></td><td><code>walk</code></td></tr>
-      <tr><td><code>planar_speed &gt; RUN_EPS</code> (4.0&nbsp;m/s)</td><td><code>run</code></td></tr>
+      <tr><td><code>current_clip == "run"</code> and <code>planar_speed &lt; RUN_EXIT</code> (3.0&nbsp;m/s)</td><td><code>walk</code> (exit run)</td></tr>
+      <tr><td><code>current_clip == "run"</code> and <code>planar_speed &ge; RUN_EXIT</code></td><td><code>run</code> (hold run)</td></tr>
+      <tr><td>otherwise, <code>planar_speed &gt; RUN_ENTER</code> (4.0&nbsp;m/s)</td><td><code>run</code> (enter run)</td></tr>
+      <tr><td>otherwise (<code>IDLE_EPS &le; planar_speed &le; RUN_ENTER</code>)</td><td><code>walk</code></td></tr>
     </tbody>
   </table>
 
-  <p>The clip is resolved once per frame, centrally, from the intent each state set — the companion's equivalent of the player's single per-frame animation update. It is then handed to <code>_play_companion_anim</code>, whose <code>ANIM_HOLD_TIME</code> (0.30&nbsp;s) debounce applies <strong>only to the <code>walk</code>↔<code>run</code> borderline</strong>, so a companion hovering near <code>RUN_EPS</code> cannot flicker frame to frame. Transitions to or from <code>wait</code> (and into the swing clip <code>atk1</code>) <strong>MUST</strong> apply immediately — the debounce <strong>MUST NOT</strong> hold a <code>wait</code>↔locomotion switch, because that lag is exactly what let the clip fall out of sync with the body during fast combat-state transitions (the sliding regression).</p>
+  <h2>Walk↔run hysteresis (#463)</h2>
+
+  <p>The measured <code>planar_speed</code> is a noisy per-frame displacement, so near a single walk/run threshold it flaps the clip run↔walk from frame to frame. The <code>ANIM_HOLD_TIME</code> debounce below only <em>rate-limits</em> that flap (its input still oscillates) — it does not stop it. Therefore the walk↔run selection <strong>MUST</strong> use a <strong>hysteresis band</strong>: the selector switches <code>walk</code>&nbsp;→&nbsp;<code>run</code> only when <code>planar_speed</code> rises <strong>above <code>RUN_ENTER</code></strong> (4.0&nbsp;m/s) and switches <code>run</code>&nbsp;→&nbsp;<code>walk</code> only when it falls <strong>below <code>RUN_EXIT</code></strong> (3.0&nbsp;m/s); for a <code>planar_speed</code> inside the <code>RUN_EXIT</code>&nbsp;…&nbsp;<code>RUN_ENTER</code> band the selector <strong>MUST</strong> return <code>current_clip</code> unchanged (hold). A measured speed hovering at the boundary therefore cannot flap the animation — once the companion has genuinely reached run speed it stays running through the band's dips, and vice-versa. The <code>IDLE_EPS</code> → <code>wait</code> veto is unconditional and takes precedence over the hold. Coming out of <code>wait</code> (or any non-<code>run</code> clip) the enter threshold applies, so a body merely drifting through the band picks <code>walk</code>, never a phantom <code>run</code>. The chosen 1&nbsp;m/s band sits below the ~6&nbsp;m/s steady follow speed; its width is the one tuning value worth confirming on-device.</p>
+
+  <p>The clip is resolved once per frame, centrally, from the intent each state set — the companion's equivalent of the player's single per-frame animation update. It is then handed to <code>_play_companion_anim</code>, whose <code>ANIM_HOLD_TIME</code> (0.30&nbsp;s) debounce applies <strong>only to the <code>walk</code>↔<code>run</code> borderline</strong> as a backstop to the selector's hysteresis band, so a companion hovering near the run threshold cannot flicker frame to frame. Transitions to or from <code>wait</code> (and into the swing clip <code>atk1</code>) <strong>MUST</strong> apply immediately — the debounce <strong>MUST NOT</strong> hold a <code>wait</code>↔locomotion switch, because that lag is exactly what let the clip fall out of sync with the body during fast combat-state transitions (the sliding regression).</p>
 
   <h2>Invariants</h2>
   <ul>
     <li><strong>MUST NOT run while stationary.</strong> A companion whose planar displacement is below <code>IDLE_EPS</code> <strong>MUST</strong> play <code>wait</code>, regardless of intent or the player's state. In particular, a rooted player attack (<code>PlayerState.ATTACKING</code>) — which leaves the companion's follow-position unchanged — <strong>MUST NOT</strong> produce a <code>walk</code>/<code>run</code> clip (the <a href="https://github.com/kion-dgl/psz-godot/issues/420">#420</a> run-in-place regression). The measured-speed veto guarantees this independently of intent.</li>
     <li><strong>MUST NOT slide.</strong> A companion that is actually moving (planar displacement &ge; <code>IDLE_EPS</code>) under its own movement intent <strong>MUST</strong> play the matching <code>walk</code>/<code>run</code> clip that same frame — the debounce <strong>MUST NOT</strong> hold it in <code>wait</code>. A body translating under a <code>wait</code> pose is the sliding defect.</li>
-    <li>The clip selector <code>locomotion_clip(intent_moving, planar_speed)</code> takes <strong>no</strong> <code>PlayerState</code> argument; the movement intent is the companion's own FSM decision. A locomotion clip requires <em>both</em> <code>intent_moving</code> and <code>planar_speed &ge; IDLE_EPS</code>; either alone yields <code>wait</code>.</li>
+    <li>The clip selector <code>locomotion_clip(intent_moving, planar_speed, current_clip)</code> takes <strong>no</strong> <code>PlayerState</code> argument; the movement intent is the companion's own FSM decision. A locomotion clip requires <em>both</em> <code>intent_moving</code> and <code>planar_speed &ge; IDLE_EPS</code>; either alone yields <code>wait</code>. The <code>current_clip</code> argument feeds only the walk↔run hysteresis and never overrides the <code>wait</code> veto.</li>
     <li>Only <code>WALKING</code> / <code>RUNNING</code> delayed samples advance the follow-position (and hence set <code>intent_moving</code> in <code>FOLLOW</code>); every other state freezes the companion.</li>
     <li>Vertical-only motion is never locomotion — the planar projection excludes <code>y</code>.</li>
   </ul>
@@ -73,8 +88,8 @@ const chart = `stateDiagram-v2
 
   <h2>Implemented by</h2>
   <ul>
-    <li><code>scripts/3d/elements/companion_combat.gd</code> (<code>CompanionCombat</code>) — <code>locomotion_clip(intent_moving, planar_speed)</code>, the pure intent×speed selector, and the <code>IDLE_EPS</code> / <code>RUN_EPS</code> thresholds (single source, shared with the tripwire).</li>
+    <li><code>scripts/3d/elements/companion_combat.gd</code> (<code>CompanionCombat</code>) — <code>locomotion_clip(intent_moving, planar_speed, current_clip)</code>, the pure intent×speed selector with the walk↔run hysteresis band, and the <code>IDLE_EPS</code> / <code>RUN_ENTER</code> / <code>RUN_EXIT</code> thresholds (single source, shared with the tripwire).</li>
     <li><code>scripts/3d/elements/companion_npc.gd</code> (<code>CompanionNpc</code>) — the per-frame <code>prev_pos</code> capture and central <code>_update_locomotion_anim</code> call in <code>_physics_process</code>; each behavior state setting <code>_move_intent</code>; <code>_play_companion_anim</code> (the <code>walk</code>↔<code>run</code>-only debounce); and <code>_autopilot_anim_tripwire</code> (the oracle).</li>
   </ul>
-  <p>Pinned by <code>test_companion_anim_from_measured_speed</code> in <code>scripts/tools/test_runner.gd</code>, which asserts the measured-speed cases (zero displacement, sub-threshold jitter, walk-speed, run-speed, pure-vertical, <code>delta == 0</code>) via <code>_select_locomotion_anim</code>, plus the intent-gate cases (intent-false → <code>wait</code> even at run speed; intent-true sub-<code>IDLE_EPS</code> → <code>wait</code>; walk; run) directly against <code>CompanionCombat.locomotion_clip</code> — no scene or <code>AnimationPlayer</code> needed.</p>
+  <p>Pinned by <code>test_companion_anim_from_measured_speed</code> in <code>scripts/tools/test_runner.gd</code>, which asserts the measured-speed cases (zero displacement, sub-threshold jitter, walk-speed, run-speed, pure-vertical, <code>delta == 0</code>) via <code>_select_locomotion_anim</code>, plus the intent-gate cases (intent-false → <code>wait</code> even at run speed; intent-true sub-<code>IDLE_EPS</code> → <code>wait</code>; walk; run) and the #463 hysteresis cases (enter run only above <code>RUN_ENTER</code>, exit run only below <code>RUN_EXIT</code>, hold in the band, and an oscillating band-straddling sequence that must stop flapping once settled in run) directly against <code>CompanionCombat.locomotion_clip</code> — no scene or <code>AnimationPlayer</code> needed.</p>
 </Concept>


### PR DESCRIPTION
Closes #463.

## Why

From Rozalin's playtest of #438: while the companion is moving it visibly alternates between the run and walk animations.

Root cause (traced, not guessed): `CompanionCombat.locomotion_clip` chose the clip from a **single hard speed threshold** (`RUN_EPS = 4.0`) applied to a **noisy per-frame measured planar displacement** (`companion_npc._select_locomotion_anim`). The companion's steady follow speed is ~6 m/s but the per-frame measurement dips through 4.0 constantly, so the selector's *output* toggled run↔walk every frame.

The existing 0.3s `ANIM_HOLD_TIME` debounce did **not** fix this — it only rate-limits the flap to ~3 Hz. The debounce gates how often the clip can change; it can't stop a change when the selector it feeds keeps flipping. The output still visibly toggles.

## Fix — speed hysteresis / deadband (selector stays pure)

Give the walk↔run split a hysteresis band:

- Replace `RUN_EPS` with **`RUN_ENTER = 4.0`** (switch walk→run only *above*) and **`RUN_EXIT = 3.0`** (switch run→walk only *below*).
- In the 3.0–4.0 band the pure selector returns the **current clip unchanged** (hold), so a measured speed hovering at the boundary can't flap the animation.
- `locomotion_clip(intent_moving, planar_speed, current_clip)` gains a `current_clip` arg; the caller threads in the companion's `_current_anim`.
- The `IDLE_EPS → "wait"` #420 veto is unconditional and still takes precedence over the run-hold. Coming out of `wait` uses the enter threshold, so a body drifting through the band picks `walk`, never a phantom `run`.

The 1 m/s band sits below the ~6 m/s steady follow speed. **Its width is the one value worth confirming on-device.**

The consts on `CompanionCombat` remain the single source, shared with the autopilot run-in-place tripwire (which keys only on `IDLE_EPS` — semantics unchanged).

## Spec

`/states/companion` gains a normative **"Walk↔run hysteresis (#463)"** clause (RFC-2119: MUST enter above `RUN_ENTER`, MUST exit below `RUN_EXIT`, MUST hold `current_clip` in the band), plus updated intent×speed table, mermaid edges, and Implemented-by signature/thresholds.

## Tests

Unit (the definitive layer — `test_companion_anim_from_measured_speed`, seeded/off-tree):

- Existing call sites updated for the new signature and kept passing.
- Threshold cases: enter run only above `RUN_ENTER`, hold in band, exit only below `RUN_EXIT`, `wait`→band picks walk.
- **Anti-regression assertion**: an oscillating band-straddling sequence (`3.9, 4.1, 3.9, 4.1, 3.5, 4.2, 3.1, 3.8, 3.9`) threaded back through `current_clip` each step must **stop changing the clip once settled in run** (zero transitions after settle) — this deterministically proves the flap is gone headlessly.
- Honest transitions preserved: clear climb 0→5 → run; clear drop 5→0 → walk → wait.

`RESULTS: 2323 passed, 0 failed`, zero `Warning treated as error`.

Autopilot layer: a walk↔run flap-rate tripwire on the `PSZ_AUTOPILOT_COMPANION_COMBAT` probe will be handled by the coordinator (no companion-bearing autopilot phase exists to run here yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)