### PR TITLE
Fix intact boxes being snapshotted as destroyed

### DIFF
--- a/scripts/3d/field/cell_object_spawner.gd
+++ b/scripts/3d/field/cell_object_spawner.gd
@@ -434,7 +434,13 @@ func _save_cell_state() -> void:
 	var intact_box_positions: Array = []
 	for box in _c._room_boxes:
 		if is_instance_valid(box):
-			intact_box_positions.append(box.position)
+			# Compare AUTHORED positions, not spawned ones. _spawn_box places the
+			# box at _place_on_floor(pos), which snaps y to the floor and can
+			# shift x/z entirely when the authored spot has no floor under it, so
+			# box.position never equals the authored position it came from.
+			# Matching on the spawned position recorded still-intact boxes as
+			# destroyed, and they never respawned on re-entry.
+			intact_box_positions.append(box.get_meta("authored_pos", box.position))
 	for obj in objects:
 		var obj_type: String = str(obj.get("type", ""))
 		if obj_type in ["box", "rare_box"]:
@@ -705,6 +711,11 @@ func _spawn_box(pos: Vector3, is_rare: bool, state: String = "intact", drop_type
 	box.drop_value = drop_value if not drop_value.is_empty() else (str(randi_range(10, 50)) if not is_rare else str(randi_range(50, 200)))
 	_c._map_root.add_child(box)
 	box.position = _place_on_floor(pos)
+	# Remember where this box was AUTHORED. _save_cell_state matches surviving
+	# boxes against the cell's object list to work out which ones were
+	# destroyed, and _place_on_floor above may have moved the box off that
+	# spot entirely.
+	box.set_meta("authored_pos", pos)
 	_c._fixup_element_materials(box)
 	_c._room_boxes.append(box)
 	# Track drops spawned from this box

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -179,6 +179,7 @@ func _run_tests_systems() -> void:
 	test_blackjack()
 	test_kill_state_survives_warp_flush()
 	test_box_state_survives_warp_flush()
+	test_box_state_survives_floor_placement()
 	test_drop_state_survives_warp_flush()
 	test_message_wall_questitem_persist()
 	test_keys_gates_survive_section_roundtrip()
@@ -4861,6 +4862,49 @@ func test_keys_gates_survive_section_roundtrip() -> void:
 # ── Full persistence contract holds across repeated city trips (#423) ────────
 # The reliability/stress case: one cell mixing every persisted category, bounced
 # to the city 3× in a row. Every category MUST hold each trip — nothing respawns.
+func test_box_state_survives_floor_placement() -> void:
+	print("── Box-state — floor-snapped/relocated boxes aren't recorded destroyed ──")
+	SessionManager.clear_section_states()
+	SessionManager._suspended_session.clear()
+
+	var stub := _KillStateStubController.new()
+	stub._current_cell = {
+		"pos": "6,6",
+		"objects": [
+			{"type": "box", "position": [1.0, 0.0, 1.0]},   # A — floor snapped y
+			{"type": "box", "position": [4.0, 0.0, 4.0]},   # B — floor relocated x/z
+			{"type": "box", "position": [9.0, 0.0, 9.0]},   # C — genuinely destroyed
+		],
+	}
+	# _spawn_box positions boxes at _place_on_floor(pos): A's floor sits below
+	# the authored y, and B's authored spot had no floor at all so the grid scan
+	# moved it several metres. Both are still standing; only C is gone.
+	var snapped_box := Box.new()
+	snapped_box.element_state = "intact"
+	snapped_box.position = Vector3(1.0, 0.35, 1.0)
+	snapped_box.set_meta("authored_pos", Vector3(1.0, 0.0, 1.0))
+	var relocated := Box.new()
+	relocated.element_state = "intact"
+	relocated.position = Vector3(7.0, 0.2, 7.0)
+	relocated.set_meta("authored_pos", Vector3(4.0, 0.0, 4.0))
+	stub._room_boxes = [snapped_box, relocated]
+
+	var spawner := CellObjectSpawner.new(stub)
+	spawner._save_cell_state()
+
+	# Only C may be recorded destroyed. A phantom "destroyed" for a box that is
+	# still standing is the bug: the saved cell state then disagrees with the
+	# room it describes.
+	var destroyed_x: Array = []
+	for o in stub._cell_states.get("6,6", {}).get("objects", []):
+		if str(o.get("type", "")) == "box" and str(o.get("state", "")) == "destroyed":
+			destroyed_x.append(snappedf(float(o.get("px", 0)), 0.01))
+	assert_true(not destroyed_x.has(1.0), "Floor-snapped box not recorded destroyed")
+	assert_true(not destroyed_x.has(4.0), "Relocated box not recorded destroyed")
+	assert_true(destroyed_x.has(9.0), "Genuinely broken box still recorded destroyed")
+	assert_eq(destroyed_x.size(), 1, "Exactly one destroyed record (no phantoms)")
+
+
 func test_field_state_full_contract_roundtrip() -> void:
 	print("── Full persistence contract holds across 3 consecutive city trips (#423) ──")
 	SessionManager.clear_section_states()


### PR DESCRIPTION
## Why

`_save_cell_state` decides which boxes were broken by diffing the cell's authored object list against the boxes still alive in the room. It compared the authored position against `box.position` — but `_spawn_box` places boxes at `_place_on_floor(pos)`, which snaps `y` to the floor and relocates `x`/`z` entirely when the authored spot has no floor under it. A box that never moved on its own therefore never matched its own authored entry, and was written into the saved state as `destroyed`.

The result is a saved cell state that disagrees with the room it describes: alongside the real `intact` record (saved at the *spawned* position) sits a phantom `destroyed` record at the *authored* one. The box still respawns, so this is state corruption rather than a vanishing box — but anything reading box state to decide what was cleared sees an untouched room as broken. In the seeded test, all three boxes are recorded destroyed when only one actually was.

Floor relocation is common in practice — free-roam runs log `floor-relocate` repeatedly — so this is not an edge case.

## How

Record the authored position on the node at spawn (`box.set_meta("authored_pos", pos)`) and diff against that. The match is then exact no matter how far `_place_on_floor` moved the box.

A positional tolerance was the obvious alternative and is wrong: `_place_on_floor`'s fallback scans a grid and can move a box **metres**, not centimetres, so no tolerance both catches relocations and avoids matching a genuinely different box.

## Verification

`test_box_state_survives_floor_placement` covers three cases — a floor-snapped box, a relocated one, and a genuinely destroyed one:

- **Unfixed code: 3 of 4 assertions FAIL** (phantom count `got 3, expected 1`)
- **With the fix: 4 of 4 pass**

Full suite **2349 passed / 0 failed**. `code-health` and orphan ratchets both 0 new. All 35 quest files valid. Run on macOS against a real local pack.

The pre-existing `test_box_state_survives_warp_flush` missed this because it positions its intact box exactly at the authored coordinates, which is the one case where the old comparison works.

## Provenance

Found while testing #568, which carried a variant of this fix as a drive-by. #568 is being closed in favour of the field-generator work, so this lands the bug fix on its own — with the exact-match approach rather than that PR's 0.5-unit tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)