### PR TITLE
Zonde: real lightning bolt, plus the cast-rooting bug it surfaced

### DIFF
--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -1906,6 +1906,12 @@ func _spawn_zonde_visual(target_pos: Vector3) -> void:
 	# Without a per-bolt seed every strike in a Gizonde chain animates in
 	# lockstep, which reads as one wide bolt rather than several.
 	mat.set_shader_parameter("Seed", randf() * 100.0)
+	# Fade looks redundant — the shader already defaults it to 1.0 — but it is
+	# load-bearing. ShaderMaterial.get("shader_parameter/x") returns null for a
+	# parameter that was never assigned, and Tween rejects a null property with
+	# "does not exist", so the fade-out below silently never runs. Deleting this
+	# line leaves a bolt that pops out after ZONDE_BOLT_HOLD with no fade.
+	mat.set_shader_parameter("Fade", 1.0)
 	bolt.material_override = mat
 	get_tree().current_scene.add_child(bolt)
 	bolt.global_position = target_pos + Vector3(0, ZONDE_BOLT_HEIGHT * 0.5, 0)

--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -1615,6 +1615,12 @@ func _cast_technique(technique_id: String) -> void:
 	_queued_combo_special = false
 	play_animation(_anim_prefix + "_tec", false)
 
+	# A cast enters ATTACKING without going through _play_attack_animation, so
+	# it has to arm the step-end machinery itself. play_animation falls back to
+	# a fuzzy suffix match, so measure the clip that actually started rather
+	# than the name we asked for.
+	_arm_attack_step(animation_player.current_animation if animation_player else "")
+
 	_spawn_technique_effect(technique_id, tech_data)
 
 
