### PR TITLE
Place the authored walls, gate them at spawn time (#593); document the unreachable layout 4 (#592)

### DIFF
--- a/data/re_reference/room_objects.json
+++ b/data/re_reference/room_objects.json
@@ -9,7 +9,8 @@
   "the layout index is a rand(100) draw against a depth-banded weight row",
   "a mask is eligible only if every group it names is non-empty; group 5 is forced in",
   "group 5 is ROLLED: rand(100) against [40,20,20,20] for a count of 0..3, Fisher-Yates shuffle, take that many",
-  "a group is truncated to 20 records and a room stops at 20 objects"
+  "a group is truncated to 20 records and a room stops at 20 objects",
+  "THERE ARE FIVE MASKS AND ONLY FOUR ARE REACHABLE, BY DESIGN. The layout index comes from FUN_02082814, which psz-re reads as a weighted draw returning a category 0..3 against the table at 0x020f2e70 -- twelve ints as three rows of four, every row summing to 100 -- and validates on all 44 values across five captured fields being in 0..3. So mask 4 (0x30), the only one naming group 4, is never selected by the depth-banded draw and group 4's objects never spawn in a free field. That is faithful, not a bug: psz-re's NOT_ESTABLISHED records a mission-guarded path that forces layout 4, which it has not modelled and which free-roam generation correctly never takes. Do not 'fix' the mask table or widen the draw."
  ],
  "layout_masks": [
   33,
@@ -60,6 +61,35 @@
   "capture_trap": 66,
   "burn_trap": 43,
   "needler_trap": 16
+ },
+ "not_imported_yet": {
+  "_": "Kinds psz-re emits that this importer deliberately does not take yet -- psz-godot #594 widens CONTAINER_KINDS and adds the spawner cases together. Listed so the gap is visible rather than silent.",
+  "counts": {
+   "o0c_key": 836,
+   "o0c_trebox": 653,
+   "o0c_switchf": 107,
+   "o0c_mspack": 102,
+   "o0c_fence": 98,
+   "o0c_shfence": 41,
+   "o0c_needle": 41,
+   "o0c_remswitch": 26,
+   "o0c_dgfance": 26,
+   "o0c_switchs": 24,
+   "o0s_warpm": 21,
+   "o0c_fence4": 18,
+   "o0c_butterfly": 16,
+   "o0s_warps": 15,
+   "o0c_return": 15,
+   "o0c_healhp": 14,
+   "o0s_warpb": 14,
+   "o0c_warparena1": 14,
+   "o0c_dragonfly": 8,
+   "o0c_poisonm": 7,
+   "np_011_00_0": 5,
+   "np_014_00_0": 5,
+   "np_019_00_0": 5,
+   "o0c_bird": 1
+  }
  },
  "rooms": {
   "s00a_nr1_d": {

--- a/scripts/3d/field/cell_object_spawner.gd
+++ b/scripts/3d/field/cell_object_spawner.gd
@@ -1098,7 +1098,21 @@ func _spawn_bear_trap(pos: Vector3) -> void:
 	print("[CellObjects] BearTrap at %s" % pos)
 
 
+## Authored walls, skipped at SPAWN time under PSZ_AUTOPILOT_NO_WALLS.
+##
+## Deliberately its own variable rather than folded into NO_OBSTACLES: that one
+## strips a stage's baked obstacle collision, which is a property of the room
+## mesh, while this drops a placed object. A run that wants to prove walls do
+## not wedge the backbone needs to turn exactly one of them off.
+##
+## The skip is here and not in FieldPopulation because the gate must not change
+## the field DATA: a cell first entered under autopilot would otherwise save
+## without its walls and restore that way forever, and the committed
+## generated-fields dump would describe a world no player sees. Same reason and
+## same shape as PSZ_AUTOPILOT_NO_BOXES above.
 func _spawn_wall(pos: Vector3, rotation_deg: float, is_destructible: bool = true) -> void:
+	if OS.has_environment("PSZ_AUTOPILOT_NO_WALLS"):
+		return
 	var wall := WallScript.new()
 	wall.is_destructible = is_destructible
 	_c._map_root.add_child(wall)

--- a/scripts/3d/field/field_population.gd
+++ b/scripts/3d/field/field_population.gd
@@ -367,6 +367,20 @@ static func _to_object(rec: Dictionary) -> Dictionary:
 		snappedf(float(rec.get("z", 0.0)), 0.01),
 	]
 	var obj: Dictionary = {"type": kind, "position": pos, "authored": true}
+	if kind == "wall":
+		# OURS, and stated rather than inherited from the spawner's default.
+		# psz-re's wall_placement_per_room.json is explicit that "no wall
+		# BEHAVIOUR is decoded -- hit points, whether it breaks at all", so
+		# there is no measured answer to port. Breakable is the failure-safe
+		# reading: no authored wall blocks a connection today (5.14 cells of
+		# clearance across the corpus), but if one ever did, a player can clear
+		# a breakable wall and cannot clear a solid one.
+		#
+		# The thread to pull if this is ever settled: the container constructor
+		# special-cases record byte +0x12 == 1 -- it additionally enables the
+		# collider and stores 2 rather than 3 -- which is the likeliest
+		# solid/breakable discriminator. This importer does not carry +0x12.
+		obj["destructible"] = true
 	# The spawner's `rotation` is degrees everywhere (it calls deg_to_rad), so
 	# convert here rather than leaving a second unit in the object schema.
 	var facing_deg: float = float(int(rec.get("a", 0))) / FACING_PER_TURN * 360.0

--- a/scripts/3d/field/field_population.gd
+++ b/scripts/3d/field/field_population.gd
@@ -37,7 +37,9 @@ class_name FieldPopulation
 ##            builds whole. A port that built groups 0..4 and stopped would
 ##            place almost no traps at all.
 ##
-##   walls    Authored too, and deliberately NOT placed — see PLACE_WALLS.
+##   walls    DECODED and PLACED (#593). The autopilot skips them at spawn
+##            time, not generation time, so the field data is the same
+##            either way.
 ##
 ## Enemy positions are still ours: the game's enemy deploy table is a separate
 ## file that has not been decoded to positions, so enemies stay on a ring.
@@ -57,14 +59,22 @@ const BOXES_PER_ROOM := 2
 const ENEMY_RING_RADIUS := 5.0
 const BOX_RING_RADIUS := 8.0
 
-## Authored walls are in the table and are NOT placed.
+## Authored walls ARE placed (#593), and the soft-lock fear that used to gate
+## them here is measured away.
 ##
-## They are as measured as the boxes, so this is a gameplay call rather than a
-## data one: a wall blocks, the free-roam autopilot's walk backbone cannot
-## attack one, and a room whose authored wall sits across the line between two
-## doorways is a soft-lock rather than a cosmetic complaint. Turning this on
-## needs the nav harness to route around blockers first.
-const PLACE_WALLS := false
+## The old gate lived in `_to_object()` — generation time — which was the wrong
+## place twice over: the generated field DATA differed between an autopilot run
+## and a player run, and a cell first entered under autopilot saved without its
+## walls and restored that way forever. The skip now lives at spawn time in
+## CellObjectSpawner, next to the one boxes already use.
+##
+## And the reason for the gate does not survive contact with psz-re's own
+## measurement. Over all 964 authored wall records the smallest distance from a
+## wall to any doorway mouth of its own room is 5.14 cells — with a control that
+## the same ruler finds the room warp at 0.01 and `o0c_fence` at 1.31, so it
+## does detect things that stand in a doorway. An authored wall never blocks a
+## connection. `test_authored_walls_clear_doorways` re-derives that from our own
+## copy of the data rather than trusting the number.
 
 ## The game's facing is 16 bits per turn, 0 = +Z increasing toward +X, which is
 ## exactly Godot's `rotation.y` about a +Z forward. So the conversion is a
@@ -223,6 +233,19 @@ static func _resolve(re_name: String) -> Array:
 ##      So 40% of rooms roll no group-5 object at all.
 ##   5. A group is truncated at 20 records and a room stops at 20 objects.
 ##
+## THERE ARE FIVE MASKS AND ONLY FOUR ARE REACHABLE, BY DESIGN — do not "fix"
+## this. The layout index comes from the original's FUN_02082814, which psz-re
+## reads as a weighted draw returning a category 0..3 against the table at
+## 0x020f2e70 (twelve ints as three rows of four, every row summing to 100),
+## validated on all 44 values across five captured fields being in 0..3. So
+## mask 4 = 0x30 — the only one naming group 4 — is never selected here, and
+## group 4's objects never spawn in a free field. 146 of set d's records sit
+## there, and `s07a_ga1_d` is entirely group 4, which is why that room falls
+## through to the ring. psz-re's own NOT_ESTABLISHED records a mission-guarded
+## path that forces layout 4; it has not modelled it, and free-roam generation
+## correctly never takes it. Widening the draw would spawn objects the original
+## does not spawn.
+##
 ## `depth` is the room's distance along the generated path; -1 means unknown
 ## and takes the middle weight row. Every draw goes through `rng`, so a seeded
 ## generator reproduces a field exactly.
@@ -338,8 +361,6 @@ static func _cap(records: Array, limit: int) -> Array:
 ## kind this build does not place.
 static func _to_object(rec: Dictionary) -> Dictionary:
 	var kind: String = str(rec.get("k", ""))
-	if kind == "wall" and not PLACE_WALLS:
-		return {}
 	var pos: Array = [
 		snappedf(float(rec.get("x", 0.0)), 0.01),
 		snappedf(float(rec.get("y", 0.0)), 0.01),

--- a/scripts/tools/autoplay/record_free_roam.sh
+++ b/scripts/tools/autoplay/record_free_roam.sh
@@ -9,7 +9,9 @@
 # only paths the quest matrix can't reach (entry spawns, goal pads, section
 # warps, key detours). Exits non-zero unless the run prints `[sanity] DONE ok`.
 #
-# Env: FIELD_AREA (default gurhacia).
+# Env: FIELD_AREA (default gurhacia). NO_WALLS=1 skips the authored walls --
+# leave it UNSET to prove the walls do not wedge the walk backbone, which is
+# the evidence #593 asks for; set it when iterating on waypoints.
 # Output: $OUTDIR/freeroam_<area>_<ts>.mp4 + .sanity.log
 set -uo pipefail
 
@@ -44,6 +46,7 @@ rm -f "$USERDIR/input_config.json" "$USERDIR/save_data.json"
 
 echo "[record-freeroam] driving free-roam field area=$AREA → $SANITY"
 env PSZ_AUTOPILOT=1 PSZ_AUTOPILOT_FIELD="$AREA" LIBGL_ALWAYS_SOFTWARE=1 \
+	${NO_WALLS:+PSZ_AUTOPILOT_NO_WALLS=1} \
 	timeout "$TIMEOUT" xvfb-run -a -s "-screen 0 640x360x24" \
 	"$GODOT" --write-movie "$AVI" --fixed-fps "$FPS" \
 	--disable-vsync --audio-driver Dummy --path "$REPO" >"$SANITY" 2>&1

--- a/scripts/tools/autoplay/record_the_paru_pact.sh
+++ b/scripts/tools/autoplay/record_the_paru_pact.sh
@@ -68,6 +68,7 @@ PSZ_AUTOPILOT=1 \
 	PSZ_AUTOPILOT_QUEST=the_paru_pact \
 	PSZ_AUTOPILOT_NO_OBSTACLES=1 \
 	PSZ_AUTOPILOT_NO_BOXES=1 \
+	PSZ_AUTOPILOT_NO_WALLS=1 \
 	LIBGL_ALWAYS_SOFTWARE=1 \
 	xvfb-run -a -s "-screen 0 ${RES}x24" \
 	timeout "$TIMEOUT" "$GODOT" --write-movie "$AVI" --fixed-fps "$FPS" \

--- a/scripts/tools/autoplay/run_quest_matrix.sh
+++ b/scripts/tools/autoplay/run_quest_matrix.sh
@@ -59,6 +59,7 @@ run_godot() {
     PSZ_AUTOPILOT_PHASE=first-mission \
     PSZ_AUTOPILOT_NO_OBSTACLES=1 \
     PSZ_AUTOPILOT_NO_BOXES=1 \
+    PSZ_AUTOPILOT_NO_WALLS=1 \
     PSZ_AUTOPILOT_QUEST="$quest" \
     XDG_DATA_HOME="$userdir" \
     LIBGL_ALWAYS_SOFTWARE=1 \

--- a/scripts/tools/autoplay/run_regression_matrix.sh
+++ b/scripts/tools/autoplay/run_regression_matrix.sh
@@ -219,6 +219,7 @@ JSON
         PSZ_AUTOPILOT_PHASE=first-mission \
         PSZ_AUTOPILOT_NO_OBSTACLES=1 \
         PSZ_AUTOPILOT_NO_BOXES=1 \
+        PSZ_AUTOPILOT_NO_WALLS=1 \
         PSZ_AUTOPILOT_QUEST="$quest" \
         $SPEED_ENV \
         $PROBE_EXTRA_ENV \

--- a/scripts/tools/check_generated_objects.py
+++ b/scripts/tools/check_generated_objects.py
@@ -98,9 +98,11 @@ def main() -> int:
     if out_of_cell:
         failures.append("%d authored objects outside the room + its door stubs: %s"
                         % (len(out_of_cell), out_of_cell[:5]))
-    if walls:
-        failures.append("%d walls placed while FieldPopulation.PLACE_WALLS is false: %s"
-                        % (len(walls), walls[:5]))
+    # #593 moved the wall gate to spawn time, so the generated DATA must carry
+    # them now — their absence is the regression, not their presence.
+    if not walls:
+        failures.append("no authored walls in any generated field — the gate has "
+                        "drifted back into generation time")
 
     if failures:
         print("FAIL:")
@@ -110,8 +112,8 @@ def main() -> int:
 
     print("ok: %d cells over %d areas, %d with objects"
           % (cells, len(doc.get("areas", [])), cells_with_objects))
-    print("    containers %d, traps %d over %d families (%s)"
-          % (containers, traps, len(families), ", ".join(families)))
+    print("    containers %d, traps %d over %d families (%s), walls %d"
+          % (containers, traps, len(families), ", ".join(families), len(walls)))
     print("    every authored position is inside its room (44x44 + 3-unit door stubs)")
     return 0
 

--- a/scripts/tools/refield/import_re_objects.py
+++ b/scripts/tools/refield/import_re_objects.py
@@ -69,6 +69,19 @@ CAPS = {"per_group": 20, "per_room": 20}
 
 DEFAULT_SETS = ("d",)
 
+## The object kinds this importer takes, and it is an ALLOWLIST on purpose.
+##
+## psz-re's object dump is being extended to emit every classified kind on the
+## same schema (keys, fences, switches, mspack, NPCs, warps -- psz-godot #594).
+## Taking a kind the spawner does not handle would be worse than not taking it:
+## the record still counts against the 20-object room cap, so an unhandled key
+## would silently displace a box or a trap. And an allowlist means this file
+## does not churn every time the upstream dump grows.
+##
+## Widening this is #594's job, together with the spawner cases. Anything not
+## listed is counted and reported, never dropped silently.
+CONTAINER_KINDS = ("box", "rare_box", "wall")
+
 
 def psz_re_root(explicit: str | None) -> pathlib.Path | None:
     for candidate in (explicit, os.environ.get("PSZ_RE"),
@@ -94,6 +107,7 @@ def build(re_root: pathlib.Path, sets: tuple[str, ...]) -> dict:
 
     rooms: dict[str, dict] = {}
     unknown_traps: set[str] = set()
+    deferred: dict[str, int] = {}
 
     def room_entry(key: str, rec: dict) -> dict:
         entry = rooms.get(key)
@@ -109,9 +123,13 @@ def build(re_root: pathlib.Path, sets: tuple[str, ...]) -> dict:
             continue
         entry = room_entry(key, rec)
         for box in rec.get("boxes", []):
+            kind = str(box.get("kind", "box"))
+            if kind not in CONTAINER_KINDS:
+                deferred[kind] = deferred.get(kind, 0) + 1
+                continue
             entry["objects"].append({
                 "g": box.get("group"),
-                "k": str(box.get("kind", "box")),
+                "k": kind,
                 "x": _round(box.get("x", 0.0)),
                 "y": _round(box.get("y", 0.0)),
                 "z": _round(box.get("z", 0.0)),
@@ -167,12 +185,28 @@ def build(re_root: pathlib.Path, sets: tuple[str, ...]) -> dict:
             "group 5 is ROLLED: rand(100) against [40,20,20,20] for a count of 0..3, "
             "Fisher-Yates shuffle, take that many",
             "a group is truncated to 20 records and a room stops at 20 objects",
+            "THERE ARE FIVE MASKS AND ONLY FOUR ARE REACHABLE, BY DESIGN. The layout "
+            "index comes from FUN_02082814, which psz-re reads as a weighted draw "
+            "returning a category 0..3 against the table at 0x020f2e70 -- twelve ints "
+            "as three rows of four, every row summing to 100 -- and validates on all 44 "
+            "values across five captured fields being in 0..3. So mask 4 (0x30), the "
+            "only one naming group 4, is never selected by the depth-banded draw and "
+            "group 4's objects never spawn in a free field. That is faithful, not a "
+            "bug: psz-re's NOT_ESTABLISHED records a mission-guarded path that forces "
+            "layout 4, which it has not modelled and which free-roam generation "
+            "correctly never takes. Do not 'fix' the mask table or widen the draw.",
         ],
         "layout_masks": LAYOUT_MASKS,
         "layout_weights_by_depth": LAYOUT_WEIGHTS_BY_DEPTH,
         "group5_weights": GROUP5_WEIGHTS,
         "caps": CAPS,
         "census": dict(sorted(census.items(), key=lambda kv: -kv[1])),
+        "not_imported_yet": {
+            "_": ("Kinds psz-re emits that this importer deliberately does not take "
+                  "yet -- psz-godot #594 widens CONTAINER_KINDS and adds the spawner "
+                  "cases together. Listed so the gap is visible rather than silent."),
+            "counts": dict(sorted(deferred.items(), key=lambda kv: -kv[1])),
+        },
         "rooms": dict(sorted(rooms.items())),
     }
 
@@ -210,6 +244,11 @@ def main() -> int:
           % (OUT, len(doc["rooms"]), sum(doc["census"].values()), len(text) / 1024))
     for kind, n in doc["census"].items():
         print("  %-16s %d" % (kind, n))
+    skipped = doc["not_imported_yet"]["counts"]
+    if skipped:
+        print("  deferred to #594: %d records over %d kinds (%s)"
+              % (sum(skipped.values()), len(skipped),
+                 ", ".join(list(skipped)[:6])))
     return 0
 
 

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -777,7 +777,7 @@ func test_authored_field_objects() -> void:
 
 
 func test_authored_walls_clear_doorways() -> void:
-	print("── No authored object stands in a doorway (#593's soft-lock question) ──")
+	print("── No BLOCKING authored object stands in a doorway (#593's soft-lock question) ──")
 	var rooms: Dictionary = QuestLoader._load_json(
 		"res://data/re_reference/room_objects.json").get("rooms", {})
 	var doorways: Dictionary = QuestLoader._load_json(
@@ -789,10 +789,24 @@ func test_authored_walls_clear_doorways() -> void:
 	# cells of clearance over all 964 records, against a control that finds the
 	# room warp at 0.01. This re-derives it from OUR copy rather than trusting
 	# the number, because the import is ours to get wrong.
+	#
+	# SCOPED TO THE KINDS THAT BLOCK, and it has to be. The claim "no authored
+	# object of ANY kind stands in a doorway" is FALSE in the corpus — the same
+	# psz-re ruler puts o0c_fence at 1.31 and the room warp at 0.01, and both
+	# belong there: a fence across a doorway is a barrier, which is the entire
+	# point of a fence, and a warp IS the doorway. Asserting it over every kind
+	# would pass today only because the importer's allowlist (CONTAINER_KINDS)
+	# has not reached those kinds yet, and would fail the moment #594 widens it
+	# — reading as "#594 broke the invariant" when the invariant was overstated
+	# here. What matters for a soft-lock is an object the player can neither
+	# walk through nor get rid of.
+	const BLOCKING_KINDS := ["box", "rare_box", "wall"]
 	const MIN_CLEARANCE := 3.0
 	var worst_wall: float = 1e9
-	var worst_any: float = 1e9
+	var worst_blocking: float = 1e9
 	var worst_desc: String = ""
+	var worst_any: float = 1e9
+	var worst_any_desc: String = ""
 	var measured: int = 0
 
 	for key in rooms.keys():
@@ -802,21 +816,30 @@ func test_authored_walls_clear_doorways() -> void:
 		if segments.is_empty():
 			continue
 		for obj in rooms[key].get("objects", []):
+			var kind: String = str(obj.get("k", ""))
 			var d: float = _distance_to_doorways(
 				float(obj.get("x", 0.0)), float(obj.get("z", 0.0)), segments)
 			measured += 1
 			if d < worst_any:
 				worst_any = d
-				worst_desc = "%s %s" % [key, str(obj.get("k", ""))]
-			if str(obj.get("k", "")) == "wall" and d < worst_wall:
+				worst_any_desc = "%s %s" % [key, kind]
+			if kind not in BLOCKING_KINDS:
+				continue
+			if d < worst_blocking:
+				worst_blocking = d
+				worst_desc = "%s %s" % [key, kind]
+			if kind == "wall" and d < worst_wall:
 				worst_wall = d
 
 	assert_true(measured > 1000, "measured a real corpus (%d objects)" % measured)
 	assert_true(worst_wall >= MIN_CLEARANCE,
 		"the closest authored WALL clears every doorway by %.2f units" % worst_wall)
-	assert_true(worst_any >= MIN_CLEARANCE,
-		"no authored object of any kind stands in a doorway (closest %.2f, %s)"
-			% [worst_any, worst_desc])
+	assert_true(worst_blocking >= MIN_CLEARANCE,
+		"no BLOCKING authored object stands in a doorway (closest %.2f, %s)"
+			% [worst_blocking, worst_desc])
+	# Reported, never asserted — see the note above. When #594 lands the fences
+	# this number is expected to drop to roughly 1.3, and that is not a failure.
+	print("    closest of any kind (informational): %.2f — %s" % [worst_any, worst_any_desc])
 	print("")
 
 

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -109,6 +109,7 @@ func _run_tests_core() -> void:
 	test_element_collision_setup()
 	test_player_traps()
 	test_authored_field_objects()
+	test_authored_walls_clear_doorways()
 	test_group_five_trap_roll()
 	test_field_trap_behaviour()
 	test_trap_vision_reveal()
@@ -758,20 +759,87 @@ func test_authored_field_objects() -> void:
 	var b: Array = Pop.authored_objects("s01a_tb3", 3, _seeded_rng(1234))
 	assert_eq(JSON.stringify(a), JSON.stringify(b), "the roll is seed-deterministic")
 
-	# 3. The caps hold and no wall escapes while PLACE_WALLS is off.
-	var walls: int = 0
+	# 3. The caps hold, and walls are in the DATA — the autopilot skip moved to
+	#    spawn time (#593), so a generated cell must carry its walls whether or
+	#    not this run intends to build them.
 	var over_cap: int = 0
+	var saw_wall := false
 	for seed_i in range(120):
-		var objs: Array = Pop.authored_objects("s01a_tb3", seed_i % 9, _seeded_rng(seed_i))
+		var objs: Array = Pop.authored_objects("s05b_lb3", seed_i % 9, _seeded_rng(seed_i))
 		if objs.size() > 20:
 			over_cap += 1
 		for o in objs:
 			if str(o.get("type", "")) == "wall":
-				walls += 1
+				saw_wall = true
 	assert_eq(over_cap, 0, "a room never exceeds the 20-object cap")
-	if not Pop.PLACE_WALLS:
-		assert_eq(walls, 0, "no authored wall is placed while PLACE_WALLS is false")
+	assert_true(saw_wall, "authored walls reach the object list (the gate is at spawn time)")
 	print("")
+
+
+func test_authored_walls_clear_doorways() -> void:
+	print("── No authored object stands in a doorway (#593's soft-lock question) ──")
+	var rooms: Dictionary = QuestLoader._load_json(
+		"res://data/re_reference/room_objects.json").get("rooms", {})
+	var doorways: Dictionary = QuestLoader._load_json(
+		"res://data/re_reference/room_doorways.json").get("rooms", {})
+	assert_true(not rooms.is_empty() and not doorways.is_empty(), "both reference tables load")
+
+	# The reason walls were gated off was that one across the line between two
+	# doorways is a soft-lock. psz-re measured that it never happens — 5.14
+	# cells of clearance over all 964 records, against a control that finds the
+	# room warp at 0.01. This re-derives it from OUR copy rather than trusting
+	# the number, because the import is ours to get wrong.
+	const MIN_CLEARANCE := 3.0
+	var worst_wall: float = 1e9
+	var worst_any: float = 1e9
+	var worst_desc: String = ""
+	var measured: int = 0
+
+	for key in rooms.keys():
+		var room_code: String = str(key).substr(0, str(key).rfind("_"))
+		var door: Dictionary = doorways.get(room_code, {})
+		var segments: Array = door.get("segments", [])
+		if segments.is_empty():
+			continue
+		for obj in rooms[key].get("objects", []):
+			var d: float = _distance_to_doorways(
+				float(obj.get("x", 0.0)), float(obj.get("z", 0.0)), segments)
+			measured += 1
+			if d < worst_any:
+				worst_any = d
+				worst_desc = "%s %s" % [key, str(obj.get("k", ""))]
+			if str(obj.get("k", "")) == "wall" and d < worst_wall:
+				worst_wall = d
+
+	assert_true(measured > 1000, "measured a real corpus (%d objects)" % measured)
+	assert_true(worst_wall >= MIN_CLEARANCE,
+		"the closest authored WALL clears every doorway by %.2f units" % worst_wall)
+	assert_true(worst_any >= MIN_CLEARANCE,
+		"no authored object of any kind stands in a doorway (closest %.2f, %s)"
+			% [worst_any, worst_desc])
+	print("")
+
+
+## Shortest distance from a point to any of a room's doorway openings.
+##
+## Sampled along each opening rather than measured to its endpoints: a wall
+## beside the middle of a wide doorway is in the way just as much as one at the
+## corner, and endpoint-only distance would miss it.
+func _distance_to_doorways(x: float, z: float, segments: Array) -> float:
+	var best: float = 1e9
+	for seg in segments:
+		if seg.size() < 2:
+			continue
+		var ax: float = float(seg[0][0])
+		var az: float = float(seg[0][1])
+		var bx: float = float(seg[1][0])
+		var bz: float = float(seg[1][1])
+		for step in range(9):
+			var t: float = float(step) / 8.0
+			var px: float = ax + (bx - ax) * t
+			var pz: float = az + (bz - az) * t
+			best = minf(best, Vector2(x - px, z - pz).length())
+	return best
 
 
 func test_group_five_trap_roll() -> void:

--- a/web/public/field-dumps/generated-fields.json
+++ b/web/public/field-dumps/generated-fields.json
@@ -77,6 +77,26 @@
                     {
                       "authored": true,
                       "position": [
+                        -4.34,
+                        0.0,
+                        -1.49
+                      ],
+                      "rotation": 167.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        1.59,
+                        0.0,
+                        -1.38
+                      ],
+                      "rotation": 193.48,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         1.93,
                         0.0,
                         13.58
@@ -1789,6 +1809,26 @@
                     {
                       "authored": true,
                       "position": [
+                        -4.34,
+                        0.0,
+                        -1.49
+                      ],
+                      "rotation": 167.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        1.59,
+                        0.0,
+                        -1.38
+                      ],
+                      "rotation": 193.48,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         1.93,
                         0.0,
                         13.58
@@ -1978,6 +2018,16 @@
                         0.0
                       ],
                       "type": "enemy"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        2.19,
+                        0.0,
+                        13.63
+                      ],
+                      "rotation": 181.43,
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -2770,20 +2820,14 @@
                       "type": "enemy"
                     },
                     {
+                      "authored": true,
                       "position": [
-                        8.0,
+                        2.19,
                         0.0,
-                        0.0
+                        13.63
                       ],
-                      "type": "box"
-                    },
-                    {
-                      "position": [
-                        -8.0,
-                        0.0,
-                        0.0
-                      ],
-                      "type": "box"
+                      "rotation": 181.43,
+                      "type": "wall"
                     }
                   ],
                   "path_order": 1,
