### PR TITLE
Stand enemies on the room's authored slots instead of a ring

### DIFF
--- a/data/re_reference/room_reference.json
+++ b/data/re_reference/room_reference.json
@@ -1,5 +1,5 @@
 {
- "_": "What the ORIGINAL has in a room that psz-godot does not place. Reference only — nothing here reaches the game; the gameplay table is room_objects.json. Regenerate with scripts/tools/refield/import_re_reference.py.",
+ "_": "What the ORIGINAL has in a room. OBJECTS are reference only and never reach the game \u2014 an unhandled kind would still eat a slot against the 20-object room cap, so the gameplay table stays room_objects.json. ENEMIES are DIFFERENT and ARE consumed: FieldPopulation stands each wave on these authored slots instead of a ring, because they are positions rather than objects and cost nothing against that cap (spec /mechanics/enemy-placement). Regenerate with scripts/tools/refield/import_re_reference.py.",
  "source": "psz-re data/object_placement_per_room.json + enemy_deploy_positions.json",
  "sets": [
   "d"

--- a/scripts/3d/field/field_population.gd
+++ b/scripts/3d/field/field_population.gd
@@ -56,6 +56,14 @@ const DEPLOY_SET := "d"
 ## the fallback for a room code invented later, not a placement policy.
 const BOXES_PER_ROOM := 2
 
+## The ring is now a FALLBACK, not the placement. Every room model the original
+## ships carries 8 or 9 authored spawn slots, and standing enemies on those is
+## the whole difference between a wave that fits its room and one that does not
+## (#604 -- enemies on rocks, waves straddling a void). A ring is a shape; it
+## knows nothing about the geometry it is drawn inside.
+##
+## Kept for room codes that have no authored slots, same as BOXES_PER_ROOM is
+## kept for room codes with no authored object table. See /mechanics/enemy-placement.
 const ENEMY_RING_RADIUS := 5.0
 const BOX_RING_RADIUS := 8.0
 
@@ -88,6 +96,13 @@ static var _loaded := false
 
 ## data/re_reference/room_objects.json, split out at load.
 static var _rooms: Dictionary = {}
+
+## Authored enemy spawn slots, room code -> Array of {x, y, z}. From
+## room_reference.json, which is otherwise reference-only -- see the note there:
+## its OBJECTS stay out of the game because an unhandled kind would eat a slot
+## against the 20-object room cap, but spawn slots are positions, not objects,
+## and cost nothing against that cap.
+static var _enemy_slots: Dictionary = {}
 static var _layout_masks: Array = []
 static var _layout_weights: Dictionary = {}
 static var _group5_weights: Array = []
@@ -111,6 +126,12 @@ static func _load() -> void:
 	_layout_masks = obj_doc.get("layout_masks", [])
 	_layout_weights = obj_doc.get("layout_weights_by_depth", {})
 	_group5_weights = obj_doc.get("group5_weights", [])
+	var ref_doc: Dictionary = _read_json(RE_DIR + "room_reference.json")
+	for code in ref_doc.get("rooms", {}):
+		var slots: Array = ref_doc["rooms"][code].get("enemies", [])
+		if not slots.is_empty():
+			_enemy_slots[code] = slots
+
 	var caps: Dictionary = obj_doc.get("caps", {})
 	_cap_per_group = int(caps.get("per_group", 20))
 	_cap_per_room = int(caps.get("per_room", 20))
@@ -430,6 +451,55 @@ static func _to_object(rec: Dictionary) -> Dictionary:
 
 
 ## Evenly spaced positions on a ring around the room centre (rooms are 44x44).
+## Where a wave's enemies stand: the room's own authored slots.
+##
+## `count` may exceed the slot count -- slots are REUSED rather than the wave
+## truncated, because the original reuses them too (a room with 8 slots was
+## observed producing 11 enemies across three waves). It may also be smaller,
+## in which case a seeded subset is taken so a given field always populates the
+## same way rather than shuffling on every revisit.
+##
+## Returns [] when the room code has no authored slots, so the caller falls
+## back to the ring.
+## The room's authored slots as the data holds them. Exposed so a test can
+## assert placement picks FROM this list rather than near it.
+static func authored_enemy_slots(room_code: String) -> Array:
+	_load()
+	return _enemy_slots.get("%s_%s" % [room_code, DEPLOY_SET], [])
+
+
+static func enemy_slot_positions(room_code: String, count: int,
+		rng: RandomNumberGenerator) -> Array:
+	_load()
+	# Same keying as authored_objects: the data is per deploy set.
+	var slots: Array = _enemy_slots.get("%s_%s" % [room_code, DEPLOY_SET], [])
+	if slots.is_empty() or count <= 0:
+		return []
+
+	# Which slots go unused is OUR choice, not a measurement: the original
+	# derives it from a per-room seed whose placement weights are still
+	# undecoded (psz-re default_parameters bytes 4..8). The POSITIONS are
+	# authored and exact; the selection among them is not claimed to match.
+	var order: Array = []
+	for i in range(slots.size()):
+		order.append(i)
+	for i in range(order.size() - 1, 0, -1):
+		var j: int = rng.randi_range(0, i)
+		var t = order[i]
+		order[i] = order[j]
+		order[j] = t
+
+	var out: Array = []
+	for i in range(count):
+		var slot: Dictionary = slots[order[i % order.size()]]
+		out.append([
+			snappedf(float(slot.get("x", 0.0)), 0.01),
+			snappedf(float(slot.get("y", 0.0)), 0.01),
+			snappedf(float(slot.get("z", 0.0)), 0.01),
+		])
+	return out
+
+
 static func ring_positions(count: int, radius: float) -> Array:
 	var out: Array = []
 	for i in range(count):
@@ -447,7 +517,9 @@ static func ring_positions(count: int, radius: float) -> Array:
 ## No boxes: these rooms are a fight and a warp, not a loot round.
 static func objects_for_single_room(room_code: String, rng: RandomNumberGenerator) -> Array:
 	var wave: Array = roll_wave(room_code, rng)
-	var spots: Array = ring_positions(wave.size(), ENEMY_RING_RADIUS)
+	var spots: Array = enemy_slot_positions(room_code, wave.size(), rng)
+	if spots.is_empty():
+		spots = ring_positions(wave.size(), ENEMY_RING_RADIUS)
 	var objects: Array = []
 	for i in range(wave.size()):
 		objects.append({
@@ -468,7 +540,9 @@ static func objects_for_cell(room_code: String, is_start: bool, is_end: bool,
 		return []
 	var objects: Array = []
 	var wave: Array = roll_wave(room_code, rng)
-	var enemy_spots: Array = ring_positions(wave.size(), ENEMY_RING_RADIUS)
+	var enemy_spots: Array = enemy_slot_positions(room_code, wave.size(), rng)
+	if enemy_spots.is_empty():
+		enemy_spots = ring_positions(wave.size(), ENEMY_RING_RADIUS)
 	for i in range(wave.size()):
 		objects.append({
 			"type": "enemy", "position": enemy_spots[i], "enemy_id": wave[i],

--- a/scripts/tools/refield/import_re_reference.py
+++ b/scripts/tools/refield/import_re_reference.py
@@ -139,10 +139,14 @@ def build(re_root: pathlib.Path, sets: tuple[str, ...]) -> dict:
                 })
 
     return {
-        "_": ("What the ORIGINAL has in a room that psz-godot does not place. "
-              "Reference only — nothing here reaches the game; the gameplay "
-              "table is room_objects.json. Regenerate with "
-              "scripts/tools/refield/import_re_reference.py."),
+        "_": ("What the ORIGINAL has in a room. OBJECTS are reference only and "
+              "never reach the game — an unhandled kind would still eat a slot "
+              "against the 20-object room cap, so the gameplay table stays "
+              "room_objects.json. ENEMIES are DIFFERENT and ARE consumed: "
+              "FieldPopulation stands each wave on these authored slots instead "
+              "of a ring, because they are positions rather than objects and "
+              "cost nothing against that cap (spec /mechanics/enemy-placement). "
+              "Regenerate with scripts/tools/refield/import_re_reference.py."),
         "source": "psz-re data/object_placement_per_room.json + enemy_deploy_positions.json",
         "sets": list(sets),
         "rooms": dict(sorted(rooms.items())),

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -116,6 +116,7 @@ func _run_tests_core() -> void:
 	test_authored_fences_are_openable()
 	test_gate_kind_per_door()
 	test_group_five_trap_roll()
+	test_enemies_stand_on_authored_slots()
 	test_field_trap_behaviour()
 	test_trap_vision_reveal()
 	test_palette_picker_grid()
@@ -1182,6 +1183,46 @@ func _distance_to_doorways(x: float, z: float, segments: Array) -> float:
 			var pz: float = az + (bz - az) * t
 			best = minf(best, Vector2(x - px, z - pz).length())
 	return best
+
+
+func test_enemies_stand_on_authored_slots() -> void:
+	print("── Enemies stand on the room's AUTHORED SLOTS, not on a ring ──")
+	const Pop := preload("res://scripts/3d/field/field_population.gd")
+
+	# The ring is radius 5.0 about the origin, so "every enemy is 5.0 from the
+	# centre" is exactly the symptom being removed (#604). Authored slots are
+	# scattered by the room's real geometry and are not equidistant.
+	var slots: Array = Pop.enemy_slot_positions("s03a_ib1", 4, _seeded_rng(1))
+	assert_true(slots.size() == 4, "four enemies get four positions")
+
+	var on_ring := 0
+	for p in slots:
+		var d: float = sqrt(float(p[0]) * float(p[0]) + float(p[2]) * float(p[2]))
+		if abs(d - 5.0) < 0.02:
+			on_ring += 1
+	assert_true(on_ring < 4, "not every enemy sits on the 5.0 ring")
+
+	# Every position MUST be one the room actually authors -- placement picks
+	# from the slot list, it does not interpolate or jitter.
+	var authored := {}
+	for e in Pop.authored_enemy_slots("s03a_ib1"):
+		authored["%.2f,%.2f" % [float(e.get("x", 0.0)), float(e.get("z", 0.0))]] = true
+	for p in slots:
+		assert_true(authored.has("%.2f,%.2f" % [float(p[0]), float(p[2])]),
+			"position %s is an authored slot" % [p])
+
+	# Seeded: the same field populates the same way every time it is entered.
+	var again: Array = Pop.enemy_slot_positions("s03a_ib1", 4, _seeded_rng(1))
+	assert_true(str(again) == str(slots), "same seed gives the same placement")
+
+	# A wave larger than the slot count REUSES slots rather than losing enemies
+	# -- the original reuses them too (8 slots, 11 enemies over three waves).
+	var big: Array = Pop.enemy_slot_positions("s03a_ib1", 12, _seeded_rng(2))
+	assert_true(big.size() == 12, "a 12-enemy wave gets 12 positions, none dropped")
+
+	# An unknown room code falls back to the ring rather than spawning nothing.
+	var none: Array = Pop.enemy_slot_positions("s99z_zz9", 3, _seeded_rng(3))
+	assert_true(none.is_empty(), "unknown room code yields no slots, so the caller rings")
 
 
 func test_group_five_trap_roll() -> void:

--- a/spec/src/pages/mechanics/enemy-placement.astro
+++ b/spec/src/pages/mechanics/enemy-placement.astro
@@ -1,0 +1,37 @@
+---
+import Concept from '../../layouts/Concept.astro';
+---
+
+<Concept title="Enemy Placement" section="Mechanics">
+  <p>The key words <strong>MUST</strong>, <strong>MUST NOT</strong>, <strong>SHOULD</strong>, and <strong>MAY</strong> are used as in RFC 2119.</p>
+
+  <p>This page governs <em>where</em> a wave's enemies stand. It does not govern <em>which</em> enemies a wave contains — that is the wave template roll, unchanged by this page.</p>
+
+  <h2>The rule</h2>
+
+  <p>Every room model in the original has <strong>authored spawn slots</strong>: 8 or 9 fixed positions per room, 2177 across 257 rooms, decoded by psz-re from <code>enemy_deploy_positions.json</code>. A wave's enemies <strong>MUST</strong> be placed on those slots.</p>
+
+  <p>psz-godot previously ringed enemies at a fixed radius of 5.0 around the cell centre. That is <strong>refuted</strong>: it ignores the room's geometry entirely, which is why enemies stand on rocks and why a wave can straddle a void (<a href="https://github.com/kion-dgl/psz-godot/issues/604">#604</a>). A ring is a shape, not a placement.</p>
+
+  <table>
+    <thead><tr><th>Case</th><th>Behaviour</th></tr></thead>
+    <tbody>
+      <tr><td>Room code has authored slots</td><td>Enemies <strong>MUST</strong> be placed on slots, chosen as below.</td></tr>
+      <tr><td>Wave is smaller than the slot count</td><td>A <strong>subset MUST</strong> be chosen, seeded from the run's RNG so a given field always populates identically.</td></tr>
+      <tr><td>Wave is larger than the slot count</td><td>Slots <strong>MUST</strong> be reused rather than the wave truncated. Slots are known to be reused across waves in the original: a room with 8 slots produced 11 enemies over 3 waves.</td></tr>
+      <tr><td>Room code has no authored slots</td><td>Fall back to the ring. This is a fallback for a room code invented later, <strong>not</strong> a placement policy.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Slots are positions, not a wave count</h2>
+
+  <p>A room's slot count <strong>MUST NOT</strong> be read as the number of enemies in a wave, nor as a per-room total. Measured against the original: a room with 8 slots produced three waves of 4, 3 and 4 enemies — 11 in total. Slots are the positions available to <em>each</em> wave, and the same slot may be used by a later wave.</p>
+
+  <h2>Coordinates</h2>
+
+  <p>Slots are room-local, in the same units and orientation as authored objects, with <code>y</code> the floor height at that point. psz-re's source orders each record <code>(x, z, elevation)</code> rather than <code>(x, y, z)</code>; the importer converts on read, so consumers see <code>&#123;x, y, z&#125;</code> and <strong>MUST NOT</strong> re-order.</p>
+
+  <h2>What this page does not settle</h2>
+
+  <p>Which subset of slots the original picks for a given wave is <strong>not known</strong>. The original derives room contents from a per-room RNG seed (record <code>+0x14</code>, confirmed by psz-re as a full-range RNG draw), and the weights that drive placement are still unidentified — psz-re's own note names <code>default_parameters.bytes_4_to_8</code> as the best candidate. Until those are decoded, the subset here is our own seeded choice and is <strong>not</strong> claimed to match the original's. The <em>positions</em> are authored data and are exact; the <em>selection among them</em> is ours.</p>
+</Concept>


### PR DESCRIPTION
Closes #604.

## Why

Enemies stand on rocks, and a wave can straddle a void. The cause is that placement never looked at the room: `ring_positions()` puts every enemy on a circle of radius 5.0 about the cell centre. That is a shape, drawn with no knowledge of the geometry it is drawn inside.

The original does not do this. **Every room model carries 8 or 9 authored spawn slots** — 2177 across 257 rooms, decoded by psz-re from `enemy_deploy_positions.json` and **already imported into `room_reference.json`, where nothing has ever read them.** The data has been sitting in the repo unused. This reads it.

## Why it is safe to read that file

`room_reference.json` said "nothing here reaches the game". That note was about **objects**: an unhandled kind would still eat a slot against the 20-object room cap and silently displace a box, which is exactly why the file was split out in the first place (1e01c16b).

Spawn slots are **positions, not objects**, and cost nothing against that cap. The note is updated in the importer *and* in the generated file rather than quietly contradicted — otherwise the file would be asserting something about itself that had become false.

## What is measured, and what is ours

Stated plainly in the spec and at the call site, because the distinction matters for every future comparison against the original:

- **The positions are authored and exact.**
- **Which subset a wave uses is our own seeded choice**, and is *not* claimed to match the original. The original derives room contents from a per-room RNG seed (record `+0x14`, confirmed by psz-re as a full-range RNG draw), and the weights that drive placement are still unidentified — psz-re's own note names `default_parameters.bytes_4_to_8` as the best candidate.

Seeded so a field populates identically each time it is entered, rather than reshuffling on revisit.

A wave **larger** than the slot count **reuses** slots rather than dropping enemies. Measured against the original this session: a room with 8 slots produced **11 enemies across three waves**, so slots are per-wave positions, not a per-room budget.

The ring survives as the fallback for a room code with no authored slots — the same role `BOXES_PER_ROOM` already plays for a room code with no object table. It is a fallback, not a placement policy.

## Spec

`/mechanics/enemy-placement`, written before the implementation per the spec-first rule, and explicit about which half of the rule is measured.

## Testing

- `test_enemies_stand_on_authored_slots` — asserts placement picks **from** the authored list rather than near it, that not every enemy lands on the 5.0 ring, that the same seed reproduces, that an oversized wave loses nobody, and that an unknown room code falls through to the ring.
- Full suite: **2657 passed, 0 failed**.
- Spec builds (and caught a real bug — Astro read `{x, y, z}` as a JS expression).

## Not done

**No autopilot probe**, so the two-layer rule is only half met. The autoplay scripts are Linux-only and this was written on the Mac. This is a spawn-position change in the field generator, so it wants a matrix run before it lands — flagging rather than quietly skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)