@@ -2203,15 +2209,24 @@ const WEAPON_SFX := {
 ## callers depend on its 0 fallback (player.gd ~1247/1770/2215/2297/2450).
 const BAREHANDED_SFX := "res://assets/sfx/weapons/unarmed_swing_1.wav"  # common46 — pending pack republish
 
-func _play_and_track_attack(anim_name: String) -> void:
-	play_animation(anim_name, false)
-	_attack_anim_elapsed = 0.0
+## Arm the step-end machinery for a clip that just started. EVERY entry into
+## ATTACKING must call this. Both exits out of the state are gated on
+## _attack_step_ended — the animation_finished double-fire guard and the
+## elapsed-length safety net — so a value left true by the previous step roots
+## the player in ATTACKING until something unrelated knocks them out of it.
+## _attack_anim_length doubles as the rhythm-window denominator (_attack_frac).
+func _arm_attack_step(anim_name: String) -> void:
 	_attack_step_ended = false
-	# Get animation length for rhythm window timing
-	if animation_player and animation_player.has_animation(anim_name):
+	_attack_anim_elapsed = 0.0
+	if anim_name != "" and animation_player and animation_player.has_animation(anim_name):
 		_attack_anim_length = animation_player.get_animation(anim_name).length
 	else:
 		_attack_anim_length = 0.5  # Fallback
+
+
+func _play_and_track_attack(anim_name: String) -> void:
+	play_animation(anim_name, false)
+	_arm_attack_step(anim_name)
 	# Hits resolve at the step's damaging frame (_handle_attack_state), not
 	# at swing start — spec /mechanics/targeting.
 	_attack_hit_done = false

--- a/scripts/3d/player/player.gd
+++ b/scripts/3d/player/player.gd
@@ -213,6 +213,15 @@ signal tech_charge_started(slot: int)
 signal tech_charge_ready(slot: int)
 signal tech_charge_released(slot: int)
 
+# Zonde / Gizonde / Razonde bolt visual. The quad is drawn additively and
+# Y-billboards in the shader, so ZONDE_BOLT_WIDTH is how wide the bolt may
+# wander, not how thick it looks.
+const LIGHTNING_SHADER := preload("res://scripts/3d/shaders/lightning_bolt.gdshader")
+const ZONDE_BOLT_HEIGHT: float = 10.0
+const ZONDE_BOLT_WIDTH: float = 2.0
+const ZONDE_BOLT_HOLD: float = 0.10
+const ZONDE_BOLT_FADE: float = 0.30
+
 # Footstep SFX
 var _footstep_timer: float = 0.0
 const FOOTSTEP_WALK_INTERVAL := 0.55
@@ -1882,25 +1891,27 @@ func _spawn_zonde(damage: int, kb: float) -> void:
 	_spawn_zonde_visual(target_enemy.global_position)
 
 
+## One bolt of the Zonde family, struck downward onto target_pos. The quad
+## Y-billboards in the shader, so it never needs to be aimed at the camera.
 func _spawn_zonde_visual(target_pos: Vector3) -> void:
 	var bolt := MeshInstance3D.new()
-	var cylinder := CylinderMesh.new()
-	cylinder.top_radius = 0.08
-	cylinder.bottom_radius = 0.08
-	cylinder.height = 10.0
-	bolt.mesh = cylinder
-	var mat := StandardMaterial3D.new()
-	mat.albedo_color = Color(1.0, 1.0, 0.3)
-	mat.emission_enabled = true
-	mat.emission = Color(0.8, 0.8, 1.0)
-	mat.emission_energy_multiplier = 3.0
-	mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	var quad := QuadMesh.new()
+	quad.size = Vector2(ZONDE_BOLT_WIDTH, ZONDE_BOLT_HEIGHT)
+	bolt.mesh = quad
+	bolt.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	var mat := ShaderMaterial.new()
+	mat.shader = LIGHTNING_SHADER
+	mat.set_shader_parameter("Main_Color", Color(1.0, 1.0, 0.85))
+	mat.set_shader_parameter("Effect_Color", Color(0.55, 0.7, 1.0))
+	# Without a per-bolt seed every strike in a Gizonde chain animates in
+	# lockstep, which reads as one wide bolt rather than several.
+	mat.set_shader_parameter("Seed", randf() * 100.0)
 	bolt.material_override = mat
 	get_tree().current_scene.add_child(bolt)
-	bolt.global_position = target_pos + Vector3(0, 5.0, 0)
+	bolt.global_position = target_pos + Vector3(0, ZONDE_BOLT_HEIGHT * 0.5, 0)
 	var tween := bolt.create_tween()
-	tween.tween_property(mat, "albedo_color:a", 0.0, 0.4)
-	tween.parallel().tween_property(mat, "emission_energy_multiplier", 0.0, 0.4)
+	tween.tween_interval(ZONDE_BOLT_HOLD)
+	tween.tween_property(mat, "shader_parameter/Fade", 0.0, ZONDE_BOLT_FADE)
 	tween.tween_callback(bolt.queue_free)
 
 

--- a/scripts/3d/shaders/lightning_bolt.gdshader
+++ b/scripts/3d/shaders/lightning_bolt.gdshader
@@ -1,0 +1,118 @@
+shader_type spatial;
+render_mode unshaded, cull_disabled, blend_add, depth_draw_never, shadows_disabled;
+
+// Adapted from Loop_Box's CC0 "3D Lightning Shader"
+// (https://godotshaders.com/shader/3d-lightning-shader/). The FBM/noise core
+// is the original; the changes for Zonde are:
+//
+//   - Y-billboard vertex(), so one flat quad reads as a bolt from any camera
+//     angle instead of disappearing edge-on as the player orbits.
+//   - blend_add + unshaded: an additive FX shouldn't take scene lighting, and
+//     EMISSION is ignored under unshaded, so Emission_Power folds into ALBEDO.
+//   - Fade uniform, so the spawner can tween the bolt out.
+//   - Seed uniform: the original is driven purely by TIME, so every bolt on
+//     screen is pixel-identical. Gizonde chains and Razonde spawn a fistful at
+//     once, and they need to differ.
+//   - Top_Taper, so the bolt fades into the sky instead of ending on the hard
+//     quad edge. The strike end stays full brightness.
+//   - Dropped the Power_Texture sampler — the original reads it into
+//     Power_Value and never uses it.
+
+uniform vec3 Main_Color : source_color = vec3(1.0);
+uniform vec3 Effect_Color : source_color = vec3(0.3, 0.3, 1.0);
+
+uniform int Octave_Count : hint_range(1, 20) = 6;
+uniform float Amp_Start = 0.5;
+uniform float Amp_Coeff = 0.5;
+uniform float Freq_Coeff = 2.0;
+uniform float Speed = 3.0;
+
+uniform float Y_Size = 4.0;
+uniform float X_Size = 1.0;
+
+uniform float Emission_Power = 2.0;
+uniform float Fade : hint_range(0.0, 1.0) = 1.0;
+uniform float Seed = 0.0;
+uniform float Top_Taper : hint_range(0.0, 1.0) = 0.25;
+
+float Hash12(vec2 UV_)
+{
+	return fract(cos(mod(dot(UV_, vec2(13.9898, 8.141)), 3.14)) * 43758.5453);
+}
+
+vec2 Hash22(vec2 UV_)
+{
+	UV_ = vec2(dot(UV_, vec2(127.1, 311.7)),
+	dot(UV_, vec2(269.5, 183.3)));
+	return 2.0 * fract(sin(UV_) * 43758.5453123);
+}
+
+float Noise(vec2 UV_)
+{
+	vec2 IUV = floor(UV_);
+	vec2 FUV = fract(UV_);
+	vec2 Blur = smoothstep(0.0, 1.0, FUV);
+
+	float A = dot(Hash22(IUV + vec2(0.0, 0.0)), FUV - vec2(0.0, 0.0));
+	float B = dot(Hash22(IUV + vec2(1.0, 0.0)), FUV - vec2(1.0, 0.0));
+	float C = dot(Hash22(IUV + vec2(0.0, 1.0)), FUV - vec2(0.0, 1.0));
+	float D = dot(Hash22(IUV + vec2(1.0, 1.0)), FUV - vec2(1.0, 1.0));
+
+	float Mix_X1 = mix(A, B, Blur.x);
+	float Mix_X2 = mix(C, D, Blur.x);
+
+	return mix(Mix_X1, Mix_X2, Blur.y) + 0.5;
+}
+
+float FBM(vec2 UV_)
+{
+	float Value = 0.0;
+	float Amplitude = Amp_Start;
+
+	for (int Index = 0; Index < Octave_Count; Index++)
+	{
+		Value += Amplitude * Noise(UV_);
+		UV_ *= Freq_Coeff;
+		Amplitude *= Amp_Coeff;
+	}
+
+	return Value;
+}
+
+void vertex()
+{
+	// Y-billboard that keeps the mesh's own scale: the quad yaws to face the
+	// camera but stays upright, so the bolt always falls straight down.
+	mat4 Facing = VIEW_MATRIX * mat4(
+		vec4(normalize(cross(vec3(0.0, 1.0, 0.0), INV_VIEW_MATRIX[2].xyz)), 0.0),
+		vec4(0.0, 1.0, 0.0, 0.0),
+		vec4(normalize(cross(INV_VIEW_MATRIX[0].xyz, vec3(0.0, 1.0, 0.0))), 0.0),
+		MODEL_MATRIX[3]);
+	MODELVIEW_MATRIX = Facing * mat4(
+		vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0),
+		vec4(0.0, length(MODEL_MATRIX[1].xyz), 0.0, 0.0),
+		vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0),
+		vec4(0.0, 0.0, 0.0, 1.0));
+}
+
+void fragment()
+{
+	vec2 Modified_UV = 2.0 * UV - 1.0;
+	Modified_UV.y *= Y_Size;
+	Modified_UV.x *= X_Size;
+
+	Modified_UV.x -= Amp_Start;
+	Modified_UV += FBM(Modified_UV + TIME * Speed + Seed);
+	Modified_UV.x += 0.5 - Amp_Coeff;
+
+	float Dist = abs(Modified_UV.x);
+
+	// UV.y is 0 at the top of a QuadMesh, so this tapers the sky end only.
+	float Taper = smoothstep(0.0, Top_Taper, UV.y);
+	float Flicker = mix(0.0, 0.05, Hash12(vec2(TIME + Seed)));
+
+	vec3 Final_Color = Effect_Color * Flicker / Dist * Taper * Fade;
+
+	ALBEDO = Final_Color * Main_Color * Emission_Power;
+	ALPHA = clamp(Final_Color.r, 0.0, 1.0);
+}