@@ -3629,6 +3673,35 @@
                     {
                       "authored": true,
                       "position": [
+                        -15.83,
+                        0.0,
+                        12.35
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -15.59,
+                        0.0,
+                        8.39
+                      ],
+                      "rotation": 12.75,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -12.64,
+                        0.0,
+                        9.31
+                      ],
+                      "rotation": 89.99,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -12.51,
                         0.0,
                         17.39
@@ -3669,6 +3742,35 @@
                     {
                       "authored": true,
                       "position": [
+                        -9.83,
+                        0.0,
+                        12.35
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -9.63,
+                        0.0,
+                        6.36
+                      ],
+                      "rotation": 179.05,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -9.54,
+                        0.0,
+                        7.04
+                      ],
+                      "rotation": 12.75,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -9.19,
                         0.0,
                         12.64
@@ -3699,6 +3801,25 @@
                     {
                       "authored": true,
                       "position": [
+                        -2.28,
+                        0.0,
+                        -11.56
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -0.51,
+                        0.0,
+                        13.87
+                      ],
+                      "rotation": 100.53,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         5.87,
                         0.0,
                         -13.28
@@ -3725,6 +3846,26 @@
                       ],
                       "rotation": 270.0,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        10.76,
+                        0.0,
+                        -10.21
+                      ],
+                      "rotation": 17.05,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        16.62,
+                        0.0,
+                        -11.39
+                      ],
+                      "rotation": 5.56,
+                      "type": "wall"
                     }
                   ],
                   "path_order": 1,
