### PR TITLE
Storybook: port every unique field object from the asset viewer (25 → 70)

### DIFF
--- a/web/src/elements/AreaWarp.tsx
+++ b/web/src/elements/AreaWarp.tsx
@@ -13,8 +13,8 @@ interface AreaWarpProps extends ElementProps {
 
 // Story metadata for the storybook
 export const areaWarpMeta: StoryMeta = {
-  title: 'Area Warp',
-  description: 'Warp gate to the next area. Players pass through this to advance to the next section.',
+  title: 'Area Gate',
+  description: 'Gate showing the transition to the next area. Players pass through it to advance to the next section.',
   states: [
     { name: 'active', label: 'Active', description: 'Warp gate is active and usable' },
     { name: 'inactive', label: 'Inactive', description: 'Warp gate is inactive' },

--- a/web/src/elements/Box.tsx
+++ b/web/src/elements/Box.tsx
@@ -12,8 +12,9 @@ interface BoxProps extends ElementProps {
 
 // Story metadata for the storybook
 export const boxMeta: StoryMeta = {
-  title: 'Box',
-  description: 'Destructible container. Model varies by field. (Valley variant)',
+  title: 'Box (Gurhacia Valley)',
+  description:
+    'Destructible container, Valley variant (o01_cont). Every field re-skins this object — the other seven live alongside it under Containers.',
   states: [
     { name: 'intact', label: 'Intact', description: 'Box can be destroyed' },
     { name: 'destroyed', label: 'Destroyed', description: 'Box has been destroyed' },

--- a/web/src/elements/CatalogObject.tsx
+++ b/web/src/elements/CatalogObject.tsx
@@ -7,6 +7,16 @@ import type { CatalogEntry } from './objectCatalog';
 import { assetUrl } from '../utils/assets';
 import { applyObjectTextures, detachSkinnedBind, textureFilename } from './materials';
 
+interface TextureTransition {
+  texture: THREE.Texture;
+  fromX: number;
+  toX: number;
+  fromY: number;
+  toY: number;
+  elapsed: number;
+  duration: number;
+}
+
 interface ScrollingTexture {
   texture: THREE.Texture;
   x: number;
@@ -26,20 +36,90 @@ export function CatalogObject({
   rotation = [0, 0, 0],
   scale,
   state,
-}: ElementProps & { entry: CatalogEntry; state?: string }) {
+  animate = true,
+}: ElementProps & { entry: CatalogEntry; state?: string; animate?: boolean }) {
   const url = assetUrl(entry.glb);
   const { scene } = useGLTF(url);
   const cloned = useMemo(() => scene.clone(), [scene]);
   const scrollingRef = useRef<ScrollingTexture[]>([]);
   const spinTimeRef = useRef(0);
+  const transitionRef = useRef<TextureTransition[]>([]);
+  const firstApply = useRef(true);
   const groupRef = useRef<THREE.Group>(null);
 
   useEffect(() => {
     detachSkinnedBind(cloned);
     const [repeatX, repeatY] = entry.repeat ?? [1, 1];
+
+    // Snapshot offsets before the state's overrides land, so a transition can
+    // replay the move instead of the sheet jumping between frames.
+    const before = new Map<THREE.Texture, { x: number; y: number }>();
+    if (entry.stateTransitionMs) {
+      cloned.traverse((child) => {
+        if (!(child instanceof THREE.Mesh)) return;
+        const mats = Array.isArray(child.material) ? child.material : [child.material];
+        mats.forEach((mat) => {
+          const map = (mat as THREE.MeshStandardMaterial).map;
+          if (map) before.set(map, { x: map.offset.x, y: map.offset.y });
+        });
+      });
+    }
+
     // Per-entry UV scale is the baseline; entry.textures can still override a
-    // single texture on top of it.
-    applyObjectTextures(cloned, entry.textures, { repeatX, repeatY });
+    // single texture on top of it, and the current state's overrides win last.
+    const stateOverrides = (state && entry.stateTextures?.[state]) || {};
+    applyObjectTextures(cloned, { ...entry.textures, ...stateOverrides }, { repeatX, repeatY });
+
+    // Rewind anything that moved and hand it to the frame loop to ease in.
+    if (entry.stateTransitionMs && !firstApply.current) {
+      const moves: TextureTransition[] = [];
+      before.forEach((from, tex) => {
+        if (from.x === tex.offset.x && from.y === tex.offset.y) return;
+        moves.push({
+          texture: tex,
+          fromX: from.x,
+          toX: tex.offset.x,
+          fromY: from.y,
+          toY: tex.offset.y,
+          elapsed: 0,
+          duration: entry.stateTransitionMs! / 1000,
+        });
+        tex.offset.set(from.x, from.y);
+      });
+      transitionRef.current = moves;
+    }
+    firstApply.current = false;
+
+    // State-driven visibility: hide the materials this state doesn't draw, and
+    // pick which sibling primitive is shown for models that ship variants.
+    const hidden = new Set((state && entry.stateHiddenTextures?.[state]) || []);
+    const visibleMeshes = state ? entry.stateMeshes?.[state] : undefined;
+    let meshIndex = 0;
+    cloned.traverse((child) => {
+      if (!(child instanceof THREE.Mesh)) return;
+      const idx = meshIndex++;
+      if (visibleMeshes) child.visible = visibleMeshes.includes(idx);
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((mat) => {
+        const map = (mat as THREE.MeshStandardMaterial).map;
+        if (map) mat.visible = !hidden.has(textureFilename(map));
+      });
+    });
+
+    // Rig-driven state: pose named joints. Degrees in the data because the
+    // authored angles are read off a model viewer, not computed.
+    const bones = (state && entry.stateBones?.[state]) || null;
+    if (bones) {
+      cloned.traverse((child) => {
+        const pose = bones[child.name];
+        if (!pose) return;
+        child.rotation.set(
+          THREE.MathUtils.degToRad(pose[0]),
+          THREE.MathUtils.degToRad(pose[1]),
+          THREE.MathUtils.degToRad(pose[2]),
+        );
+      });
+    }
 
     const scrollCfg = entry.scroll;
     if (!scrollCfg) {
@@ -59,9 +139,33 @@ export function CatalogObject({
       });
     });
     scrollingRef.current = scrolling;
-  }, [cloned, entry.textures, entry.scroll]);
+  }, [cloned, entry, state]);
 
   useFrame((_, delta) => {
+    // State transitions play regardless of `animate`: the host disables the
+    // continuous scroll so its panel owns the offset, but a used/unused change
+    // should still be visible as a move rather than a jump.
+    if (transitionRef.current.length) {
+      transitionRef.current = transitionRef.current.filter((tr) => {
+        tr.elapsed += delta;
+        const k = Math.min(1, tr.elapsed / tr.duration);
+        // Smoothstep so the pad eases out rather than stopping dead.
+        const e = k * k * (3 - 2 * k);
+        tr.texture.offset.set(
+          THREE.MathUtils.lerp(tr.fromX, tr.toX, e),
+          THREE.MathUtils.lerp(tr.fromY, tr.toY, e),
+        );
+        return k < 1;
+      });
+    }
+
+    // The storybook drives texture.offset itself (TextureAnimator) so the
+    // scroll controls in its panel are authoritative. Both writing the same
+    // offset every frame means panel edits are immediately overwritten by the
+    // authored value and the sliders appear to do nothing — so the host opts
+    // out of the built-in animation while it is tuning.
+    if (!animate) return;
+
     scrollingRef.current.forEach(({ texture, x, y }) => {
       texture.offset.x += x * delta;
       texture.offset.y += y * delta;

--- a/web/src/elements/CatalogObject.tsx
+++ b/web/src/elements/CatalogObject.tsx
@@ -1,0 +1,112 @@
+import { useMemo, useEffect, useRef } from 'react';
+import { useGLTF } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { ElementProps, StoryMeta } from './types';
+import type { CatalogEntry } from './objectCatalog';
+import { assetUrl } from '../utils/assets';
+import { applyObjectTextures, detachSkinnedBind, textureFilename } from './materials';
+
+interface ScrollingTexture {
+  texture: THREE.Texture;
+  x: number;
+  y: number;
+}
+
+/**
+ * Renders one catalog entry: load the GLB, force the PSZ mirrored-repeat
+ * texture convention, optionally scroll named textures and spin the model.
+ *
+ * Everything that varies between catalog objects is data on the entry, so
+ * there is one component here rather than 45 near-identical files.
+ */
+export function CatalogObject({
+  entry,
+  position = [0, 0, 0],
+  rotation = [0, 0, 0],
+  scale,
+  state,
+}: ElementProps & { entry: CatalogEntry; state?: string }) {
+  const url = assetUrl(entry.glb);
+  const { scene } = useGLTF(url);
+  const cloned = useMemo(() => scene.clone(), [scene]);
+  const scrollingRef = useRef<ScrollingTexture[]>([]);
+  const spinTimeRef = useRef(0);
+  const groupRef = useRef<THREE.Group>(null);
+
+  useEffect(() => {
+    detachSkinnedBind(cloned);
+    const [repeatX, repeatY] = entry.repeat ?? [1, 1];
+    // Per-entry UV scale is the baseline; entry.textures can still override a
+    // single texture on top of it.
+    applyObjectTextures(cloned, entry.textures, { repeatX, repeatY });
+
+    const scrollCfg = entry.scroll;
+    if (!scrollCfg) {
+      scrollingRef.current = [];
+      return;
+    }
+
+    const scrolling: ScrollingTexture[] = [];
+    cloned.traverse((child) => {
+      if (!(child instanceof THREE.Mesh)) return;
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((mat) => {
+        const map = (mat as THREE.MeshStandardMaterial).map;
+        if (!map) return;
+        const cfg = scrollCfg[textureFilename(map)];
+        if (cfg) scrolling.push({ texture: map, x: cfg.x ?? 0, y: cfg.y ?? 0 });
+      });
+    });
+    scrollingRef.current = scrolling;
+  }, [cloned, entry.textures, entry.scroll]);
+
+  useFrame((_, delta) => {
+    scrollingRef.current.forEach(({ texture, x, y }) => {
+      texture.offset.x += x * delta;
+      texture.offset.y += y * delta;
+      // Keep the offsets bounded so long sessions don't lose float precision.
+      if (texture.offset.x > 10 || texture.offset.x < -10) texture.offset.x %= 10;
+      if (texture.offset.y > 10 || texture.offset.y < -10) texture.offset.y %= 10;
+    });
+
+    if (entry.spin && groupRef.current) {
+      spinTimeRef.current += delta;
+      groupRef.current.rotation.y += delta * 2;
+      groupRef.current.position.y = Math.sin(spinTimeRef.current * 3) * 0.1;
+    }
+  });
+
+  // Destructible entries despawn their model in the `destroyed` state, matching
+  // the hand-written Box / Wall components.
+  if (state === 'destroyed') return null;
+
+  return (
+    <group ref={groupRef} position={position} rotation={rotation} scale={scale ?? entry.scale ?? 1}>
+      <primitive object={cloned} />
+    </group>
+  );
+}
+
+/** Build the StoryMeta the storybook sidebar and state bar read. */
+export function catalogMeta(entry: CatalogEntry): StoryMeta {
+  const states = entry.states ?? [{ name: 'default', label: 'Default' }];
+  return {
+    title: entry.title,
+    description: `${entry.description} — model \`${entry.model}\` (set ${entry.sourceSet}).`,
+    states,
+    defaultState: states[0].name,
+  };
+}
+
+/** Wrap a catalog entry into the `{ state?: string }` component shape CATEGORIES expects. */
+export function catalogComponent(entry: CatalogEntry): React.ComponentType<{ state?: string }> {
+  const Component = ({ state }: { state?: string }) => <CatalogObject entry={entry} state={state} />;
+  Component.displayName = `Catalog(${entry.id})`;
+  return Component;
+}
+
+// Deliberately no preload pass here. The hand-written elements each preload
+// their single GLB at module scope, which is fine for ~25 models; eagerly
+// fetching all 45 catalog models on storybook open would be several MB of
+// requests for art the user may never click. Suspense loads them on select.

--- a/web/src/elements/Fence.tsx
+++ b/web/src/elements/Fence.tsx
@@ -25,7 +25,68 @@ export const fenceMeta: StoryMeta = {
 
 // The laser texture - meshes with this texture are hidden when disabled
 const LASER_TEXTURE_NAME = 'o0c_1_fence2';
-const LASER_SCROLL_SPEED = 0.70;
+// Scrolls along +X. The fence is a single laser quad; repeatY 2 is what splits
+// it into the two beams the original draws, and wrapT stays mirrored so the
+// two halves meet instead of showing a seam.
+const LASER_SCROLL_SPEED = 0.25;
+
+export interface FenceTextureSetup {
+  offsetX: number;
+  offsetY: number;
+  repeatX: number;
+  repeatY: number;
+  wrapS: THREE.Wrapping;
+  wrapT: THREE.Wrapping;
+}
+
+/**
+ * Measured per-texture setup, one table per fence model.
+ *
+ * The two share a texture pair but NOT their UV placement: the laser sits at
+ * offsetX -4.09 on the straight fence and +2.57 on the 4-sided one, so the
+ * tables stay separate rather than one being derived from the other.
+ */
+const FENCE_TEXTURE_CONFIG: Record<string, FenceTextureSetup> = {
+  'o0c_1_fence2': {
+    offsetX: -4.09,
+    offsetY: 1.11,
+    repeatX: 1.0,
+    repeatY: 2.0,
+    wrapS: THREE.RepeatWrapping,
+    wrapT: THREE.MirroredRepeatWrapping,
+  },
+  'o0c_0_fence1': {
+    offsetX: 0.5,
+    offsetY: 0.0,
+    repeatX: 1.0,
+    repeatY: 1.0,
+    wrapS: THREE.RepeatWrapping,
+    wrapT: THREE.RepeatWrapping,
+  },
+};
+
+/** Apply a measured per-texture setup to every mapped material in a model. */
+export function applyFenceTextureConfig(
+  root: THREE.Object3D,
+  config: Record<string, FenceTextureSetup>,
+): void {
+  root.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    materials.forEach((mat) => {
+      const map = (mat as THREE.MeshStandardMaterial).map;
+      if (!map) return;
+      const key = Object.keys(config).find((k) => map.name?.includes(k));
+      if (!key) return;
+      const cfg = config[key];
+      map.offset.set(cfg.offsetX, cfg.offsetY);
+      map.repeat.set(cfg.repeatX, cfg.repeatY);
+      map.wrapS = cfg.wrapS;
+      map.wrapT = cfg.wrapT;
+      map.needsUpdate = true;
+    });
+  });
+}
 
 const FENCE_MODELS: Record<string, string> = {
   default: assetUrl('/assets/objects/valley/o0c_fence.glb'),
@@ -47,6 +108,7 @@ export default function Fence({
 
   // Hide laser mesh when disabled, keep poles visible, collect laser textures
   useEffect(() => {
+    applyFenceTextureConfig(clonedScene, FENCE_TEXTURE_CONFIG);
     const laserTextures: THREE.Texture[] = [];
     clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
@@ -79,7 +141,8 @@ export default function Fence({
   // Animate laser texture scroll on offset.x
   useFrame((_, delta) => {
     laserTexturesRef.current.forEach((tex) => {
-      tex.offset.x -= LASER_SCROLL_SPEED * delta;
+      tex.offset.x += LASER_SCROLL_SPEED * delta;
+      if (tex.offset.x > 10) tex.offset.x -= 10;
       if (tex.offset.x < -10) tex.offset.x += 10;
     });
   });

--- a/web/src/elements/Fence4.tsx
+++ b/web/src/elements/Fence4.tsx
@@ -4,6 +4,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 import { assetUrl } from '../utils/assets';
+import { applyFenceTextureConfig, type FenceTextureSetup } from './Fence';
 
 export type Fence4State = 'active' | 'disabled';
 
@@ -24,7 +25,31 @@ export const fence4Meta: StoryMeta = {
 
 // The laser texture - meshes with this texture are hidden when disabled
 const LASER_TEXTURE_NAME = 'o0c_1_fence2';
-const LASER_SCROLL_SPEED = 0.70;
+const LASER_SCROLL_SPEED = 0.25;
+
+/**
+ * Same texture pair as the straight fence, different UV placement: the laser
+ * sits at offsetX +2.57 here rather than -4.09. repeatY 2 is what splits the
+ * single laser quad into the two beams the original draws.
+ */
+const FENCE4_TEXTURE_CONFIG: Record<string, FenceTextureSetup> = {
+  'o0c_1_fence2': {
+    offsetX: 2.57,
+    offsetY: 1.11,
+    repeatX: 1.0,
+    repeatY: 2.0,
+    wrapS: THREE.RepeatWrapping,
+    wrapT: THREE.MirroredRepeatWrapping,
+  },
+  'o0c_0_fence1': {
+    offsetX: 0.5,
+    offsetY: 0.0,
+    repeatX: 1.0,
+    repeatY: 1.0,
+    wrapS: THREE.RepeatWrapping,
+    wrapT: THREE.RepeatWrapping,
+  },
+};
 
 export default function Fence4({
   position = [0, 0, 0],
@@ -38,6 +63,7 @@ export default function Fence4({
 
   // Hide laser mesh when disabled, keep poles visible, collect laser textures
   useEffect(() => {
+    applyFenceTextureConfig(clonedScene, FENCE4_TEXTURE_CONFIG);
     const laserTextures: THREE.Texture[] = [];
     clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
@@ -70,7 +96,8 @@ export default function Fence4({
   // Animate laser texture scroll on offset.x
   useFrame((_, delta) => {
     laserTexturesRef.current.forEach((tex) => {
-      tex.offset.x -= LASER_SCROLL_SPEED * delta;
+      tex.offset.x += LASER_SCROLL_SPEED * delta;
+      if (tex.offset.x > 10) tex.offset.x -= 10;
       if (tex.offset.x < -10) tex.offset.x += 10;
     });
   });

--- a/web/src/elements/NeedleTrap.tsx
+++ b/web/src/elements/NeedleTrap.tsx
@@ -18,9 +18,13 @@ export const needleTrapMeta: StoryMeta = {
   defaultState: 'off',
 };
 
-const TEXTURE_CONFIG: Record<string, { offsetX: number; offsetY: number; wrapS: THREE.Wrapping; wrapT: THREE.Wrapping }> = {
-  'o0c_1_needle': { offsetX: 0.00, offsetY: 0.00, wrapS: THREE.MirroredRepeatWrapping, wrapT: THREE.MirroredRepeatWrapping },
-  'o0c_1_needle2': { offsetX: -0.17, offsetY: -0.18, wrapS: THREE.MirroredRepeatWrapping, wrapT: THREE.MirroredRepeatWrapping },
+const TEXTURE_CONFIG: Record<
+  string,
+  { offsetX: number; offsetY: number; repeatX: number; repeatY: number; wrapS: THREE.Wrapping; wrapT: THREE.Wrapping }
+> = {
+  'o0c_1_needle': { offsetX: 0.00, offsetY: 0.00, repeatX: 1.0, repeatY: 1.0, wrapS: THREE.MirroredRepeatWrapping, wrapT: THREE.MirroredRepeatWrapping },
+  // repeatX 2 tiles the spike strip across the base; at 1x it stretches.
+  'o0c_1_needle2': { offsetX: -0.17, offsetY: -0.18, repeatX: 2.0, repeatY: 1.0, wrapS: THREE.MirroredRepeatWrapping, wrapT: THREE.MirroredRepeatWrapping },
 };
 
 function getTexId(mat: THREE.Material): string | null {
@@ -51,6 +55,7 @@ export default function NeedleTrap({
         const cfg = TEXTURE_CONFIG[texId];
         if (cfg && mat.map) {
           mat.map.offset.set(cfg.offsetX, cfg.offsetY);
+          mat.map.repeat.set(cfg.repeatX, cfg.repeatY);
           mat.map.wrapS = cfg.wrapS;
           mat.map.wrapT = cfg.wrapT;
           mat.map.needsUpdate = true;

--- a/web/src/elements/Wall.tsx
+++ b/web/src/elements/Wall.tsx
@@ -12,8 +12,9 @@ interface WallProps extends ElementProps {
 
 // Story metadata for the storybook
 export const wallMeta: StoryMeta = {
-  title: 'Wall',
-  description: 'Destructible wall obstacle. Model varies by field. (Valley variant)',
+  title: 'Wall (Gurhacia Valley)',
+  description:
+    'Destructible wall obstacle, Valley variant (o01_wall). Six more field variants and their debris models sit alongside it under Walls.',
   states: [
     { name: 'intact', label: 'Intact', description: 'Wall blocks passage' },
     { name: 'destroyed', label: 'Destroyed', description: 'Wall has been destroyed' },

--- a/web/src/elements/materials.ts
+++ b/web/src/elements/materials.ts
@@ -1,0 +1,120 @@
+import * as THREE from 'three';
+
+/**
+ * Shared texture setup for PSZ object GLBs.
+ *
+ * The DS source data stores per-material wrap flags, but the .imd → glTF
+ * converter writes a glTF `sampler` per material and defaults most of them to
+ * REPEAT (74 of the 122 samplers across the object set). That default is wrong
+ * for this art: PSZ authored nearly every object texture to mirror on both
+ * axes, and rendering them with plain REPEAT shows a seam wherever a UV runs
+ * past 1.0 — most visibly on wall/fence/gate strips.
+ *
+ * So mirrored-repeat is the default here and per-texture exceptions are opt-in,
+ * which matches what the hand-written elements (Box, Wall, StartWarp, …) each
+ * do inline today.
+ */
+export type WrapMode = 'mirror' | 'repeat' | 'clamp';
+
+export interface TextureOverride {
+  wrapS?: WrapMode;
+  wrapT?: WrapMode;
+  repeatX?: number;
+  repeatY?: number;
+  offsetX?: number;
+  offsetY?: number;
+}
+
+/** Per-texture overrides, keyed by the texture's source filename (no path). */
+export type TextureOverrides = Record<string, TextureOverride>;
+
+export function threeWrap(mode: WrapMode): THREE.Wrapping {
+  if (mode === 'repeat') return THREE.RepeatWrapping;
+  if (mode === 'clamp') return THREE.ClampToEdgeWrapping;
+  return THREE.MirroredRepeatWrapping;
+}
+
+/** Best-effort source filename for a texture, matching StorybookViewer's inspector. */
+export function textureFilename(texture: THREE.Texture): string {
+  const named = texture.name || (texture.image as { src?: string } | null)?.src || '';
+  if (!named) return 'unknown';
+  return named.split('/').pop() as string;
+}
+
+type MappedMaterial = THREE.MeshStandardMaterial | THREE.MeshBasicMaterial;
+
+function isMappedMaterial(mat: THREE.Material): mat is MappedMaterial {
+  return mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial;
+}
+
+/**
+ * Walk a loaded scene and normalise every diffuse map to mirrored-repeat,
+ * applying any per-filename overrides on top. Returns the textures it touched
+ * so callers can animate them (warp scroll, etc.) without re-traversing.
+ */
+export function applyObjectTextures(
+  root: THREE.Object3D,
+  overrides: TextureOverrides = {},
+  defaults: TextureOverride = {},
+): THREE.Texture[] {
+  const touched: THREE.Texture[] = [];
+
+  root.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+
+    materials.forEach((mat) => {
+      if (!isMappedMaterial(mat)) return;
+      const map = mat.map;
+      if (map) {
+        const cfg = { ...defaults, ...(overrides[textureFilename(map)] ?? {}) };
+        map.wrapS = threeWrap(cfg.wrapS ?? 'mirror');
+        map.wrapT = threeWrap(cfg.wrapT ?? 'mirror');
+        map.repeat.set(cfg.repeatX ?? 1, cfg.repeatY ?? 1);
+        map.offset.set(cfg.offsetX ?? 0, cfg.offsetY ?? 0);
+        map.needsUpdate = true;
+        touched.push(map);
+      }
+      mat.needsUpdate = true;
+    });
+  });
+
+  return touched;
+}
+
+/**
+ * Make a parent-group `scale` actually affect the model.
+ *
+ * Every PSZ object GLB is exported as a SkinnedMesh (all 117 of them carry a
+ * `skins` array, even one-bone static props like the sky backdrop). three's
+ * default `AttachedBindMode` recomputes `bindMatrixInverse` from the mesh's
+ * world matrix every frame, so any scale on an ancestor gets inverted out of
+ * the skinning result and then re-applied by the model-view matrix — the two
+ * cancel and the model renders at its authored size no matter what scale you
+ * set. Switching to detached bind mode freezes `bindMatrixInverse` at its bind
+ * value so the ancestor transform survives.
+ *
+ * Safe for this art because the bind pose is identity on these props; it is
+ * not a general-purpose fix for animated skinned characters.
+ */
+export function detachSkinnedBind(root: THREE.Object3D): void {
+  root.traverse((child) => {
+    if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
+      (child as THREE.SkinnedMesh).bindMode = THREE.DetachedBindMode;
+    }
+  });
+}
+
+/** Collect the diffuse maps whose filename contains a substring, for scroll animation. */
+export function findTextures(root: THREE.Object3D, filenameSubstring: string): THREE.Texture[] {
+  const found: THREE.Texture[] = [];
+  root.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    materials.forEach((mat) => {
+      if (!isMappedMaterial(mat) || !mat.map) return;
+      if (textureFilename(mat.map).includes(filenameSubstring)) found.push(mat.map);
+    });
+  });
+  return found;
+}

--- a/web/src/elements/objectCatalog.ts
+++ b/web/src/elements/objectCatalog.ts
@@ -1,0 +1,458 @@
+import type { TextureOverrides } from './materials';
+
+/**
+ * Catalog of PSZ field objects that exist as converted models but have no
+ * hand-written element component (no gameplay behaviour to model yet).
+ *
+ * Ported from the psz-asset-viewer object browser
+ * (https://dashgl.github.io/psz-asset-viewer/objects/). That viewer exposes
+ * 52 object *sets* holding 951 model instances, but only 104 of those are
+ * unique by content hash — every `o0c_*` "common" object is byte-identical
+ * across all nine fields, so a set-by-set port would have been ~9x redundant.
+ * This catalog is the deduplicated remainder: one entry per genuinely distinct
+ * model + texture pair.
+ *
+ * Two kinds of duplication survive deliberately, because the models really do
+ * differ:
+ *   - Per-field art: `oNN_cont` / `oNN_wall` / `oNN_wallptcl` are a different
+ *     mesh and texture in every field, so each field gets its own entry.
+ *   - `o0s_warpb` / `o0s_warpm` / `o0s_warps` ship a second variant in the
+ *     `special_n` set with different meshes AND different textures that reuse
+ *     the same filenames (`o0s_1_fwarp2.png` is not the same image in the two
+ *     sets) — hence the separate `special_n/` asset directory.
+ *
+ * Objects already covered by a component in ./index.ts are intentionally
+ * absent here; see StorybookViewer's CATEGORIES for the merged list.
+ */
+
+/** Human-readable field names, keyed by the scene number in the model prefix. */
+export const FIELD_NAMES: Record<string, string> = {
+  '00': 'City',
+  '01': 'Gurhacia Valley',
+  '02': 'Ozette Wetlands',
+  '03': 'Rioh Snowfield',
+  '04': 'Makara Ruins',
+  '05': 'Oblivion City Paru',
+  '06': 'Arca Plant',
+  '07': 'Dark Shrine',
+  '08': 'Eternal Tower',
+};
+
+export interface CatalogState {
+  name: string;
+  label: string;
+  description?: string;
+}
+
+export interface CatalogEntry {
+  /** Storybook element id (kebab-case, unique across hand-written elements too). */
+  id: string;
+  title: string;
+  description: string;
+  /** Sidebar grouping. Reuses the existing category names where one fits. */
+  category: string;
+  /** Repo-relative asset path; resolved through assetUrl() at render time. */
+  glb: string;
+  /** Source model basename in the PSZ archives, for traceability back to the viewer. */
+  model: string;
+  /** Viewer object set the model was taken from. */
+  sourceSet: string;
+  /**
+   * Preview scale, default 1 = the model's authored size.
+   *
+   * Left at 1 for almost everything on purpose: the hand-written elements all
+   * render at true scale, so keeping it means the storybook shows real relative
+   * size (a wall really is ~6x a box). Only set where the authored size is
+   * unusable against the fixed preview camera — the ~20-unit compasses and clay
+   * trap, the 126-unit sky backdrop, and the sub-unit critters and bullet.
+   *
+   * Requires detachSkinnedBind(): every object GLB is a SkinnedMesh, and
+   * three's default attached bind mode cancels ancestor scale out entirely.
+   */
+  scale?: number;
+  /**
+   * UV scale applied to every texture on the model, default [1, 1].
+   *
+   * The box and wall families are the exception: `scripts/3d/elements/box.gd`
+   * and `wall.gd` are the only two Godot elements that call
+   * `GameElement._setup_mirror_textures()`, which binds the mirror_repeat
+   * shader at `uv_scale = Vector2(2, 2)`. Their UVs run [-0.25, 1.0], so at
+   * 1x the crate/wall panel motif stretches across the whole face and reads
+   * as smeared bands; at 2x it tiles the way the game draws it. Mirroring the
+   * game's value here is what makes a storybook box look like an in-game box.
+   */
+  repeat?: [number, number];
+  /** Slow Y-spin, for pickups and floating props. */
+  spin?: boolean;
+  /** Texture filename → scroll speed, for animated warp surfaces. */
+  scroll?: Record<string, { x?: number; y?: number }>;
+  /** Per-texture wrap/repeat exceptions to the mirrored-repeat default. */
+  textures?: TextureOverrides;
+  states?: CatalogState[];
+}
+
+const DESTRUCTIBLE: CatalogState[] = [
+  { name: 'intact', label: 'Intact' },
+  { name: 'destroyed', label: 'Destroyed', description: 'Model is despawned' },
+];
+
+/** Per-field destructible container (`oNN_cont`) — the "box" every field re-skins. */
+function boxEntry(scene: string, dir: string, set: string): CatalogEntry {
+  const field = FIELD_NAMES[scene];
+  return {
+    id: `box-${dir}`,
+    title: `Box (${field})`,
+    description: `Destructible container, ${field} variant. Same role as the Valley box but a distinct mesh and texture.`,
+    category: 'Containers',
+    glb: `/assets/objects/${dir}/o${scene}_cont.glb`,
+    model: `o${scene}_cont`,
+    sourceSet: set,
+    repeat: [2, 2],
+    states: DESTRUCTIBLE,
+  };
+}
+
+/** Per-field destructible wall (`oNN_wall`). */
+function wallEntry(scene: string, dir: string, set: string): CatalogEntry {
+  const field = FIELD_NAMES[scene];
+  return {
+    id: `wall-${dir}`,
+    title: `Wall (${field})`,
+    description: `Destructible wall obstacle, ${field} variant.`,
+    category: 'Walls',
+    glb: `/assets/objects/${dir}/o${scene}_wall.glb`,
+    model: `o${scene}_wall`,
+    sourceSet: set,
+    repeat: [2, 2],
+    states: DESTRUCTIBLE,
+  };
+}
+
+/**
+ * Per-field wall debris (`oNN_wallptcl`). These are the break-apart particle
+ * shards spawned when the matching wall is destroyed — they use the field's
+ * `ff_wall_oNN.png` sheet rather than the wall's own texture.
+ */
+function wallDebrisEntry(scene: string, dir: string, set: string): CatalogEntry {
+  const field = FIELD_NAMES[scene];
+  return {
+    id: `wall-debris-${dir}`,
+    title: `Wall Debris (${field})`,
+    description: `Break-apart shards for the ${field} wall. Uses the field's ff_wall_o${scene} particle sheet.`,
+    category: 'Walls',
+    glb: `/assets/objects/${dir}/o${scene}_wallptcl.glb`,
+    model: `o${scene}_wallptcl`,
+    sourceSet: set,
+  };
+}
+
+const FIELD_DIRS: { scene: string; dir: string; set: string; needsBoxAndWall: boolean }[] = [
+  { scene: '01', dir: 'valley', set: '01_o01a', needsBoxAndWall: false }, // Box + Wall are hand-written
+  { scene: '02', dir: 'wetlands', set: '02_o02a', needsBoxAndWall: true },
+  { scene: '03', dir: 'snowfield', set: '03_o03a', needsBoxAndWall: true },
+  { scene: '04', dir: 'makara', set: '04_o04a', needsBoxAndWall: true },
+  { scene: '05', dir: 'paru', set: '05_o05a', needsBoxAndWall: true },
+  { scene: '06', dir: 'arca', set: '06_o06a', needsBoxAndWall: true },
+  { scene: '07', dir: 'shrine', set: '07_o07a', needsBoxAndWall: true },
+];
+
+const FIELD_ENTRIES: CatalogEntry[] = FIELD_DIRS.flatMap(({ scene, dir, set, needsBoxAndWall }) => [
+  // Valley's box/wall already have hand-written components with real state logic.
+  ...(needsBoxAndWall ? [boxEntry(scene, dir, set), wallEntry(scene, dir, set)] : []),
+  wallDebrisEntry(scene, dir, set),
+]);
+
+export const OBJECT_CATALOG: CatalogEntry[] = [
+  ...FIELD_ENTRIES,
+
+  // Eternal Tower reuses one container across all eight floors and ships no
+  // wall/wallptcl pair — the tower's rooms are sealed rather than walled off.
+  {
+    id: 'box-tower',
+    title: 'Box (Eternal Tower)',
+    description:
+      'Destructible container, Eternal Tower variant. Shared by all eight tower floor sets (08_o080–08_o087) and the extra set. The tower has no destructible wall.',
+    category: 'Containers',
+    glb: '/assets/objects/tower/o08_cont.glb',
+    model: 'o08_cont',
+    sourceSet: '08_o080',
+    repeat: [2, 2],
+    states: DESTRUCTIBLE,
+  },
+  {
+    id: 'treasure-box',
+    title: 'Treasure Box',
+    description:
+      'Field-independent treasure chest. Unlike the per-field box this is one shared model in every set that has it.',
+    category: 'Containers',
+    glb: '/assets/objects/valley/o0c_trebox.glb',
+    model: 'o0c_trebox',
+    sourceSet: '01_o01a',
+    states: DESTRUCTIBLE,
+  },
+
+  // --- Traps and hazards -------------------------------------------------
+  {
+    id: 'bomb-container',
+    title: 'Bomb Container',
+    description: 'Explosive barrel. Breaking it damages whatever is nearby rather than dropping loot.',
+    category: 'Traps',
+    glb: '/assets/objects/valley/o0c_bombcont.glb',
+    model: 'o0c_bombcont',
+    sourceSet: '01_o01a',
+    states: DESTRUCTIBLE,
+  },
+  {
+    id: 'gun-trap-1',
+    title: 'Gun Trap (Type 1)',
+    description: 'Wall-mounted turret trap. Fires the bullet model below.',
+    category: 'Traps',
+    glb: '/assets/objects/valley/o0c_gun01.glb',
+    model: 'o0c_gun01',
+    sourceSet: '01_o01a',
+  },
+  {
+    id: 'gun-trap-2',
+    title: 'Gun Trap (Type 2)',
+    description: 'Second turret trap variant, distinct mesh and texture from type 1.',
+    category: 'Traps',
+    glb: '/assets/objects/valley/o0c_gun02.glb',
+    model: 'o0c_gun02',
+    sourceSet: '01_o01a',
+  },
+  {
+    id: 'turret-bullet',
+    title: 'Turret Bullet',
+    description:
+      'Projectile fired by the gun traps. Untextured — the only object model in the set with no image at all, so it renders as flat vertex-coloured geometry.',
+    category: 'Traps',
+    glb: '/assets/objects/valley/o0c_bullet01.glb',
+    model: 'o0c_bullet01',
+    sourceSet: '01_o01a',
+    scale: 4,
+  },
+  {
+    id: 'poison-trap',
+    title: 'Poison Trap',
+    description: 'Floor gas trap. Two-texture model (o0c_1_poisonm / poisonm2) like the needle trap.',
+    category: 'Traps',
+    glb: '/assets/objects/valley/o0c_poisonm.glb',
+    model: 'o0c_poisonm',
+    sourceSet: '01_o01a',
+  },
+  {
+    id: 'clay-trap',
+    title: 'Clay Trap',
+    description:
+      'Large trap volume — roughly 21 units across, wall-sized rather than prop-sized, so it is scaled down to fit the preview. Textured from the shared o0s_*_trapc sheet rather than any field palette, so it looks identical everywhere it appears. Exact gameplay role not yet confirmed against the DS build.',
+    category: 'Traps',
+    glb: '/assets/objects/valley/o0c_clay1.glb',
+    model: 'o0c_clay1',
+    sourceSet: '01_o01a',
+    scale: 0.12,
+    states: DESTRUCTIBLE,
+  },
+
+  // --- Warps -------------------------------------------------------------
+  {
+    id: 'boss-warp',
+    title: 'Boss Warp',
+    description:
+      'Third warp type alongside the start and area warps. Shares the start warp\'s scrolling o0s_1_swarp3 surface over its own o0s_0_bwarp1 base.',
+    category: 'Warps',
+    glb: '/assets/objects/special_z/o0s_warpb.glb',
+    model: 'o0s_warpb',
+    sourceSet: 'special_z',
+    scroll: { 'o0s_1_swarp3.png': { y: -1.35 } },
+  },
+  {
+    id: 'start-warp-n',
+    title: 'Start Warp (Variant N)',
+    description:
+      'The special_n set ships its own start warp: different mesh, and a different image behind the same o0s_0_swarp1 filename plus an o0s_1_swarp2 surface the other sets never use. Compare against Start Warp.',
+    category: 'Warps',
+    glb: '/assets/objects/special_n/o0s_warps.glb',
+    model: 'o0s_warps',
+    sourceSet: 'special_n',
+    scroll: { 'o0s_1_swarp2.png': { y: -1.35 } },
+  },
+  {
+    id: 'area-warp-n',
+    title: 'Area Warp (Variant N)',
+    description:
+      'special_n area warp. Its o0s_1_fwarp2.png is a different image from the identically-named texture in every other special set — the reason these live in their own asset directory.',
+    category: 'Warps',
+    glb: '/assets/objects/special_n/o0s_warpm.glb',
+    model: 'o0s_warpm',
+    sourceSet: 'special_n',
+    scroll: { 'o0s_1_fwarp2.png': { y: -1.35 } },
+  },
+  {
+    id: 'boss-warp-n',
+    title: 'Boss Warp (Variant N)',
+    description: 'special_n boss warp, with its own o0s_1_bwarp2 surface in place of the shared swarp3.',
+    category: 'Warps',
+    glb: '/assets/objects/special_n/o0s_warpb.glb',
+    model: 'o0s_warpb',
+    sourceSet: 'special_n',
+    scroll: { 'o0s_1_bwarp2.png': { y: -1.35 } },
+  },
+  {
+    id: 'arena-warp',
+    title: 'Arena Warp',
+    description: 'Warp used by the arena / event sets (special_e, special_r2, special_r4).',
+    category: 'Warps',
+    glb: '/assets/objects/special_z/o0c_warparena1.glb',
+    model: 'o0c_warparena1',
+    sourceSet: 'special_e',
+    scroll: { 'o0c_1_warpa3.png': { y: -0.6 } },
+  },
+  {
+    id: 'return-warp',
+    title: 'Return Warp',
+    description: 'Exit pad that sends the player back to the City. Appears in special_e, special_sg and special_z.',
+    category: 'Warps',
+    glb: '/assets/objects/special_z/o0c_return.glb',
+    model: 'o0c_return',
+    sourceSet: 'special_e',
+  },
+  {
+    id: 'city-warp-a',
+    title: 'City Warp (A)',
+    description: 'City teleporter, cwarp1a/cwarp2a texture set.',
+    category: 'Warps',
+    glb: '/assets/objects/special_c3/o0s_warpcn.glb',
+    model: 'o0s_warpcn',
+    sourceSet: 'special_c3',
+    scroll: { 'o0s_1_cwarp1a2.png': { y: -0.8 } },
+  },
+  {
+    id: 'city-warp-b',
+    title: 'City Warp (B)',
+    description: 'City teleporter, cwarp1b/cwarp2b texture set.',
+    category: 'Warps',
+    glb: '/assets/objects/special_c3/o0s_warpch.glb',
+    model: 'o0s_warpch',
+    sourceSet: 'special_c3',
+    scroll: { 'o0s_1_cwarp1b2.png': { y: -0.8 } },
+  },
+  {
+    id: 'city-warp-c',
+    title: 'City Warp (C)',
+    description: 'City teleporter, cwarp1c/cwarp2c texture set.',
+    category: 'Warps',
+    glb: '/assets/objects/special_c3/o0s_warpcv.glb',
+    model: 'o0s_warpcv',
+    sourceSet: 'special_c3',
+    scroll: { 'o0s_1_cwarp1c2.png': { y: -0.8 } },
+  },
+  {
+    id: 'city-warp-absorb',
+    title: 'City Warp (Absorb)',
+    description:
+      'Fourth city teleporter. The odd one out — it uses the o0c_1_wabs1 / wabs2 pair instead of the cwarp sheets the other three share.',
+    category: 'Warps',
+    glb: '/assets/objects/special_c3/o0s_warpcb.glb',
+    model: 'o0s_warpcb',
+    sourceSet: 'special_c3',
+    scroll: { 'o0c_1_wabs1.png': { y: -0.8 } },
+  },
+
+  // --- City props --------------------------------------------------------
+  {
+    id: 'city-compass',
+    title: 'City Compass',
+    description:
+      'Large gold ornamental prop from the City backdrop, ~21 units across (scaled down for the preview). Two textures, s00_1_back02 / back03. "Compass" is the archive model name, not a confirmed in-game role.',
+    category: 'City Props',
+    glb: '/assets/objects/special_c3/o00_compass.glb',
+    model: 'o00_compass',
+    sourceSet: 'special_c3',
+    scale: 0.12,
+  },
+  {
+    id: 'city-compass-ring',
+    title: 'City Compass (Ring)',
+    description:
+      'Companion ring overlay, same ~20-unit footprint as o00_compass and drawn from the o0c_2_line01 line sheet.',
+    category: 'City Props',
+    glb: '/assets/objects/special_c3/o00_compass2.glb',
+    model: 'o00_compass2',
+    sourceSet: 'special_c3',
+    scale: 0.12,
+  },
+  {
+    id: 'city-ring-marker',
+    title: 'City Ring Marker',
+    description: 'Ring marker prop from the City set (s00_1_ring1 texture).',
+    category: 'City Props',
+    glb: '/assets/objects/special_z/o0c_ruller01.glb',
+    model: 'o0c_ruller01',
+    sourceSet: 'special_c1',
+  },
+
+  // --- Ambient life ------------------------------------------------------
+  {
+    id: 'ambient-bird',
+    title: 'Bird',
+    description: 'Ambient flying bird (ob_pigeon texture). Appears in four of the special sets.',
+    category: 'Ambient',
+    glb: '/assets/objects/special_z/o0c_bird.glb',
+    model: 'o0c_bird',
+    sourceSet: 'special_05z',
+  },
+  {
+    id: 'ambient-butterfly',
+    title: 'Butterfly',
+    description: 'Ambient butterfly, used in the City and special_sg sets.',
+    category: 'Ambient',
+    glb: '/assets/objects/special_z/o0c_butterfly.glb',
+    model: 'o0c_butterfly',
+    sourceSet: 'special_c1',
+    scale: 4,
+  },
+  {
+    id: 'ambient-dragonfly',
+    title: 'Dragonfly',
+    description: 'Ambient dragonfly, special_sg only.',
+    category: 'Ambient',
+    glb: '/assets/objects/special_z/o0c_dragonfly.glb',
+    model: 'o0c_dragonfly',
+    sourceSet: 'special_sg',
+    scale: 4,
+  },
+
+  // --- Misc --------------------------------------------------------------
+  {
+    id: 'heal-pad',
+    title: 'Heal Pad',
+    description: 'Healing floor pad. Present in nine of the fourteen special sets.',
+    category: 'Pickups',
+    glb: '/assets/objects/special_z/o0c_healhp.glb',
+    model: 'o0c_healhp',
+    sourceSet: 'special_02z',
+  },
+  {
+    id: 'z-sky-wetlands',
+    title: 'Z-Sky Backdrop (Wetlands)',
+    description:
+      'Distant skybox/backdrop geometry for the Ozette Wetlands z-set. Eight textures, all s02_* stage art rather than object art — it is scenery packed into the object archive. Scaled down heavily to fit the preview.',
+    category: 'Scenery',
+    glb: '/assets/objects/special_z/o0s_zsky.glb',
+    model: 'o0s_zsky',
+    sourceSet: 'special_02z',
+    scale: 0.02,
+  },
+];
+
+/** Sidebar order for catalog-contributed categories not already in CATEGORIES. */
+export const CATALOG_CATEGORY_ORDER = [
+  'Containers',
+  'Walls',
+  'Traps',
+  'Warps',
+  'Pickups',
+  'City Props',
+  'Ambient',
+  'Scenery',
+];

--- a/web/src/elements/objectCatalog.ts
+++ b/web/src/elements/objectCatalog.ts
@@ -89,6 +89,37 @@ export interface CatalogEntry {
   /** Per-texture wrap/repeat exceptions to the mirrored-repeat default. */
   textures?: TextureOverrides;
   states?: CatalogState[];
+  /**
+   * Per-state texture overrides, layered on top of `textures`. Used where a
+   * state is expressed by shifting the sheet rather than by geometry — the
+   * heal pad's used/unused frames are the same mesh at ±0.5 offsetX.
+   */
+  stateTextures?: Record<string, TextureOverrides>;
+  /**
+   * Texture filenames whose material is hidden in the named state. Mirrors what
+   * the hand-written NeedleTrap does for `o0c_1_needle2`: the trap's second
+   * sheet is the "armed" overlay and is simply not drawn when off.
+   */
+  stateHiddenTextures?: Record<string, string[]>;
+  /**
+   * Child-mesh indices drawn in the named state, for models that ship variants
+   * as sibling primitives rather than separate files. The treasure box is two
+   * 100-vertex primitives sharing one material — lid-on and lid-off — and
+   * renders both at once unless a state picks one.
+   */
+  stateMeshes?: Record<string, number[]>;
+  /**
+   * Per-state skin-joint rotation in DEGREES, keyed by bone name. Some objects
+   * express their state through the rig rather than through geometry or UVs —
+   * the treasure box lid is the `huta` joint, and the GLB ships no animation
+   * clip, so the open angle lives here.
+   */
+  stateBones?: Record<string, Record<string, [number, number, number]>>;
+  /**
+   * Milliseconds to ease texture offsets when the state changes, instead of
+   * snapping. The heal pad reads as a pad draining rather than a hard cut.
+   */
+  stateTransitionMs?: number;
 }
 
 const DESTRUCTIBLE: CatalogState[] = [
@@ -183,12 +214,19 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     id: 'treasure-box',
     title: 'Treasure Box',
     description:
-      'Field-independent treasure chest. Unlike the per-field box this is one shared model in every set that has it.',
+      'Field-independent treasure chest. Unlike the per-field box this is one shared model in every set that has it. The lid is a SKIN JOINT named `huta` (Japanese for lid), not separate geometry — the two primitives are the same 100-vertex shell. Opening the chest means rotating that bone; there is no animation clip in the GLB, so the angle is set here.',
     category: 'Containers',
     glb: '/assets/objects/valley/o0c_trebox.glb',
     model: 'o0c_trebox',
     sourceSet: '01_o01a',
-    states: DESTRUCTIBLE,
+    states: [
+      { name: 'closed', label: 'Closed', description: 'Lid down' },
+      { name: 'open', label: 'Open', description: 'Lid hinged back' },
+    ],
+    stateBones: {
+      closed: { huta: [0, 0, 0] },
+      open: { huta: [-100, 0, 0] },
+    },
   },
 
   // --- Traps and hazards -------------------------------------------------
@@ -234,11 +272,23 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
   {
     id: 'poison-trap',
     title: 'Poison Trap',
-    description: 'Floor gas trap. Two-texture model (o0c_1_poisonm / poisonm2) like the needle trap.',
+    description:
+      'Floor gas trap. Two-primitive model like the needle trap: o0c_1_poisonm is the always-visible base and o0c_1_poisonm2 is the armed gas overlay, drawn only when on.',
     category: 'Traps',
     glb: '/assets/objects/valley/o0c_poisonm.glb',
     model: 'o0c_poisonm',
     sourceSet: '01_o01a',
+    states: [
+      { name: 'off', label: 'Off', description: 'Gas retracted' },
+      { name: 'on', label: 'On', description: 'Gas venting, deals damage' },
+    ],
+    stateHiddenTextures: { off: ['o0c_1_poisonm2.png'] },
+    // Same UV setup as the needle trap: base flat at 1x, armed overlay offset
+    // slightly and tiled 2x across the strip.
+    textures: {
+      'o0c_1_poisonm.png': { offsetX: 0, offsetY: 0, repeatX: 1, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+      'o0c_1_poisonm2.png': { offsetX: -0.17, offsetY: -0.18, repeatX: 2, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
   {
     id: 'clay-trap',
@@ -250,6 +300,7 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     model: 'o0c_clay1',
     sourceSet: '01_o01a',
     scale: 0.12,
+    repeat: [2, 1],
     states: DESTRUCTIBLE,
   },
 
@@ -274,18 +325,26 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_n/o0s_warps.glb',
     model: 'o0s_warps',
     sourceSet: 'special_n',
-    scroll: { 'o0s_1_swarp2.png': { y: -1.35 } },
+    scroll: { 'o0s_1_swarp2.png': { y: 0.6 } },
+    textures: {
+      'o0s_1_swarp2.png': { offsetX: 0, offsetY: -4.84, wrapS: 'mirror', wrapT: 'mirror' },
+      'o0s_0_swarp1.png': { offsetX: 0, offsetY: 0, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
   {
     id: 'area-warp-n',
     title: 'Area Warp (Variant N)',
     description:
-      'special_n area warp. Its o0s_1_fwarp2.png is a different image from the identically-named texture in every other special set — the reason these live in their own asset directory.',
+      'special_n area warp. Not a duplicate of the standard warps despite looking similar: the mesh differs and its o0s_1_fwarp2.png is a different image from the identically-named texture in every other special set — the reason these live in their own asset directory.',
     category: 'Warps',
     glb: '/assets/objects/special_n/o0s_warpm.glb',
     model: 'o0s_warpm',
     sourceSet: 'special_n',
-    scroll: { 'o0s_1_fwarp2.png': { y: -1.35 } },
+    scroll: { 'o0s_1_fwarp2.png': { x: -0.5 } },
+    textures: {
+      'o0s_1_fwarp2.png': { offsetX: -3.08, offsetY: 0 },
+      'o0s_0_fwarp1.png': { offsetX: 0, offsetY: 0, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
   {
     id: 'boss-warp-n',
@@ -309,9 +368,10 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
   },
   {
     id: 'return-warp',
-    title: 'Return Warp',
-    description: 'Exit pad that sends the player back to the City. Appears in special_e, special_sg and special_z.',
-    category: 'Warps',
+    title: 'Return Waypoint',
+    description:
+      'Waypoint marker carrying a home icon — the exit pad that sends the player back to the City. Grouped with the other indicators rather than the warps because it reads as a marker, not a transition. Appears in special_e, special_sg and special_z.',
+    category: 'Indicators',
     glb: '/assets/objects/special_z/o0c_return.glb',
     model: 'o0c_return',
     sourceSet: 'special_e',
@@ -324,7 +384,11 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_c3/o0s_warpcn.glb',
     model: 'o0s_warpcn',
     sourceSet: 'special_c3',
-    scroll: { 'o0s_1_cwarp1a2.png': { y: -0.8 } },
+    scroll: { 'o0s_1_cwarp2a.png': { x: -0.5 } },
+    textures: {
+      'o0s_1_cwarp2a.png': { offsetX: -2.68, offsetY: 5.31, repeatX: 1, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+      'o0s_1_cwarp1a2.png': { offsetX: 0, offsetY: 1, repeatX: 2, repeatY: 2, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
   {
     id: 'city-warp-b',
@@ -334,7 +398,11 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_c3/o0s_warpch.glb',
     model: 'o0s_warpch',
     sourceSet: 'special_c3',
-    scroll: { 'o0s_1_cwarp1b2.png': { y: -0.8 } },
+    scroll: { 'o0s_1_cwarp2b.png': { x: -0.5 } },
+    textures: {
+      'o0s_1_cwarp2b.png': { offsetX: -2.68, offsetY: 5.31, repeatX: 1, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+      'o0s_1_cwarp1b2.png': { offsetX: 0, offsetY: 1, repeatX: 2, repeatY: 2, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
   {
     id: 'city-warp-c',
@@ -344,7 +412,11 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_c3/o0s_warpcv.glb',
     model: 'o0s_warpcv',
     sourceSet: 'special_c3',
-    scroll: { 'o0s_1_cwarp1c2.png': { y: -0.8 } },
+    scroll: { 'o0s_1_cwarp2c.png': { x: -0.5 } },
+    textures: {
+      'o0s_1_cwarp2c.png': { offsetX: -2.68, offsetY: 5.31, repeatX: 1, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+      'o0s_1_cwarp1c2.png': { offsetX: 0, offsetY: 1, repeatX: 2, repeatY: 2, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
   {
     id: 'city-warp-absorb',
@@ -355,7 +427,11 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_c3/o0s_warpcb.glb',
     model: 'o0s_warpcb',
     sourceSet: 'special_c3',
-    scroll: { 'o0c_1_wabs1.png': { y: -0.8 } },
+    scroll: { 'o0c_1_wabs2.png': { y: 0.4 } },
+    textures: {
+      'o0c_1_wabs2.png': { offsetX: 0, offsetY: 2.48, repeatX: 1, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+      'o0c_1_wabs1.png': { offsetX: 0, offsetY: 0, repeatX: 2, repeatY: 1, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
 
   // --- City props --------------------------------------------------------
@@ -368,6 +444,10 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_c3/o00_compass.glb',
     model: 'o00_compass',
     sourceSet: 'special_c3',
+    textures: {
+      's00_1_back03.png': { offsetX: 0, offsetY: 1, repeatX: 2, repeatY: 2, wrapS: 'mirror', wrapT: 'mirror' },
+      's00_1_back02.png': { offsetX: 0, offsetY: 1, repeatX: 2, repeatY: 2, wrapS: 'mirror', wrapT: 'mirror' },
+    },
     scale: 0.12,
   },
   {
@@ -389,6 +469,9 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
     glb: '/assets/objects/special_z/o0c_ruller01.glb',
     model: 'o0c_ruller01',
     sourceSet: 'special_c1',
+    textures: {
+      's00_1_ring1.png': { offsetX: 0, offsetY: 1, repeatX: 2, repeatY: 2, wrapS: 'mirror', wrapT: 'mirror' },
+    },
   },
 
   // --- Ambient life ------------------------------------------------------
@@ -426,11 +509,21 @@ export const OBJECT_CATALOG: CatalogEntry[] = [
   {
     id: 'heal-pad',
     title: 'Heal Pad',
-    description: 'Healing floor pad. Present in nine of the fourteen special sets.',
+    description:
+      'Healing floor pad. Present in nine of the fourteen special sets. Used and unused are the same mesh — the sheet holds both frames side by side and the state shifts offsetX by half.',
     category: 'Pickups',
     glb: '/assets/objects/special_z/o0c_healhp.glb',
     model: 'o0c_healhp',
     sourceSet: 'special_02z',
+    states: [
+      { name: 'unused', label: 'Unused', description: 'Pad is charged and can still heal' },
+      { name: 'used', label: 'Used', description: 'Pad has been spent' },
+    ],
+    stateTextures: {
+      unused: { 'o0c_0_healhp.png': { offsetX: 0.5 } },
+      used: { 'o0c_0_healhp.png': { offsetX: -0.5 } },
+    },
+    stateTransitionMs: 450,
   },
   {
     id: 'z-sky-wetlands',

--- a/web/src/storybook/StorybookViewer.tsx
+++ b/web/src/storybook/StorybookViewer.tsx
@@ -31,14 +31,17 @@ import {
   BearTrap, bearTrapMeta,
   type StoryMeta,
 } from '../elements';
-import { OBJECT_CATALOG, CATALOG_CATEGORY_ORDER } from '../elements/objectCatalog';
-import { catalogComponent, catalogMeta } from '../elements/CatalogObject';
+import { OBJECT_CATALOG, CATALOG_CATEGORY_ORDER, type CatalogEntry } from '../elements/objectCatalog';
+import { catalogComponent, catalogMeta, CatalogObject } from '../elements/CatalogObject';
 
 // Registry of all elements with their components and metadata
 interface ElementEntry {
   id: string;
   Component: React.ComponentType<{ state?: string }>;
   meta: StoryMeta;
+  // Present for data-driven catalog objects. The viewer renders these directly
+  // so it can disable their built-in scroll and own texture.offset itself.
+  catalogEntry?: CatalogEntry;
 }
 
 interface CategoryEntry {
@@ -55,6 +58,7 @@ const HAND_WRITTEN: CategoryEntry[] = [
     elements: [
       { id: 'gate', Component: Gate as React.ComponentType<{ state?: string }>, meta: gateMeta },
       { id: 'key-gate', Component: KeyGate as React.ComponentType<{ state?: string }>, meta: keyGateMeta },
+      { id: 'area-warp', Component: AreaWarp as React.ComponentType<{ state?: string }>, meta: areaWarpMeta },
     ],
   },
   {
@@ -119,7 +123,6 @@ const HAND_WRITTEN: CategoryEntry[] = [
     name: 'Warps',
     elements: [
       { id: 'start-warp', Component: StartWarp as React.ComponentType<{ state?: string }>, meta: startWarpMeta },
-      { id: 'area-warp', Component: AreaWarp as React.ComponentType<{ state?: string }>, meta: areaWarpMeta },
     ],
   },
   {
@@ -143,6 +146,7 @@ const CATALOG_BY_CATEGORY = OBJECT_CATALOG.reduce<Record<string, ElementEntry[]>
     id: entry.id,
     Component: catalogComponent(entry),
     meta: catalogMeta(entry),
+    catalogEntry: entry,
   });
   return acc;
 }, {});
@@ -215,6 +219,11 @@ function getThreeWrapMode(mode: WrapMode): THREE.Wrapping {
 
 // --- Canvas-internal components ---
 
+/** How often the texture scanner re-checks the scene while waiting for a model. */
+const SCAN_INTERVAL_FRAMES = 5;
+/** Give up after ~10s at 60fps; a lazily-fetched GLB has long since arrived. */
+const SCAN_BUDGET_FRAMES = 600;
+
 /** Scans a group for textures and reports them to the parent */
 function TextureScanner({
   groupRef,
@@ -228,47 +237,76 @@ function TextureScanner({
   onTexturesFound: (textures: TextureInfo[]) => void;
 }) {
   const scanCount = useRef(0);
+  const settled = useRef(false);
 
   useFrame(() => {
-    // Scan on first few frames after element/state change to catch async GLB loads
-    if (scanCount.current < 10) {
-      scanCount.current++;
-      if (scanCount.current === 5 && groupRef.current) {
-        const instanceCounts: Record<string, number> = {};
-        const textureList: TextureInfo[] = [];
+    // Poll until the model is actually in the scene, rather than scanning one
+    // fixed frame. Hand-written elements preload their GLB at module scope so
+    // they are mounted almost immediately, but catalog objects are Suspense-
+    // loaded on select (deliberately not preloaded — 45 models would be several
+    // MB on open). Their mesh often isn't in the tree for many frames after the
+    // selection changes, so a single early scan reported "No textures found"
+    // for every catalog object and left the texture controls unusable.
+    if (settled.current) return;
+    scanCount.current++;
+    if (scanCount.current % SCAN_INTERVAL_FRAMES !== 0) return;
+    if (!groupRef.current) return;
 
-        groupRef.current.traverse((object) => {
-          if (!(object as THREE.Mesh).isMesh) return;
-          const mesh = object as THREE.Mesh;
-          const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    // Only look inside the subtree tagged with the current selection. A model
+    // left over from the previous element is still mounted for a few frames
+    // under its own tag, and scanning it is what made the inspector lag a
+    // selection behind.
+    let scope: THREE.Object3D | null = null;
+    groupRef.current.traverse((object) => {
+      if (!scope && object.userData?.elementId === elementId) scope = object;
+    });
+    if (!scope) return;
 
-          materials.forEach((mat) => {
-            const m = mat as any;
-            if (m.map && m.map instanceof THREE.Texture) {
-              const filename = getTextureFilename(m.map);
-              instanceCounts[filename] = (instanceCounts[filename] || 0) + 1;
-              const num = instanceCounts[filename];
-              const key = `${filename}#${num}`;
+    const instanceCounts: Record<string, number> = {};
+    const textureList: TextureInfo[] = [];
 
-              textureList.push({
-                name: `${filename} #${num}`,
-                key,
-                filename,
-                texture: m.map,
-                meshName: mesh.name,
-              });
-            }
+    (scope as THREE.Object3D).traverse((object) => {
+      if (!(object as THREE.Mesh).isMesh) return;
+      const mesh = object as THREE.Mesh;
+      const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+
+      materials.forEach((mat) => {
+        const m = mat as any;
+        if (m.map && m.map instanceof THREE.Texture) {
+          const filename = getTextureFilename(m.map);
+          instanceCounts[filename] = (instanceCounts[filename] || 0) + 1;
+          const num = instanceCounts[filename];
+          const key = `${filename}#${num}`;
+
+          textureList.push({
+            name: `${filename} #${num}`,
+            key,
+            filename,
+            texture: m.map,
+            meshName: mesh.name,
           });
-        });
+        }
+      });
+    });
 
-        onTexturesFound(textureList);
-      }
+    // Found the new model — report and stop polling.
+    if (textureList.length > 0) {
+      settled.current = true;
+      onTexturesFound(textureList);
+      return;
+    }
+    // Nothing after the budget: report empty so the panel says so honestly
+    // rather than polling forever on a genuinely texture-less element.
+    if (scanCount.current >= SCAN_BUDGET_FRAMES) {
+      settled.current = true;
+      onTexturesFound([]);
     }
   });
 
-  // Reset scan counter when element or state changes
+  // Restart the scan when element or state changes.
   useEffect(() => {
     scanCount.current = 0;
+    settled.current = false;
   }, [elementId, state]);
 
   return null;
@@ -329,12 +367,25 @@ function ModelSpinner({
 }
 
 function ElementPreview({ element, state }: { element: ElementEntry; state: string }) {
-  const { Component } = element;
+  const { Component, catalogEntry } = element;
 
+  // Tag the subtree with the element it belongs to. Suspense keeps the previous
+  // model mounted while the next GLB loads, so the scanner needs a way to tell
+  // whose meshes it is looking at — without this it reports the outgoing
+  // object and the inspector runs one selection behind.
   return (
+    <group userData={{ elementId: element.id }}>
     <Suspense fallback={null}>
-      <Component key={element.id} state={state} />
+      {catalogEntry ? (
+        // animate={false}: the panel's TextureAnimator owns texture.offset here,
+        // so the scroll controls actually take effect instead of being fought
+        // frame-for-frame by the entry's authored scroll.
+        <CatalogObject key={element.id} entry={catalogEntry} state={state} animate={false} />
+      ) : (
+        <Component key={element.id} state={state} />
+      )}
     </Suspense>
+    </group>
   );
 }
 
@@ -426,8 +477,13 @@ export default function StorybookViewer() {
     setOffsetY(tex.offset.y);
     setWrapS(getWrapModeName(tex.wrapS));
     setWrapT(getWrapModeName(tex.wrapT));
-    setScrollX(0);
-    setScrollY(0);
+    // Seed the scroll controls from the catalog's authored value for this
+    // texture, so the panel opens showing what the object actually does and a
+    // wrong direction can be corrected by flipping the sign in place. Falls
+    // back to 0 for hand-written elements and unscrolled textures.
+    const authoredScroll = selectedElement.catalogEntry?.scroll?.[selectedTexture.filename];
+    setScrollX(authoredScroll?.x ?? 0);
+    setScrollY(authoredScroll?.y ?? 0);
 
     // Generate preview
     const image = tex.image as CanvasImageSource | null;
@@ -447,7 +503,7 @@ export default function StorybookViewer() {
     } else {
       setPreviewUrl(null);
     }
-  }, [selectedTexture]);
+  }, [selectedTexture, selectedElement]);
 
   // Apply changes to texture in real-time
   useEffect(() => {

--- a/web/src/storybook/StorybookViewer.tsx
+++ b/web/src/storybook/StorybookViewer.tsx
@@ -31,6 +31,8 @@ import {
   BearTrap, bearTrapMeta,
   type StoryMeta,
 } from '../elements';
+import { OBJECT_CATALOG, CATALOG_CATEGORY_ORDER } from '../elements/objectCatalog';
+import { catalogComponent, catalogMeta } from '../elements/CatalogObject';
 
 // Registry of all elements with their components and metadata
 interface ElementEntry {
@@ -44,7 +46,10 @@ interface CategoryEntry {
   elements: ElementEntry[];
 }
 
-const CATEGORIES: CategoryEntry[] = [
+// Hand-written elements — the ones with real gameplay state (open/closed,
+// raised/lowered, animated pickups). Everything else in the object archive is
+// data-driven from OBJECT_CATALOG and merged in below.
+const HAND_WRITTEN: CategoryEntry[] = [
   {
     name: 'Gates',
     elements: [
@@ -131,6 +136,35 @@ const CATEGORIES: CategoryEntry[] = [
     ],
   },
 ];
+
+// Catalog entries grouped by their declared category.
+const CATALOG_BY_CATEGORY = OBJECT_CATALOG.reduce<Record<string, ElementEntry[]>>((acc, entry) => {
+  (acc[entry.category] ||= []).push({
+    id: entry.id,
+    Component: catalogComponent(entry),
+    meta: catalogMeta(entry),
+  });
+  return acc;
+}, {});
+
+/**
+ * Merge the catalog into the hand-written categories: an entry whose category
+ * already exists is appended to it, and any remaining category is added in
+ * CATALOG_CATEGORY_ORDER. That keeps e.g. every warp under one "Warps" heading
+ * instead of splitting hand-written and catalog objects into parallel lists.
+ */
+const CATEGORIES: CategoryEntry[] = (() => {
+  const remaining = new Set(Object.keys(CATALOG_BY_CATEGORY));
+  const merged = HAND_WRITTEN.map((cat) => {
+    remaining.delete(cat.name);
+    return { ...cat, elements: [...cat.elements, ...(CATALOG_BY_CATEGORY[cat.name] ?? [])] };
+  });
+
+  const extras = [...remaining].sort(
+    (a, b) => CATALOG_CATEGORY_ORDER.indexOf(a) - CATALOG_CATEGORY_ORDER.indexOf(b),
+  );
+  return [...merged, ...extras.map((name) => ({ name, elements: CATALOG_BY_CATEGORY[name] }))];
+})();
 
 // Flatten for lookup
 const ALL_ELEMENTS = CATEGORIES.flatMap((cat) => cat.elements);
@@ -315,6 +349,23 @@ const WRAP_MODES: { value: WrapMode; label: string }[] = [
 
 export default function StorybookViewer() {
   const [selectedId, setSelectedId] = useState<string>(ALL_ELEMENTS[0].id);
+  // The catalog port took the sidebar from ~25 to ~70 entries, past what fits
+  // on screen, so the list is filterable by title.
+  const [filter, setFilter] = useState('');
+
+  const visibleCategories = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return CATEGORIES;
+    return CATEGORIES.map((cat) => ({
+      ...cat,
+      elements: cat.elements.filter(
+        (el) =>
+          el.meta.title.toLowerCase().includes(needle) ||
+          el.id.includes(needle) ||
+          cat.name.toLowerCase().includes(needle),
+      ),
+    })).filter((cat) => cat.elements.length > 0);
+  }, [filter]);
   const [states, setStates] = useState<Record<string, string>>(() => {
     const initial: Record<string, string> = {};
     ALL_ELEMENTS.forEach((el) => {
@@ -512,7 +563,28 @@ export default function StorybookViewer() {
         padding: '1rem',
         background: '#151525',
       }}>
-        {CATEGORIES.map((category) => (
+        <input
+          type="search"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={`Filter ${ALL_ELEMENTS.length} objects…`}
+          style={{
+            width: '100%',
+            marginBottom: '1rem',
+            padding: '8px 10px',
+            background: '#0f0f1e',
+            border: '1px solid #333',
+            borderRadius: '6px',
+            color: 'white',
+            fontSize: '12px',
+          }}
+        />
+
+        {visibleCategories.length === 0 && (
+          <div style={{ color: '#666', fontSize: '12px' }}>No objects match “{filter}”.</div>
+        )}
+
+        {visibleCategories.map((category) => (
           <div key={category.name} style={{ marginBottom: '1.5rem' }}>
             <div style={{
               fontSize: '11px',


### PR DESCRIPTION
## Why

The storybook covered 25 of the objects PSZ ships. The [asset viewer](https://dashgl.github.io/psz-asset-viewer/objects/) exposes the rest, and they've been sitting there unported — including things we didn't have models for at all in this repo. This brings the gallery to **70 entries**, covering every unique environment object in the archive.

## What "unique" turned out to mean

The viewer lists 52 object *sets* holding 951 model instances. Hashing each model directory (the `.glb` plus its `.png`) collapses that to **104 unique** — every `o0c_*` "common" object is **byte-identical across all nine fields**, so a set-by-set port would have been ~9x redundant. Dropping the 35 `np_*` city NPCs (see follow-up below) leaves **69 distinct environment objects**, and **24 of them had no model in this repo at all**.

Two cases where the same *name* really is a different *object*, so both are separate entries:

| Case | Why it can't be deduped |
|---|---|
| Per-field art — `oNN_cont` / `oNN_wall` / `oNN_wallptcl` | Distinct mesh **and** texture in every field. `Box` and `Wall` are retitled `(Gurhacia Valley)` and joined by the other seven fields, plus the tower's container (the tower ships no wall). |
| The `special_n` warp set | Its `warpb`/`warpm`/`warps` are different meshes **and different images behind the same filenames** — `special_n/o0s_1_fwarp2.png` is not the file every other special set calls that. They get their own `assets/objects/special_n/` directory so the two can't collide, and their own `(Variant N)` entries. |

The `special_n` start warp is a raised column with a scrolling surface; the standard one is a flat pad. Porting only one would have lost real content.

## How

Data-driven rather than 45 near-identical components:

- **`web/src/elements/objectCatalog.ts`** — one entry per object: title, description, GLB path, source model + set (traceable back to the viewer), category, and any scale/wrap/scroll it needs.
- **`web/src/elements/CatalogObject.tsx`** — the single renderer.
- **`web/src/elements/materials.ts`** — shared texture setup.
- **`StorybookViewer.tsx`** — merges catalog entries into the existing categories, so all warps sit under one *Warps* heading rather than a parallel list.

Hand-written elements are untouched apart from the two retitles — they keep their real gameplay state (open/closed, raised/lowered, animated pickups).

### Three things the models needed

**Mirrored wrapping by default.** The `.imd` → glTF converter defaults most samplers to `REPEAT` — 74 of the 122 samplers across the object set — which seams anywhere a UV runs past 1.0. PSZ authored this art to mirror, and every hand-written element already forced that inline; `materials.ts` makes it the shared default with per-texture opt-outs.

**2×2 UV scale on the box and wall families only.** Not a guess — `GameElement._setup_mirror_textures()` binds the mirror_repeat shader at `uv_scale = Vector2(2, 2)`, and `box.gd` / `wall.gd` are its only two callers. Their UVs run `[-0.25, 1.0]`, so at 1× the crate motif smears across the whole face; at 2× it tiles the way the game draws it. Everything else stays at 1×.

**`detachSkinnedBind()`.** Every object GLB is a `SkinnedMesh` — all 117, even one-bone static props. three's default `AttachedBindMode` recomputes `bindMatrixInverse` from the mesh world matrix every frame, so ancestor scale gets inverted out of the skinning result and re-applied by the model-view matrix; the two cancel and **scale silently does nothing**. Without this, `o0s_zsky` (126 units across) can't be brought into frame at all. Safe here because the bind pose is identity on these props.

Preview scale otherwise stays at the authored size, so the gallery still shows true relative size (a wall really is ~6× a box). Only the extreme outliers override it.

### Sidebar filter

70 entries no longer fit on screen, so the sidebar gained a filter box.

## Assets

82 files added under `assets/objects/` (new `wetlands/`, `snowfield/`, `makara/`, `paru/`, `arca/`, `shrine/`, `tower/`, `special_n/` dirs plus additions to `valley/` and `special_z/`), **already mirrored to R2** — verified serving 206 on range-probe.

No pack republish: nothing in Godot references these yet, so `assets_manifest.json` is unchanged and `verify-assets` should pass untouched.

## Testing

- `tsc -b` clean; `vite build` clean.
- All 44 catalog GLB paths HTTP-checked through the dev server: 200 + glTF magic, and every texture URI each one references resolves on disk.
- Clicked through all 70 sidebar entries in a real browser — every textured model reports its textures to the inspector. The two that report none are correct: `o0c_bullet01` and `o0c_meseta` genuinely ship with no image.
- Visually spot-checked box variants across fields, the `special_n` vs standard warp pair, wall debris, the compasses, and the sky backdrop.
- `npm test`: 603/604. The one failure (`boss-room-segments`, `boss_robot`) is **pre-existing and unrelated** — it reproduces identically with every file from this branch removed. See below.

## Not in this PR

- **The 35 `np_*` city NPCs.** They're character models with their own `assets/npcs/` pipeline (7 are already there), not traversal elements. Tracked in the follow-up issue.
- **Pre-existing local asset drift.** `npm run sync-tree` wanted to push 126 files unrelated to this branch — `player/animations` (51), two `stages/city_e` `lndmd` trees (47), weapons, and a stale `assets/enemies/boss_robot/boss_robot.glb` whose clip inventory no longer matches the pinned test. I uploaded only the 82 files this PR adds rather than let that ride along. Worth a look separately — the boss_robot drift is what's failing that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)