--- a/scripts/3d/shaders/lightning_bolt.gdshader.uid
+++ b/scripts/3d/shaders/lightning_bolt.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cxeisuqmoytpo

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -59,6 +59,7 @@ func _run_tests_combat() -> void:
 	test_damage_formulas()
 	test_charge_drop_paths()
 	test_mechgun_final_step_no_root()
+	test_technique_cast_recovers()
 	test_weapon_attack_sfx_mapping()
 	test_weapon_anim_data_new_animation_sets()
 	test_companion_combat_decisions()
@@ -6798,6 +6799,77 @@ func test_mechgun_final_step_no_root() -> void:
 	assert_eq(int(pl.get("current_state")), int(PlayerScript.PlayerState.ATTACKING),
 		"queued chain keeps ATTACKING — next step fires at the safety net")
 	assert_eq(int(pl.get("combo_state")), 2, "queued step advanced the combo at anim length")
+
+	pl.free()
+	print("")
+
+
+# ── Technique cast recovers to IDLE (every cast, not just the first) ──
+# A cast enters ATTACKING via _cast_technique, which does NOT go through
+# _play_attack_animation — so the step-end tracking that path resets was left
+# holding the previous attack step's values. _attack_step_ended stayed true,
+# and BOTH exits out of ATTACKING are gated on it: the animation_finished
+# double-fire guard and the elapsed-length safety net. Net effect was that the
+# first cast after a spawn worked and every cast after it stranded the player
+# in ATTACKING until an unrelated event (usually taking a hit) knocked them out.
+# Same root as the mechgun case above: an entry point into ATTACKING that
+# forgets to arm the step-end machinery.
+func test_technique_cast_recovers() -> void:
+	print("── Technique cast returns to IDLE ──")
+	const PlayerScript := preload("res://scripts/3d/player/player.gd")
+	var pl = PlayerScript.new()
+
+	# A cast-shaped step: combo_state 0 (techniques never combo), tracking armed
+	# the way _cast_technique now arms it. The safety net must land it in IDLE
+	# even though no animation_finished ever arrives.
+	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
+	pl.set("combo_state", 0)
+	pl.set("_attack_step_ended", false)
+	pl.set("_attack_anim_length", 0.4)
+	pl.set("_attack_anim_elapsed", 0.0)
+	for _i in range(10):
+		pl._handle_attack_state(0.1)
+	assert_eq(int(pl.get("current_state")), int(PlayerScript.PlayerState.IDLE),
+		"a cast returns to IDLE at animation length with no animation_finished")
+
+	# Why it has to be armed: a stale _attack_step_ended disables BOTH exits, so
+	# the player never leaves ATTACKING no matter how long the clip runs.
+	pl.set("current_state", PlayerScript.PlayerState.ATTACKING)
+	pl.set("combo_state", 0)
+	pl.set("_attack_step_ended", true)  # stale, as _cast_technique used to leave it
+	pl.set("_attack_anim_length", 0.4)
+	pl.set("_attack_anim_elapsed", 0.0)
+	for _i in range(10):
+		pl._handle_attack_state(0.1)
+	assert_eq(int(pl.get("current_state")), int(PlayerScript.PlayerState.ATTACKING),
+		"stale _attack_step_ended roots the player — why every ATTACKING entry must arm")
+
+	# The regression pin: _arm_attack_step is the shared arming both the attack
+	# path and the cast path go through, and it must clear a stale flag. Drop
+	# the call from _cast_technique and casts root again — this is the assert
+	# that makes that failure loud.
+	pl.set("_attack_step_ended", true)
+	pl.set("_attack_anim_elapsed", 99.0)
+	pl._arm_attack_step("")
+	assert_true(not bool(pl.get("_attack_step_ended")),
+		"_arm_attack_step clears a stale step-end flag")
+	assert_eq(float(pl.get("_attack_anim_elapsed")), 0.0,
+		"_arm_attack_step restarts the elapsed clock")
+	assert_eq(float(pl.get("_attack_anim_length")), 0.5,
+		"_arm_attack_step falls back to 0.5s so the safety net stays armed")
+
+	# The call site itself. Everything above proves _arm_attack_step works;
+	# none of it proves _cast_technique still calls it, and that call is the
+	# whole fix. It can't be driven from an off-tree player — _cast_technique
+	# reaches _spawn_technique_effect, which needs get_tree() — so pin the
+	# source instead.
+	var src: String = _read_text_file("res://scripts/3d/player/player.gd")
+	var cast_start: int = src.find("func _cast_technique(")
+	assert_true(cast_start >= 0, "_cast_technique still exists in player.gd")
+	var next_func: int = src.find("\nfunc ", cast_start + 1)
+	var cast_body: String = src.substr(cast_start, next_func - cast_start) if next_func > 0 else src.substr(cast_start)
+	assert_true(cast_body.contains("_arm_attack_step("),
+		"_cast_technique arms the step-end machinery (drop this and every cast roots the player)")
 
 	pl.free()
 	print("")