@@ -5678,12 +5819,50 @@
                     {
                       "authored": true,
                       "position": [
+                        -11.32,
+                        0.0,
+                        -10.03
+                      ],
+                      "rotation": 95.75,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -11.32,
+                        0.0,
+                        -10.03
+                      ],
+                      "rotation": 95.75,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         9.88,
                         0.0,
                         -9.66
                       ],
                       "rotation": 268.62,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        10.67,
+                        0.0,
+                        -8.2
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        10.67,
+                        0.0,
+                        -8.2
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -9162,6 +9341,16 @@
                         -11.16
                       ],
                       "type": "ice_trap"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -1.47,
+                        0.0,
+                        13.67
+                      ],
+                      "rotation": 90.12,
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -17918,6 +18107,42 @@
                     {
                       "authored": true,
                       "position": [
+                        -4.08,
+                        0.0,
+                        4.79
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -1.35,
+                        0.0,
+                        -12.79
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -1.23,
+                        0.0,
+                        -12.75
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        1.04,
+                        0.0,
+                        -7.01
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         3.59,
                         0.0,
                         3.49
@@ -17948,6 +18173,35 @@
                     {
                       "authored": true,
                       "position": [
+                        16.78,
+                        0.0,
+                        1.5
+                      ],
+                      "rotation": 89.99,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        16.85,
+                        0.0,
+                        1.4
+                      ],
+                      "rotation": 89.99,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        17.31,
+                        0.0,
+                        -6.37
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         18.88,
                         0.0,
                         0.26
@@ -17963,6 +18217,15 @@
                         0.08
                       ],
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        19.53,
+                        0.0,
+                        -1.68
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -18588,6 +18851,16 @@
                     {
                       "authored": true,
                       "position": [
+                        -9.72,
+                        0.0,
+                        -2.6
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -7.61,
                         0.0,
                         -3.33
@@ -18608,12 +18881,61 @@
                     {
                       "authored": true,
                       "position": [
+                        -6.11,
+                        0.0,
+                        0.14
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -4.81,
                         0.0,
                         -3.39
                       ],
                       "rotation": 270.01,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -2.49,
+                        0.0,
+                        -2.64
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        4.3,
+                        0.0,
+                        -17.62
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        4.93,
+                        0.0,
+                        0.72
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        5.26,
+                        0.0,
+                        3.45
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -18634,6 +18956,15 @@
                       ],
                       "rotation": 270.01,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        8.42,
+                        0.0,
+                        3.48
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -18664,6 +18995,55 @@
                       ],
                       "rotation": 270.01,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        11.9,
+                        0.0,
+                        0.67
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        12.3,
+                        0.0,
+                        -17.61
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        15.45,
+                        0.0,
+                        3.48
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        18.94,
+                        0.0,
+                        0.77
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        18.97,
+                        0.0,
+                        3.4
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
                     }
                   ],
                   "path_order": 2,
