### PR TITLE
Make sanity-check honest on a Mac, and actually run #591's guards in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,20 @@ jobs:
       - name: Orphan-file ratchet
         run: python3 scripts/tools/orphan_files.py --check
 
+      # The generator's own output, not the unit tests' view of it: the seeded
+      # tests call FieldPopulation.authored_objects directly, so they cannot
+      # catch the generator forgetting to call it. This reads the committed
+      # dump and asserts every authored object landed inside its room (#591).
+      - name: Generated fields carry their authored objects
+        run: python3 scripts/tools/check_generated_objects.py
+
+      # Drift guard for data/re_reference/room_objects.json against psz-re.
+      # Self-skips (exit 0) when psz-re is not checked out, which is the CI
+      # case — it earns its keep on a dev box with $PSZ_RE set, and costs a
+      # second here so nobody has to remember to run it (#591).
+      - name: Authored-object table has not drifted from psz-re
+        run: python3 scripts/tools/refield/import_re_objects.py --check
+
       # Beta working agreement: accepting debt (growing any baseline) must be
       # loud and deliberate — requires a `Debt-Accepted: <reason>` trailer in
       # a PR commit. Decreases pass silently. spec /engineering.

--- a/scripts/tools/autoplay/sanity_check.sh
+++ b/scripts/tools/autoplay/sanity_check.sh
@@ -20,7 +20,18 @@ set -uo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 GODOT="${GODOT:-$(command -v godot || echo /home/kion/.local/bin/godot)}"
-USERDIR="$HOME/.local/share/godot/app_userdata/PSZ Godot"
+
+# Godot's user:// root is per-platform, and this used to be the Linux path
+# unconditionally. On a Mac that made the reset below a silent no-op: the run
+# then booted an already-configured, already-created character, so the four
+# first-run checkpoints (input_select, character_create) could not fire and the
+# check reported four failures that had nothing to do with the diff under test.
+# SANITY_USERDIR overrides both.
+case "$(uname -s)" in
+	Darwin) DEFAULT_USERDIR="$HOME/Library/Application Support/Godot/app_userdata/PSZ Godot" ;;
+	*)      DEFAULT_USERDIR="${XDG_DATA_HOME:-$HOME/.local/share}/godot/app_userdata/PSZ Godot" ;;
+esac
+USERDIR="${SANITY_USERDIR:-$DEFAULT_USERDIR}"
 MANIFEST="$REPO/assets_manifest.json"
 PACK="$REPO/dist/assets.pck"
 TIMEOUT="${SANITY_TIMEOUT:-600}"
@@ -38,11 +49,33 @@ if [ ! -f "$PACK" ]; then
 	exit 1
 fi
 
+# coreutils `timeout` is not on macOS. Prefer it, then gtimeout (brew
+# coreutils), then a fork/kill equivalent — same contract, 124 on expiry.
+run_with_timeout() {
+	local secs="$1"; shift
+	if command -v timeout >/dev/null 2>&1; then timeout "$secs" "$@"; return $?; fi
+	if command -v gtimeout >/dev/null 2>&1; then gtimeout "$secs" "$@"; return $?; fi
+	"$@" &
+	local child=$!
+	( sleep "$secs"; kill -TERM "$child" 2>/dev/null ) &
+	local watcher=$!
+	wait "$child"; local rc=$?
+	kill "$watcher" 2>/dev/null; wait "$watcher" 2>/dev/null
+	[ "$rc" -ge 128 ] && rc=124
+	return "$rc"
+}
+
 # 1) Fresh player state. Keep packs/ so the local pack stays cached between runs
 #    (first run copies it from dist — the "download" — later runs cache-hit).
+#
+#    Moved aside rather than deleted. This is a disposable-dev-box script by
+#    design, but it also runs on kion's Mac, where user:// is a real save — so
+#    the reset keeps one generation back instead of being unrecoverable.
 echo "[sanity-check] resetting player state (input_config.json, save_data.json)…"
-mkdir -p "$USERDIR"
-rm -f "$USERDIR/input_config.json" "$USERDIR/save_data.json"
+mkdir -p "$USERDIR/_sanity_backup"
+for f in input_config.json save_data.json; do
+	[ -f "$USERDIR/$f" ] && mv -f "$USERDIR/$f" "$USERDIR/_sanity_backup/$f"
+done
 
 # 2) Repoint the manifest at the local pack so bootstrap copies from disk, not
 #    Arweave. sha256/size are read from the actual file so it always verifies.