### PR DESCRIPTION
Two things, bundled because a single play-test verifies both: the Zonde visual, and a cast bug that testing the visual exposed. Per *testing is the unit of a PR* — the same Mac session exercises the pair. Happy to split if you'd rather a revert of one not take the other.

## 1. The bolt (cosmetic)

`_spawn_zonde_visual` was a placeholder: a yellow emissive cylinder that faded out. It read as a glowing stick. All three of Zonde / Gizonde / Razonde draw through it, so all three change.

Adapts Loop_Box's CC0 [3D Lightning Shader](https://godotshaders.com/shader/3d-lightning-shader/) into `scripts/3d/shaders/lightning_bolt.gdshader`. The FBM/noise core is the original verbatim. Five changes were needed to make it work as a *spawned* effect rather than a hand-placed mesh:

| Change | Why |
|---|---|
| Y-billboard `vertex()` | The original is fragment-only. A flat quad vanishes edge-on as the camera orbits the player. It now yaws to face the camera but stays upright, so the bolt always falls straight down. |
| `blend_add` + `unshaded` | An additive FX shouldn't take scene lighting. `EMISSION` is ignored under `unshaded`, so `Emission_Power` folds into `ALBEDO`. |
| `Seed` uniform | The original is driven purely by `TIME`, so every bolt on screen is pixel-identical. Gizonde chains up to 10 and Razonde fires one per enemy in a 12m radius — a chain of identical bolts reads as one wide bolt. |
| `Fade` uniform | Something for the spawner to tween out. |
| `Top_Taper` | The bolt fades into the sky instead of ending on the hard quad edge. The strike end stays full brightness. |