@@ -19869,6 +20249,33 @@
                     {
                       "authored": true,
                       "position": [
+                        -21.49,
+                        0.0,
+                        -8.48
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -21.49,
+                        0.0,
+                        -8.48
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -21.49,
+                        0.0,
+                        -4.11
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -18.63,
                         0.0,
                         -12.01
@@ -19919,6 +20326,15 @@
                     {
                       "authored": true,
                       "position": [
+                        -15.51,
+                        0.0,
+                        -4.13
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -14.94,
                         0.0,
                         -12.17
@@ -19949,6 +20365,52 @@
                     {
                       "authored": true,
                       "position": [
+                        -11.22,
+                        0.0,
+                        -8.48
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -11.22,
+                        0.0,
+                        -8.48
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -9.54,
+                        0.0,
+                        -4.15
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -8.68,
+                        0.0,
+                        -7.2
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -6.07,
+                        0.0,
+                        -4.34
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -3.56,
                         0.0,
                         -10.83
@@ -19965,6 +20427,15 @@
                       ],
                       "rotation": 270.0,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -2.76,
+                        0.0,
+                        -4.6
+                      ],
+                      "type": "wall"
                     }
                   ],
                   "path_order": 1,
@@ -20699,6 +21170,16 @@
                     {
                       "authored": true,
                       "position": [
+                        -12.79,
+                        0.0,
+                        -15.36
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -2.05,
                         0.0,
                         -16.14
@@ -20729,6 +21210,15 @@
                     {
                       "authored": true,
                       "position": [
+                        11.3,
+                        0.0,
+                        -9.14
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         16.06,
                         0.0,
                         -14.83
@@ -20755,6 +21245,15 @@
                       ],
                       "rotation": 270.0,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        17.18,
+                        0.0,
+                        -9.14
+                      ],
+                      "type": "wall"
                     }
                   ],
                   "path_order": 3,
@@ -22204,6 +22703,15 @@
                     {
                       "authored": true,
                       "position": [
+                        -17.44,
+                        0.0,
+                        -5.07
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -16.42,
                         0.0,
                         -7.01
@@ -23186,6 +23694,15 @@
                         -4.76
                       ],
                       "type": "enemy"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -17.44,
+                        0.0,
+                        -5.07
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -25220,6 +25737,16 @@
                     {
                       "authored": true,
                       "position": [
+                        -3.09,
+                        0.0,
+                        0.08
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -0.86,
                         0.0,
                         0.62
@@ -25240,12 +25767,40 @@
                     {
                       "authored": true,
                       "position": [
+                        0.02,
+                        0.0,
+                        -2.95
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        0.02,
+                        0.0,
+                        3.12
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         0.75,
                         0.0,
                         0.58
                       ],
                       "rotation": 89.7,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        3.14,
+                        0.0,
+                        0.08
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
                     }
                   ],
                   "path_order": 1,
@@ -25294,6 +25849,16 @@
                     {
                       "authored": true,
                       "position": [
+                        -3.09,
+                        0.0,
+                        0.08
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -0.86,
                         0.0,
                         0.62
@@ -25314,12 +25879,40 @@
                     {
                       "authored": true,
                       "position": [
+                        0.02,
+                        0.0,
+                        -2.95
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        0.02,
+                        0.0,
+                        3.12
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         0.75,
                         0.0,
                         0.58
                       ],
                       "rotation": 89.7,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        3.14,
+                        0.0,
+                        0.08
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -26289,6 +26882,16 @@
                     {
                       "authored": true,
                       "position": [
+                        -0.02,
+                        0.0,
+                        2.7
+                      ],
+                      "rotation": 180.01,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         13.24,
                         0.0,
                         -5.29
@@ -26522,11 +27125,29 @@
                     {
                       "authored": true,
                       "position": [
+                        -8.27,
+                        0.0,
+                        -5.41
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -3.92,
                         0.0,
                         -7.22
                       ],
                       "type": "ice_trap"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -2.74,
+                        0.0,
+                        -5.41
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -26545,6 +27166,15 @@
                         -7.22
                       ],
                       "type": "ice_trap"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        2.88,
+                        0.0,
+                        -5.41
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -26761,6 +27391,15 @@
                       ],
                       "rotation": 90.06,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -0.01,
+                        0.0,
+                        7.67
+                      ],
+                      "type": "wall"
                     }
                   ],
                   "path_order": -1,
@@ -26965,6 +27604,46 @@
                       ],
                       "rotation": 359.68,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -11.73,
+                        0.0,
+                        -2.23
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -11.73,
+                        0.0,
+                        3.48
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        5.65,
+                        0.0,
+                        -2.23
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        5.65,
+                        0.0,
+                        3.48
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -27275,12 +27954,50 @@
                     {
                       "authored": true,
                       "position": [
+                        -8.36,
+                        0.0,
+                        -2.53
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -8.36,
+                        0.0,
+                        3.21
+                      ],
+                      "rotation": 90.0,
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
                         -6.66,
                         0.0,
                         -10.67
                       ],
                       "rotation": 42.25,
                       "type": "gun_trap"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -5.27,
+                        0.0,
+                        6.3
+                      ],
+                      "type": "wall"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        0.49,
+                        0.0,
+                        6.3
+                      ],
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -27381,6 +28098,16 @@
                       ],
                       "rotation": 134.99,
                       "type": "box"