@@ -67,8 +100,9 @@ JSON
 # transition, interact at the guild NPC must be consumed by the menu).
 MENU_CARRY="${SANITY_MENU_CARRY:-0}"
 echo "[sanity-check] launching game under autopilot (timeout ${TIMEOUT}s, menu-carry=${MENU_CARRY})…"
-PSZ_AUTOPILOT=1 PSZ_AUTOPILOT_MENU_CARRY="$MENU_CARRY" \
-	timeout "$TIMEOUT" "$GODOT" --headless --path "$REPO" >"$LOG" 2>&1
+run_with_timeout "$TIMEOUT" \
+	env PSZ_AUTOPILOT=1 PSZ_AUTOPILOT_MENU_CARRY="$MENU_CARRY" \
+	"$GODOT" --headless --path "$REPO" >"$LOG" 2>&1
 RC=$?
 
 echo "── game log (bootstrap / sanity) ──"


### PR DESCRIPTION
## Why

Both halves of this came out of merging #591 — two guards that were not guarding.

## `sanity-check` reported four failures that were not real

`USERDIR` was the Linux path unconditionally:

```bash
USERDIR="$HOME/.local/share/godot/app_userdata/PSZ Godot"
```

On macOS `user://` lives under `~/Library/Application Support/…`, so the "reset player state" step deleted nothing. The run then booted an **already-configured, already-created** character, and the four first-run checkpoints could not fire:

```
FAIL: first-run → controller-config screen (missing: 'routing to input_select')
FAIL: autopilot drove controller config (missing: '[sanity] input_select: injecting keyboard')
FAIL: reached character create (missing: '[sanity] checkpoint: character_create')
FAIL: entered character name (missing: '[sanity] entering name:')
══ SANITY CHECK FAILED (23 passed, 4 failed, godot rc=0) ══
```

That is the worst failure mode a gate can have — it reads as a regression in whatever you just changed, and none of the four had anything to do with the diff under test. It also means the gate has been passing/failing for the wrong reasons on the Mac for as long as anyone has run it there.

Same script, same commit, after the fix:

```
══ SANITY CHECK PASSED (27 checks, godot rc=0) ══
```

— the four first-run checkpoints among them, which is what proves the path resolution rather than just the absence of a failure.

Two more portability fixes while in there:

- **macOS ships no coreutils `timeout`**, so the launch line failed outright before the game even started. `run_with_timeout` prefers `timeout`, then `gtimeout` (brew coreutils), then a fork/kill equivalent with the same 124-on-expiry contract.
- **The reset moves rather than deletes.** The two files go to `_sanity_backup/` instead of `rm -f`. This is a disposable-dev-box script by design and the header says so, but it demonstrably also runs on the Mac, where `user://` is a real save — one generation back beats unrecoverable.

`SANITY_USERDIR` overrides the resolution on either platform, and Linux now honours `XDG_DATA_HOME` (which is how the autoplay harness already stages its scratch userdirs).

## #591's two guards were never wired up

#591 ships `scripts/tools/check_generated_objects.py` as its second test layer — the one that catches the *generator* failing to call `authored_objects()`, which unit tests structurally cannot — and `import_re_objects.py --check` as a drift guard, described as being there "so the file cannot go stale against psz-re silently".

Neither appeared in any workflow. Both now run in `code-health`:

- `check_generated_objects.py` — reads the committed dump the real generator produced. Currently: **392 cells over 7 areas, 804 containers, 293 traps over all 8 families, every authored position inside its room.**
- `import_re_objects.py --check` — self-skips with exit 0 when psz-re is not checked out, which is exactly the CI case. It costs a second here and earns its keep on a dev box with `$PSZ_RE` set, so nobody has to remember to run it.

## Verification

- `npm run sanity-check`: **27 of 27** for `93257b66`, up from 23/27 on the same commit before the fix. The delta is precisely the four first-run checkpoints.
- `check_generated_objects.py` and `import_re_objects.py --check` both green standalone.
- `code_graph --check` and `orphan_files --check` clean.
- No `.gd`, scene or quest data touched, so no autopilot matrix — the only Godot-adjacent change is the harness that *drives* it, and its own run is the evidence above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