Dropped the `Power_Texture` sampler: the original reads it into `Power_Value` and never uses it. `Octave_Count` is **6** rather than 10 — six octaves of value-noise FBM per fragment times ~10 simultaneous Razonde bolts is the Android risk, and the difference isn't visible at this size.

### `Fade` had to be set explicitly

The first version tweened `shader_parameter/Fade` without ever assigning it, and every cast printed:

```
ERROR: The tweened property "shader_parameter/Fade" does not exist in object "<ShaderMaterial#...>"
```

The property *is* in the material's property list, but `ShaderMaterial.get()` returns `null` for a parameter that has never been assigned — it falls back to the shader's default at draw time and stores nothing, and Tween rejects a null as nonexistent. The tweener was never added, so the bolt went from the 0.1s hold straight to `queue_free`: a 100ms pop, no fade. Fixed by assigning it, with a comment — the line reads as redundant next to `uniform float Fade = 1.0` and deleting it restores the bug silently.

## 2. Technique casts rooted the player (pre-existing)

Found by play-testing the above: cast, and the character never returns to idle. **Not caused by this PR, and not specific to Zonde — every technique cast is affected.** It surfaced now because casting repeatedly is exactly what testing a cast visual involves.

`_cast_technique` enters `ATTACKING` directly rather than through `_play_attack_animation`, so the step-end tracking that path resets was left holding the *previous attack step's* values. `_attack_step_ended` is the fatal one, because both exits out of `ATTACKING` are gated on it:

- `_on_animation_finished`'s double-fire guard — `if _attack_step_ended: return`
- the elapsed-length safety net in `_handle_attack_state` — `and not _attack_step_ended`

The flag that exists to stop those two from *both* firing for one step was, for casts, stopping *either* from firing. The first cast after a spawn worked (flag still false from init) and set it true on its way out; every cast after that rooted the player until something unrelated knocked them loose — in practice taking a hit, which routes through `DAMAGED`. That's why it presents as intermittent, and why the play-test logs still show 4–6 casts per run: the player was being un-stuck by the mobs that eventually killed them.

Same root cause as the mechgun-root bug the safety net was added for (`test_mechgun_final_step_no_root`): an entry point into `ATTACKING` that forgets to arm the step-end machinery. Rather than duplicate the arming a third time, extract `_arm_attack_step()` and call it from both `_play_and_track_attack` and `_cast_technique`. The cast path measures `animation_player.current_animation` rather than the name it asked for, because `play_animation` falls back to a fuzzy suffix match and can start a differently-named clip.

## Testing

- **Seeded unit test**: `test_technique_cast_recovers` — the safety net for a cast-shaped step, the rooting a stale flag causes, and `_arm_attack_step` clearing it. Suite **2608 passed, 0 failed**.
- **Mutation-checked**: the behavioural asserts all passed while *describing* the bug without pinning the fix — deleting the reset wouldn't have failed them. `_cast_technique` can't be driven off-tree (`_spawn_technique_effect` needs `get_tree()`), so the call site is pinned by source inspection via the existing `_read_text_file` helper. Removing the call from `_cast_technique` produces `FAIL: _cast_technique arms the step-end machinery`.
- **Play-tested on the Mac** (the real renderer): casts are clean, no `Fade` errors, bolt strikes and fades.
- `check_baseline_debt.py` clean. No files under `assets/`, so no pack republish or `sync-tree`.

### Gaps, stated plainly

- **No autopilot probe.** CLAUDE.md's two-layer rule wants one for anything combat-driven, and the cast fix qualifies. The matrix scripts are Linux-only, so I can't run one here to verify a probe I'd be writing blind. This is a real gap, not something quietly covered.
- **The shader was never proven by the render check.** That check proved the shader compiled and drew; it never exercised the tween, which is why the `Fade` bug reached a play-test. Rendering a frame and running an animation are different claims.
- **The flicker is unjudged.** `mix(0.0, 0.05, Hash12(TIME))` is the original's, and unbiased — some frames land near-invisible, so a ~0.4s life is ~24 frames of hard strobe. Wants a call on real hardware; raising the floor off `0.0` is a one-uniform change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)