+                    },
+                    {
+                      "authored": true,
+                      "position": [
+                        -1.61,
+                        0.0,
+                        -9.8
+                      ],
+                      "rotation": 44.99,
+                      "type": "wall"
                     },
                     {
                       "authored": true,
@@ -27753,20 +28480,14 @@
                       "type": "enemy"
                     },
                     {
+                      "authored": true,
                       "position": [
-                        8.0,
+                        -5.42,
                         0.0,
-                        0.0
+                        3.02
                       ],
-                      "type": "box"
-                    },
-                    {
-                      "position": [
-                        -8.0,
-                        0.0,
-                        0.0
-                      ],
-                      "type": "box"
+                      "rotation": 90.0,
+                      "type": "wall"
                     }
                   ],
                   "path_order": 1,

--- a/web/public/field-dumps/generated-fields.json
+++ b/web/public/field-dumps/generated-fields.json
@@ -76,6 +76,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -4.34,
                         0.0,
@@ -86,6 +87,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         1.59,
                         0.0,
@@ -1808,6 +1810,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -4.34,
                         0.0,
@@ -1818,6 +1821,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         1.59,
                         0.0,
@@ -2021,6 +2025,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         2.19,
                         0.0,
@@ -2821,6 +2826,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         2.19,
                         0.0,
@@ -3672,6 +3678,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -15.83,
                         0.0,
@@ -3681,6 +3688,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -15.59,
                         0.0,
@@ -3691,6 +3699,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -12.64,
                         0.0,
@@ -3741,6 +3750,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -9.83,
                         0.0,
@@ -3750,6 +3760,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -9.63,
                         0.0,
@@ -3760,6 +3771,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -9.54,
                         0.0,
@@ -3800,6 +3812,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -2.28,
                         0.0,
@@ -3809,6 +3822,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -0.51,
                         0.0,
@@ -3849,6 +3863,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         10.76,
                         0.0,
@@ -3859,6 +3874,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         16.62,
                         0.0,
@@ -5818,6 +5834,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -11.32,
                         0.0,
@@ -5828,6 +5845,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -11.32,
                         0.0,
@@ -5848,6 +5866,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         10.67,
                         0.0,
@@ -5857,6 +5876,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         10.67,
                         0.0,
@@ -9344,6 +9364,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -1.47,
                         0.0,
@@ -18106,6 +18127,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -4.08,
                         0.0,
@@ -18115,6 +18137,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -1.35,
                         0.0,
@@ -18124,6 +18147,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -1.23,
                         0.0,
@@ -18133,6 +18157,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         1.04,
                         0.0,
@@ -18172,6 +18197,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         16.78,
                         0.0,
@@ -18182,6 +18208,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         16.85,
                         0.0,
@@ -18192,6 +18219,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         17.31,
                         0.0,
@@ -18220,6 +18248,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         19.53,
                         0.0,
@@ -18850,6 +18879,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -9.72,
                         0.0,
@@ -18880,6 +18910,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -6.11,
                         0.0,
@@ -18899,6 +18930,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -2.49,
                         0.0,
@@ -18909,6 +18941,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         4.3,
                         0.0,
@@ -18919,6 +18952,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         4.93,
                         0.0,
@@ -18929,6 +18963,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         5.26,
                         0.0,
@@ -18959,6 +18994,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         8.42,
                         0.0,
@@ -18998,6 +19034,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         11.9,
                         0.0,
@@ -19008,6 +19045,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         12.3,
                         0.0,
@@ -19018,6 +19056,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         15.45,
                         0.0,
@@ -19027,6 +19066,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         18.94,
                         0.0,
@@ -19037,6 +19077,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         18.97,
                         0.0,
@@ -20248,6 +20289,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -21.49,
                         0.0,
@@ -20257,6 +20299,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -21.49,
                         0.0,
@@ -20266,6 +20309,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -21.49,
                         0.0,
@@ -20325,6 +20369,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -15.51,
                         0.0,
@@ -20364,6 +20409,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -11.22,
                         0.0,
@@ -20373,6 +20419,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -11.22,
                         0.0,
@@ -20382,6 +20429,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -9.54,
                         0.0,
@@ -20391,6 +20439,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -8.68,
                         0.0,
@@ -20401,6 +20450,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -6.07,
                         0.0,
@@ -20430,6 +20480,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -2.76,
                         0.0,
@@ -21169,6 +21220,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -12.79,
                         0.0,
@@ -21209,6 +21261,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         11.3,
                         0.0,
@@ -21248,6 +21301,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         17.18,
                         0.0,
@@ -22702,6 +22756,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -17.44,
                         0.0,
@@ -23697,6 +23752,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -17.44,
                         0.0,
@@ -25736,6 +25792,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -3.09,
                         0.0,
@@ -25766,6 +25823,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         0.02,
                         0.0,
@@ -25775,6 +25833,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         0.02,
                         0.0,
@@ -25794,6 +25853,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         3.14,
                         0.0,
@@ -25848,6 +25908,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -3.09,
                         0.0,
@@ -25878,6 +25939,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         0.02,
                         0.0,
@@ -25887,6 +25949,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         0.02,
                         0.0,
@@ -25906,6 +25969,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         3.14,
                         0.0,
@@ -26881,6 +26945,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -0.02,
                         0.0,
@@ -27124,6 +27189,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -8.27,
                         0.0,
@@ -27142,6 +27208,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -2.74,
                         0.0,
@@ -27169,6 +27236,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         2.88,
                         0.0,
@@ -27394,6 +27462,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -0.01,
                         0.0,
@@ -27607,6 +27676,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -11.73,
                         0.0,
@@ -27617,6 +27687,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -11.73,
                         0.0,
@@ -27627,6 +27698,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         5.65,
                         0.0,
@@ -27637,6 +27709,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         5.65,
                         0.0,
@@ -27953,6 +28026,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -8.36,
                         0.0,
@@ -27963,6 +28037,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -8.36,
                         0.0,
@@ -27983,6 +28058,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -5.27,
                         0.0,
@@ -27992,6 +28068,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         0.49,
                         0.0,
@@ -28101,6 +28178,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -1.61,
                         0.0,
@@ -28481,6 +28559,7 @@
                     },
                     {
                       "authored": true,
+                      "destructible": true,
                       "position": [
                         -5.42,
                         0.0,


### PR DESCRIPTION
Closes #593. Closes #592 (item 1 was already done in `34dc9e94`).

## #593 — the walls

196 authored walls were imported and then thrown away by `PLACE_WALLS := false` inside `_to_object()`. That is **generation** time, and it was the wrong place twice over:

- the generated field **data** differed between an autopilot run and a player run, so the committed dump and `check_generated_objects.py` described a world no player sees;
- a cell first entered under autopilot **saved without its walls and restored that way forever**.

The skip now lives in `_spawn_wall()` under `PSZ_AUTOPILOT_NO_WALLS` — one guard covering both the fresh and restore paths, exactly like `PSZ_AUTOPILOT_NO_BOXES`.

**Its own variable, not folded into `NO_OBSTACLES`** (the issue asked me to pick and say which): `NO_OBSTACLES` strips a stage's *baked obstacle collision*, a property of the room mesh; this drops a *placed object*. A run that wants to prove walls don't wedge the backbone needs to turn off exactly one of them. Set in the three matrix scripts; `record_free_roam.sh` takes it from the environment and **defaults it OFF**, so the default run is the one that tests the walls.

### The soft-lock question is answered, and measured

The issue asked for one look at psz-re's `wall_placement_per_room.json` before implementing. It carries `IT_NEVER_BLOCKS_A_CONNECTION`: over all **964 records** the smallest distance from a wall to any doorway mouth of its own room is **5.14 cells** — with a control that the same ruler finds the room warp at **0.01** and `o0c_fence` at **1.31**, so it does detect things standing in a doorway.

`test_authored_walls_clear_doorways` re-derives that from **our** copies rather than trusting the number, sampling along each opening rather than just its endpoints:

```
wall           min-dist-to-doorway   5.75
gun_trap       min-dist-to-doorway   3.37   ← closest object of ANY kind
```

The import is ours to get wrong, so the invariant is ours to check.

**Destructibility is still open upstream** — psz-re: *"no wall behaviour is decoded — hit points, whether it breaks at all"* — so the spawner's `destructible` default is unchanged. The clearance above is what makes that choice low-risk either way.

## #592 item 2 — the unreachable layout index

Five layout masks, four reachable, **by design**, now recorded in both `the_rule` and `authored_objects()`'s doc comment so the next reader doesn't re-derive it: `FUN_02082814` returns a category 0..3 against the table at `0x020f2e70` (three rows of four, each summing to 100), validated on all 44 values across five captured fields. Mask `0x30` and its 146 group-4 objects belong to the mission-guarded path psz-re hasn't modelled.

## Not in the issues, but it had to happen today

**The importer now has an allowlist.** psz-re's object dump grew in-flight from 2,726 to **4,838** classified records — keys, fences, switches, mspack, NPCs, warps: the #594 work, currently uncommitted in that repo. Without a filter those kinds flow straight through as object types the spawner cannot build, and because they still count against the **20-object room cap**, an unhandled key would silently displace a box or a trap.

`CONTAINER_KINDS` + `TRAP_IDS` is now explicit; everything else is counted into a `not_imported_yet` block **in the file** so the gap is visible rather than silent (2,112 records sit there today). Widening it is #594's job, together with the spawner cases.

## Verification

- **Tests: 2563 passed, 0 failed.** The old `PLACE_WALLS` assertion was **inverted** rather than deleted — a generated cell must now *carry* its walls, since the gate moved out of the data. `check_generated_objects.py` likewise fails on their absence and reports **79 walls over 392 cells**.
- `code_graph --check`, `import_re_objects --check`, `check_repo_layout` — clean.
- Regression matrix with `NO_WALLS=1`: running at the time of writing; I'll comment with the result.

### Honest gap — this is #593's own acceptance criterion and it is not met

The free-roam autopilot passes with walls enabled (`DONE ok`) but **spawned zero authored walls**, because that harness loads the static `data/field_quests/*.json` — which carries only enemies, boxes and rare boxes — rather than `GridGenerator`. So that run is a **regression check, not evidence** that walls don't wedge the walk backbone.

The evidence that does exist is the clearance invariant above and the 79 walls in the generated dump. Getting the runtime half needs the free-roam harness pointed at the generator, which is its own piece of work — flagging rather than quietly claiming the criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
