### PR TITLE
trebox is the treasure box, and o0c_mspack is the message pack

### DIFF
--- a/data/re_reference/room_reference.json
+++ b/data/re_reference/room_reference.json
@@ -1,5 +1,5 @@
 {
- "_": "What the ORIGINAL has in a room. OBJECTS are reference only and never reach the game \u2014 an unhandled kind would still eat a slot against the 20-object room cap, so the gameplay table stays room_objects.json. ENEMIES are DIFFERENT and ARE consumed: FieldPopulation stands each wave on these authored slots instead of a ring, because they are positions rather than objects and cost nothing against that cap (spec /mechanics/enemy-placement). Regenerate with scripts/tools/refield/import_re_reference.py.",
+ "_": "What the ORIGINAL has in a room. OBJECTS are reference only and never reach the game — an unhandled kind would still eat a slot against the 20-object room cap, so the gameplay table stays room_objects.json. ENEMIES are DIFFERENT and ARE consumed: FieldPopulation stands each wave on these authored slots instead of a ring, because they are positions rather than objects and cost nothing against that cap (spec /mechanics/enemy-placement). Regenerate with scripts/tools/refield/import_re_reference.py.",
  "source": "psz-re data/object_placement_per_room.json + enemy_deploy_positions.json",
  "sets": [
   "d"
@@ -24,7 +24,7 @@
      "z": 22.168
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 3.911,
@@ -45,7 +45,7 @@
      "z": -1.96
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -6.24,
@@ -135,7 +135,7 @@
      "z": -1.857
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -10.147,
@@ -143,7 +143,7 @@
      "z": 4.011
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.864,
@@ -167,7 +167,7 @@
      "z": -1.857
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -2.913,
@@ -175,7 +175,7 @@
      "z": -2.952
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -9.877,
@@ -249,7 +249,7 @@
      "z": 4.389
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.095,
@@ -257,7 +257,7 @@
      "z": 7.526
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.095,
@@ -273,7 +273,7 @@
      "z": -12.598
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -14.114,
@@ -289,7 +289,7 @@
      "z": 5.188
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -14.114,
@@ -368,7 +368,7 @@
      "z": -11.436
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.953,
@@ -376,7 +376,7 @@
      "z": -8.077
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.953,
@@ -392,7 +392,7 @@
      "z": -2.233
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -15.157,
@@ -408,7 +408,7 @@
      "z": 8.481
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -10.79,
@@ -487,7 +487,7 @@
      "z": 4.873
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 8.098,
@@ -495,7 +495,7 @@
      "z": -19.035
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 13.805,
@@ -519,7 +519,7 @@
      "z": -16.654
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 13.842,
@@ -527,7 +527,7 @@
      "z": -18.998
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 8.059,
@@ -606,7 +606,7 @@
      "z": -9.775
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -9.771,
@@ -614,7 +614,7 @@
      "z": 8.429
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.013,
@@ -630,7 +630,7 @@
      "z": -3.127
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -12.901,
@@ -646,7 +646,7 @@
      "z": 9.656
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -7.303,
@@ -720,7 +720,7 @@
      "z": -2.121
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 13.37,
@@ -728,7 +728,7 @@
      "z": -4.603
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 7.056,
@@ -744,7 +744,7 @@
      "z": 4.527
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -1.518,
@@ -752,7 +752,7 @@
      "z": -0.636
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 2.434,
@@ -834,7 +834,7 @@
      "z": -12.037
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -8.661,
@@ -842,7 +842,7 @@
      "z": 13.785
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -4.481,
@@ -921,7 +921,7 @@
      "z": 17.177
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 10.129,
@@ -929,7 +929,7 @@
      "z": -11.039
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 14.157,
@@ -953,7 +953,7 @@
      "z": 15.514
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 12.136,
@@ -961,7 +961,7 @@
      "z": -8.893
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 12.136,
@@ -1019,7 +1019,7 @@
   "s01a_na1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -11.773,
@@ -1043,7 +1043,7 @@
      "z": 1.82
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -8.373,
@@ -1051,7 +1051,7 @@
      "z": 0.446
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -1.897,
@@ -1075,7 +1075,7 @@
      "z": -0.077
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -8.373,
@@ -1154,7 +1154,7 @@
      "z": 2.883
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 16.416,
@@ -1162,7 +1162,7 @@
      "z": 6.167
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -5.554,
@@ -1186,7 +1186,7 @@
      "z": 4.854
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 14.82,
@@ -1194,7 +1194,7 @@
      "z": 9.101
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -5.544,
@@ -1268,7 +1268,7 @@
      "z": 15.374
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -20.533,
@@ -1276,7 +1276,7 @@
      "z": 11.561
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.41,
@@ -1300,7 +1300,7 @@
      "z": -17.213
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 15.946,
@@ -1308,7 +1308,7 @@
      "z": 14.451
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -20.533,
@@ -1387,7 +1387,7 @@
      "z": 22.168
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 3.911,
@@ -1445,7 +1445,7 @@
      "z": -3.749
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.139,
@@ -1461,7 +1461,7 @@
      "z": 5.474
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.139,
@@ -1543,7 +1543,7 @@
      "z": -12.024
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 15.317,
@@ -1567,7 +1567,7 @@
      "z": 11.067
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 15.308,
@@ -1646,7 +1646,7 @@
      "z": 2.963
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.463,
@@ -1670,7 +1670,7 @@
      "z": 12.849
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -10.94,
@@ -1749,7 +1749,7 @@
      "z": 15.452
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 5.729,
@@ -1773,7 +1773,7 @@
      "z": 15.452
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 5.729,
@@ -1852,7 +1852,7 @@
      "z": 9.654
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.676,
@@ -1868,7 +1868,7 @@
      "z": 1.21
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 7.701,
@@ -2048,7 +2048,7 @@
      "z": -7.033
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.442,
@@ -2056,7 +2056,7 @@
      "z": 2.277
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -8.835,
@@ -2072,7 +2072,7 @@
      "z": 10.091
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -8.835,
@@ -2088,7 +2088,7 @@
      "z": -19.686
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 3.661,
@@ -2162,7 +2162,7 @@
      "z": 15.945
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 11.056,
@@ -2170,7 +2170,7 @@
      "z": -1.857
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 10.229,
@@ -2194,7 +2194,7 @@
      "z": -12.305
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 12.503,
@@ -2202,7 +2202,7 @@
      "z": -12.348
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 12.503,
@@ -2276,7 +2276,7 @@
      "z": 12.176
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 15.854,
@@ -2284,7 +2284,7 @@
      "z": 7.031
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 15.854,
@@ -2358,7 +2358,7 @@
      "z": -6.975
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -15.209,
@@ -2366,7 +2366,7 @@
      "z": -12.555
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -15.209,
@@ -2390,7 +2390,7 @@
      "z": -4.902
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -14.663,
@@ -2398,7 +2398,7 @@
      "z": -12.777
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -11.008,
@@ -2477,7 +2477,7 @@
      "z": -10.469
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -6.596,
@@ -2485,7 +2485,7 @@
      "z": 2.249
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.834,
@@ -2559,7 +2559,7 @@
      "z": -2.898
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.582,
@@ -2567,7 +2567,7 @@
      "z": -8.898
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.746,
@@ -2583,7 +2583,7 @@
      "z": -9.386
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 5.179,
@@ -2599,7 +2599,7 @@
      "z": 10.952
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 9.279,
@@ -2673,7 +2673,7 @@
      "z": 8.398
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.558,
@@ -2681,7 +2681,7 @@
      "z": 7.29
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.558,
@@ -2705,7 +2705,7 @@
      "z": -0.063
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 14.462,
@@ -2713,7 +2713,7 @@
      "z": -14.655
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 14.462,
@@ -2792,7 +2792,7 @@
      "z": 10.904
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -15.529,
@@ -2800,7 +2800,7 @@
      "z": -12.309
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -15.529,
@@ -2824,7 +2824,7 @@
      "z": 16.484
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -16.631,
@@ -2832,7 +2832,7 @@
      "z": -11.824
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -16.631,
@@ -2911,7 +2911,7 @@
      "z": 10.214
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.152,
@@ -2919,7 +2919,7 @@
      "z": -0.462
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 4.842,
@@ -2943,7 +2943,7 @@
      "z": 10.284
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -1.29,
@@ -2951,7 +2951,7 @@
      "z": 0.266
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": 4.842,
@@ -2959,7 +2959,7 @@
      "z": -2.823
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": 4.842,
@@ -2967,7 +2967,7 @@
      "z": -2.823
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -10.012,
@@ -3041,7 +3041,7 @@
   "s01b_nb2_d": {
    "objects": [
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -6.963,
@@ -3049,7 +3049,7 @@
      "z": 17.571
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.622,
@@ -3073,7 +3073,7 @@
      "z": -21.261
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -6.957,
@@ -3081,7 +3081,7 @@
      "z": 17.597
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 14.685,
@@ -3176,7 +3176,7 @@
      "z": 6.038
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -10.695,
@@ -3184,7 +3184,7 @@
      "z": 11.922
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -14.629,
@@ -3200,7 +3200,7 @@
      "z": 4.109
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -12.634,
@@ -3216,7 +3216,7 @@
      "z": 1.909
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -4.36,
@@ -3295,7 +3295,7 @@
      "z": 22.168
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 3.911,
@@ -3353,7 +3353,7 @@
      "z": -16.593
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.844,
@@ -3432,7 +3432,7 @@
      "z": 14.886
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -16.56,
@@ -3448,7 +3448,7 @@
      "z": 15.829
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -16.56,
@@ -3535,7 +3535,7 @@
      "z": -4.241
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.892,
@@ -3559,7 +3559,7 @@
      "z": -17.134
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -2.432,
@@ -3638,7 +3638,7 @@
      "z": -5.939
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 4.034,
@@ -3654,7 +3654,7 @@
      "z": -17.786
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -5.552,
@@ -3736,7 +3736,7 @@
      "z": 21.46
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 3.372,
@@ -3760,7 +3760,7 @@
      "z": 8.56
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 11.9,
@@ -3826,7 +3826,7 @@
      "z": -20.14
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.231,
@@ -3850,7 +3850,7 @@
      "z": -2.761
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -2.019,
@@ -3908,7 +3908,7 @@
   "s01e_nr2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.077,
@@ -3982,7 +3982,7 @@
      "z": 5.757
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.551,
@@ -4142,7 +4142,7 @@
      "z": -4.797
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.796,
@@ -4158,7 +4158,7 @@
      "z": -2.985
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.712,
@@ -4166,7 +4166,7 @@
      "z": -6.069
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.782,
@@ -4190,7 +4190,7 @@
      "z": -4.797
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.905,
@@ -4198,7 +4198,7 @@
      "z": 6.015
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.058,
@@ -4222,7 +4222,7 @@
      "z": -8.621
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -6.189,
@@ -4280,7 +4280,7 @@
   "s02a_ib2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -1.963,
@@ -4312,7 +4312,7 @@
      "z": 0.138
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.57,
@@ -4328,7 +4328,7 @@
      "z": 0.138
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -1.657,
@@ -4352,7 +4352,7 @@
      "z": -4.797
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.36,
@@ -4360,7 +4360,7 @@
      "z": 5.873
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -1.795,
@@ -4384,7 +4384,7 @@
      "z": 8.028
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.106,
@@ -4455,7 +4455,7 @@
      "z": 13.33
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 14.799,
@@ -4479,7 +4479,7 @@
      "z": -6.541
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -3.077,
@@ -4487,7 +4487,7 @@
      "z": 0.116
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.461,
@@ -4511,7 +4511,7 @@
      "z": 2.811
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.461,
@@ -4527,7 +4527,7 @@
      "z": 13.33
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.499,
@@ -4543,7 +4543,7 @@
      "z": 0.189
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.499,
@@ -4650,7 +4650,7 @@
   "s02a_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 13.131,
@@ -4690,7 +4690,7 @@
      "z": 13.46
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -3.203,
@@ -4706,7 +4706,7 @@
      "z": -6.558
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.54,
@@ -4722,7 +4722,7 @@
      "z": 6.495
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.54,
@@ -4730,7 +4730,7 @@
      "z": -2.125
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.352,
@@ -4762,7 +4762,7 @@
      "z": 13.612
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.352,
@@ -4828,7 +4828,7 @@
      "z": 8.095
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.148,
@@ -4844,7 +4844,7 @@
      "z": 7.938
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.148,
@@ -4852,7 +4852,7 @@
      "z": -6.106
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -6.114,
@@ -4876,7 +4876,7 @@
      "z": -1.214
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.14,
@@ -4884,7 +4884,7 @@
      "z": -4.199
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.175,
@@ -4908,7 +4908,7 @@
      "z": -1.214
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.175,
@@ -5023,7 +5023,7 @@
      "z": -5.374
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.615,
@@ -5047,7 +5047,7 @@
      "z": -7.575
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -1.492,
@@ -5055,7 +5055,7 @@
      "z": -10.807
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -5.21,
@@ -5079,7 +5079,7 @@
      "z": -11.109
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.263,
@@ -5087,7 +5087,7 @@
      "z": -13.031
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -14.973,
@@ -5111,7 +5111,7 @@
      "z": -7.203
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.128,
@@ -5185,7 +5185,7 @@
      "z": 0.587
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.454,
@@ -5201,7 +5201,7 @@
      "z": -6.31
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 14.72,
@@ -5209,7 +5209,7 @@
      "z": 0.483
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 14.719,
@@ -5233,7 +5233,7 @@
      "z": 0.587
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.226,
@@ -5241,7 +5241,7 @@
      "z": 0.499
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.454,
@@ -5265,7 +5265,7 @@
      "z": 0.587
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.454,
@@ -5344,7 +5344,7 @@
      "z": -12.028
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.069,
@@ -5352,7 +5352,7 @@
      "z": 13.492
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.754,
@@ -5360,7 +5360,7 @@
      "z": 0.187
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -15.855,
@@ -5384,7 +5384,7 @@
      "z": 6.713
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -10.638,
@@ -5392,7 +5392,7 @@
      "z": -0.013
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -12.128,
@@ -5416,7 +5416,7 @@
      "z": -0.08
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.052,
@@ -5528,7 +5528,7 @@
   "s02a_na1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.271,
@@ -5552,7 +5552,7 @@
      "z": 7.972
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -10.96,
@@ -5576,7 +5576,7 @@
      "z": -5.498
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.345,
@@ -5584,7 +5584,7 @@
      "z": -5.509
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -10.96,
@@ -5592,7 +5592,7 @@
      "z": 12.393
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.298,
@@ -5616,7 +5616,7 @@
      "z": 7.972
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -10.96,
@@ -5682,7 +5682,7 @@
      "z": -4.45
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.06,
@@ -5698,7 +5698,7 @@
      "z": -0.992
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 0.094,
@@ -5714,7 +5714,7 @@
      "z": -0.144
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.06,
@@ -5746,7 +5746,7 @@
      "z": -0.144
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 1.588,
@@ -5754,7 +5754,7 @@
      "z": 19.744
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.758,
@@ -5778,7 +5778,7 @@
      "z": -9.4
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 1.588,
@@ -5836,7 +5836,7 @@
   "s02a_nc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.116,
@@ -5860,7 +5860,7 @@
      "z": 2.24
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -15.847,
@@ -5868,7 +5868,7 @@
      "z": 0.03
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.116,
@@ -5892,7 +5892,7 @@
      "z": -3.522
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -15.847,
@@ -5971,7 +5971,7 @@
      "z": 22.168
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 3.911,
@@ -6029,7 +6029,7 @@
      "z": 6.404
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -1.582,
@@ -6045,7 +6045,7 @@
      "z": 6.806
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -8.647,
@@ -6069,7 +6069,7 @@
      "z": 9.096
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.744,
@@ -6159,7 +6159,7 @@
      "z": -0.288
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 7.306,
@@ -6175,7 +6175,7 @@
      "z": -7.131
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -13.646,
@@ -6199,7 +6199,7 @@
      "z": -0.134
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -13.675,
@@ -6289,7 +6289,7 @@
      "z": -7.292
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -8.274,
@@ -6305,7 +6305,7 @@
      "z": -7.179
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.116,
@@ -6353,7 +6353,7 @@
      "z": -7.862
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.129,
@@ -6432,7 +6432,7 @@
      "z": -5.409
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.013,
@@ -6464,7 +6464,7 @@
      "z": 1.285
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.052,
@@ -6496,7 +6496,7 @@
      "z": 5.043
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.107,
@@ -6562,7 +6562,7 @@
   "s02a_xb2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.001,
@@ -6586,7 +6586,7 @@
      "z": 14.789
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.065,
@@ -6610,7 +6610,7 @@
      "z": -11.071
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.258,
@@ -6737,7 +6737,7 @@
      "z": 7.34
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.988,
@@ -6769,7 +6769,7 @@
      "z": 11.089
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.888,
@@ -6777,7 +6777,7 @@
      "z": -2.024
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.674,
@@ -6809,7 +6809,7 @@
      "z": -11.592
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.041,
@@ -6817,7 +6817,7 @@
      "z": -1.54
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.674,
@@ -6841,7 +6841,7 @@
      "z": 0.953
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.399,
@@ -6907,7 +6907,7 @@
      "z": 5.238
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.026,
@@ -6923,7 +6923,7 @@
      "z": -12.105
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -3.571,
@@ -6955,7 +6955,7 @@
      "z": -11.704
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.493,
@@ -6979,7 +6979,7 @@
      "z": 7.926
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.679,
@@ -6995,7 +6995,7 @@
      "z": -11.681
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.553,
@@ -7019,7 +7019,7 @@
      "z": -10.538
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.376,
@@ -7085,7 +7085,7 @@
      "z": 17.373
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 16.377,
@@ -7101,7 +7101,7 @@
      "z": 9.282
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 12.925,
@@ -7109,7 +7109,7 @@
      "z": 12.396
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 16.349,
@@ -7133,7 +7133,7 @@
      "z": 9.412
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 12.425,
@@ -7157,7 +7157,7 @@
      "z": 9.26
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 16.743,
@@ -7165,7 +7165,7 @@
      "z": 12.399
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 12.416,
@@ -7228,7 +7228,7 @@
   "s02b_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.124,
@@ -7252,7 +7252,7 @@
      "z": -10.964
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.124,
@@ -7260,7 +7260,7 @@
      "z": 7.468
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.116,
@@ -7284,7 +7284,7 @@
      "z": -11.535
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.116,
@@ -7308,7 +7308,7 @@
      "z": -9.134
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.08,
@@ -7316,7 +7316,7 @@
      "z": 14.377
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.026,
@@ -7387,7 +7387,7 @@
      "z": 10.153
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.405,
@@ -7411,7 +7411,7 @@
      "z": 11.043
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.405,
@@ -7419,7 +7419,7 @@
      "z": 0.562
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.111,
@@ -7451,7 +7451,7 @@
      "z": -11.756
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.111,
@@ -7459,7 +7459,7 @@
      "z": -8.759
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.229,
@@ -7491,7 +7491,7 @@
      "z": -4.698
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.229,
@@ -7557,7 +7557,7 @@
      "z": -15.543
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.285,
@@ -7573,7 +7573,7 @@
      "z": -3.495
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 10.267,
@@ -7581,7 +7581,7 @@
      "z": -8.074
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.262,
@@ -7605,7 +7605,7 @@
      "z": -15.543
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 10.133,
@@ -7663,7 +7663,7 @@
   "s02b_lc1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.654,
@@ -7695,7 +7695,7 @@
      "z": 11.304
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -6.972,
@@ -7703,7 +7703,7 @@
      "z": -10.25
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.742,
@@ -7727,7 +7727,7 @@
      "z": 15.372
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.141,
@@ -7735,7 +7735,7 @@
      "z": -4.316
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.614,
@@ -7767,7 +7767,7 @@
      "z": 5.578
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.397,
@@ -7838,7 +7838,7 @@
      "z": -4.864
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.477,
@@ -7854,7 +7854,7 @@
      "z": 13.467
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 7.463,
@@ -7862,7 +7862,7 @@
      "z": -9.599
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.477,
@@ -7886,7 +7886,7 @@
      "z": 13.467
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.362,
@@ -7894,7 +7894,7 @@
      "z": -5.096
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.477,
@@ -7918,7 +7918,7 @@
      "z": 8.949
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.299,
@@ -7992,7 +7992,7 @@
      "z": 2.769
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.911,
@@ -8000,7 +8000,7 @@
      "z": 2.918
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -8.387,
@@ -8008,7 +8008,7 @@
      "z": -6.642
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.911,
@@ -8032,7 +8032,7 @@
      "z": 2.769
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -8.387,
@@ -8040,7 +8040,7 @@
      "z": -6.642
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -12.936,
@@ -8064,7 +8064,7 @@
      "z": 9.58
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -8.387,
@@ -8122,7 +8122,7 @@
   "s02b_nb2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.609,
@@ -8146,7 +8146,7 @@
      "z": 6.427
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -16.226,
@@ -8154,7 +8154,7 @@
      "z": 11.058
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.609,
@@ -8178,7 +8178,7 @@
      "z": -13.219
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -16.226,
@@ -8236,7 +8236,7 @@
   "s02b_nc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.306,
@@ -8268,7 +8268,7 @@
      "z": 4.29
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 4.186,
@@ -8276,7 +8276,7 @@
      "z": 17.782
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -7.129,
@@ -8308,7 +8308,7 @@
      "z": 4.29
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 4.186,
@@ -8316,7 +8316,7 @@
      "z": 17.782
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -7.129,
@@ -8348,7 +8348,7 @@
      "z": 4.29
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 4.186,
@@ -8422,7 +8422,7 @@
      "z": 22.168
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 3.911,
@@ -8480,7 +8480,7 @@
      "z": 4.062
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.175,
@@ -8496,7 +8496,7 @@
      "z": 10.81
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -3.786,
@@ -8520,7 +8520,7 @@
      "z": 5.218
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -8.871,
@@ -8610,7 +8610,7 @@
      "z": 9.555
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.147,
@@ -8626,7 +8626,7 @@
      "z": 9.873
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.146,
@@ -8650,7 +8650,7 @@
      "z": 8.578
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -12.516,
@@ -8737,7 +8737,7 @@
      "z": 9.203
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.678,
@@ -8753,7 +8753,7 @@
      "z": 12.498
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.678,
@@ -8777,7 +8777,7 @@
      "z": 9.203
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.678,
@@ -8864,7 +8864,7 @@
      "z": 10.607
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.625,
@@ -8880,7 +8880,7 @@
      "z": -12.398
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.71,
@@ -8904,7 +8904,7 @@
      "z": 10.607
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 15.696,
@@ -8999,7 +8999,7 @@
      "z": 7.746
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -8.19,
@@ -9015,7 +9015,7 @@
      "z": 11.024
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -1.565,
@@ -9039,7 +9039,7 @@
      "z": -11.629
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.757,
@@ -9134,7 +9134,7 @@
      "z": -17.4
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -10.749,
@@ -9142,7 +9142,7 @@
      "z": -10.528
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 9.159,
@@ -9216,7 +9216,7 @@
   "s02e_nr2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -7.788,
@@ -9282,7 +9282,7 @@
   "s02z_na1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 17.175,
@@ -9377,7 +9377,7 @@
   "s03a_ib1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.221,
@@ -9401,7 +9401,7 @@
      "z": -15.224
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.092,
@@ -9475,7 +9475,7 @@
      "z": 2.829
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.701,
@@ -9483,7 +9483,7 @@
      "z": -9.369
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.964,
@@ -9587,7 +9587,7 @@
   "s03a_ic1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.87,
@@ -9611,7 +9611,7 @@
      "z": -1.177
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 9.759,
@@ -9619,7 +9619,7 @@
      "z": 5.257
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 15.127,
@@ -9643,7 +9643,7 @@
      "z": -12.263
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -8.053,
@@ -9667,7 +9667,7 @@
      "z": -9.038
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 12.162,
@@ -9675,7 +9675,7 @@
      "z": -11.648
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 9.585,
@@ -9738,7 +9738,7 @@
   "s03a_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 3.967,
@@ -9762,7 +9762,7 @@
      "z": -11.179
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.158,
@@ -9833,7 +9833,7 @@
      "z": 5.456
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.967,
@@ -9849,7 +9849,7 @@
      "z": 2.106
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.252,
@@ -9915,7 +9915,7 @@
      "z": 1.889
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -9.481,
@@ -9931,7 +9931,7 @@
      "z": 3.376
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -11.739,
@@ -10005,7 +10005,7 @@
      "z": 3.452
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.47,
@@ -10013,7 +10013,7 @@
      "z": -9.816
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.264,
@@ -10029,7 +10029,7 @@
      "z": 15.674
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -7.532,
@@ -10045,7 +10045,7 @@
      "z": 19.024
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.801,
@@ -10053,7 +10053,7 @@
      "z": -10.588
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 14.488,
@@ -10077,7 +10077,7 @@
      "z": 19.288
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -4.888,
@@ -10143,7 +10143,7 @@
      "z": 8.567
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.315,
@@ -10159,7 +10159,7 @@
      "z": 10.475
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.851,
@@ -10225,7 +10225,7 @@
      "z": 6.808
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -4.908,
@@ -10241,7 +10241,7 @@
      "z": 5.072
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -1.715,
@@ -10307,7 +10307,7 @@
      "z": -3.237
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 9.204,
@@ -10323,7 +10323,7 @@
      "z": -1.436
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 10.725,
@@ -10389,7 +10389,7 @@
      "z": -9.608
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -6.76,
@@ -10405,7 +10405,7 @@
      "z": -12.958
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -18.125,
@@ -10463,7 +10463,7 @@
   "s03a_nr5_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -4.45,
@@ -10471,7 +10471,7 @@
      "z": 3.731
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -12.359,
@@ -10555,7 +10555,7 @@
      "z": -2.307
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 11.054,
@@ -10634,7 +10634,7 @@
      "z": 3.013
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -8.813,
@@ -10705,7 +10705,7 @@
   "s03a_td1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 11.089,
@@ -10787,7 +10787,7 @@
      "z": 3.792
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 3.035,
@@ -10866,7 +10866,7 @@
      "z": -11.068
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 7.723,
@@ -10969,7 +10969,7 @@
      "z": 14.009
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.215,
@@ -10985,7 +10985,7 @@
      "z": 10.659
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.593,
@@ -11059,7 +11059,7 @@
      "z": 5.159
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.542,
@@ -11067,7 +11067,7 @@
      "z": -1.979
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.203,
@@ -11146,7 +11146,7 @@
      "z": -8.29
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 8.578,
@@ -11154,7 +11154,7 @@
      "z": 5.12
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -9.098,
@@ -11233,7 +11233,7 @@
      "z": 2.843
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -11.609,
@@ -11241,7 +11241,7 @@
      "z": -11.317
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.994,
@@ -11320,7 +11320,7 @@
      "z": 15.055
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.386,
@@ -11328,7 +11328,7 @@
      "z": -1.407
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.191,
@@ -11402,7 +11402,7 @@
      "z": 8.891
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.304,
@@ -11410,7 +11410,7 @@
      "z": -5.396
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.54,
@@ -11484,7 +11484,7 @@
      "z": -11.974
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.969,
@@ -11492,7 +11492,7 @@
      "z": -10.752
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.086,
@@ -11500,7 +11500,7 @@
      "z": -10.828
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -5.966,
@@ -11524,7 +11524,7 @@
      "z": 14.554
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -5.069,
@@ -11644,7 +11644,7 @@
      "z": 4.74
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.306,
@@ -11652,7 +11652,7 @@
      "z": 7.449
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -13.203,
@@ -11731,7 +11731,7 @@
      "z": -9.217
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.498,
@@ -11739,7 +11739,7 @@
      "z": -2.469
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -4.468,
@@ -11813,7 +11813,7 @@
      "z": -16.464
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 13.212,
@@ -11821,7 +11821,7 @@
      "z": 10.724
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 16.28,
@@ -11900,7 +11900,7 @@
      "z": -6.654
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -6.766,
@@ -11908,7 +11908,7 @@
      "z": 6.795
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 13.501,
@@ -11916,7 +11916,7 @@
      "z": 5.662
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -8.899,
@@ -11940,7 +11940,7 @@
      "z": -12.732
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": 13.501,
@@ -11998,7 +11998,7 @@
   "s03b_nr5_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -4.45,
@@ -12006,7 +12006,7 @@
      "z": 3.731
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -12.359,
@@ -12098,7 +12098,7 @@
      "z": -4.992
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.371,
@@ -12172,7 +12172,7 @@
      "z": 15.715
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.177,
@@ -12292,7 +12292,7 @@
      "z": 5.303
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 7.783,
@@ -12371,7 +12371,7 @@
      "z": 9.189
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.275,
@@ -12450,7 +12450,7 @@
      "z": 16.112
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -4.396,
@@ -12529,7 +12529,7 @@
      "z": 25.521
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.085,
@@ -12545,7 +12545,7 @@
      "z": -19.358
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 6.543,
@@ -12603,7 +12603,7 @@
   "s03e_nr2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.253,
@@ -12677,7 +12677,7 @@
      "z": -5.027
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.33,
@@ -12780,7 +12780,7 @@
      "z": -3.846
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.276,
@@ -12788,7 +12788,7 @@
      "z": 0.102
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.902,
@@ -12812,7 +12812,7 @@
      "z": 9.457
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 3.434,
@@ -12820,7 +12820,7 @@
      "z": 0.113
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.901,
@@ -12894,7 +12894,7 @@
      "z": 14.125
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.86,
@@ -12902,7 +12902,7 @@
      "z": -1.649
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.258,
@@ -12926,7 +12926,7 @@
      "z": -0.617
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -5.277,
@@ -12934,7 +12934,7 @@
      "z": 6.496
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -1.252,
@@ -13000,7 +13000,7 @@
      "z": -0.954
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 14.014,
@@ -13008,7 +13008,7 @@
      "z": -16.796
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 16.74,
@@ -13040,7 +13040,7 @@
      "z": 8.363
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 14.023,
@@ -13048,7 +13048,7 @@
      "z": -16.746
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 16.643,
@@ -13127,7 +13127,7 @@
      "z": 7.429
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.726,
@@ -13135,7 +13135,7 @@
      "z": -14.812
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -11.963,
@@ -13159,7 +13159,7 @@
      "z": -18.082
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -11.943,
@@ -13167,7 +13167,7 @@
      "z": -9.009
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.68,
@@ -13238,7 +13238,7 @@
      "z": 4.569
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.275,
@@ -13254,7 +13254,7 @@
      "z": -7.157
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.402,
@@ -13278,7 +13278,7 @@
      "z": 4.642
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.301,
@@ -13286,7 +13286,7 @@
      "z": -3.946
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 4.174,
@@ -13360,7 +13360,7 @@
      "z": 16.564
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 5.332,
@@ -13368,7 +13368,7 @@
      "z": -0.864
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 5.332,
@@ -13384,7 +13384,7 @@
      "z": -12.855
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 3.409,
@@ -13400,7 +13400,7 @@
      "z": 9.509
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 12.009,
@@ -13474,7 +13474,7 @@
      "z": -15.04
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 11.419,
@@ -13482,7 +13482,7 @@
      "z": 10.06
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 9.753,
@@ -13490,7 +13490,7 @@
      "z": 11.846
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 11.435,
@@ -13514,7 +13514,7 @@
      "z": -1.178
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 13.231,
@@ -13593,7 +13593,7 @@
      "z": 15.894
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.415,
@@ -13601,7 +13601,7 @@
      "z": 12.464
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 11.514,
@@ -13625,7 +13625,7 @@
      "z": 14.438
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -12.415,
@@ -13633,7 +13633,7 @@
      "z": 12.464
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 9.642,
@@ -13707,7 +13707,7 @@
      "z": 12.993
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 3.869,
@@ -13715,7 +13715,7 @@
      "z": -3.81
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -2.809,
@@ -13723,7 +13723,7 @@
      "z": 17.483
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -1.605,
@@ -13747,7 +13747,7 @@
      "z": 5.52
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -2.809,
@@ -13771,7 +13771,7 @@
      "z": 12.956
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 4.491,
@@ -13779,7 +13779,7 @@
      "z": 2.855
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -2.809,
@@ -13845,7 +13845,7 @@
      "z": -11.899
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.238,
@@ -13853,7 +13853,7 @@
      "z": -4.309
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 7.006,
@@ -13885,7 +13885,7 @@
      "z": 3.731
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -1.235,
@@ -13893,7 +13893,7 @@
      "z": -2.783
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": 7.006,
@@ -13901,7 +13901,7 @@
      "z": 16.44
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": 7.006,
@@ -13909,7 +13909,7 @@
      "z": 16.44
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -3.276,
@@ -13999,7 +13999,7 @@
      "z": -9.394
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.268,
@@ -14007,7 +14007,7 @@
      "z": -12.156
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -16.269,
@@ -14015,7 +14015,7 @@
      "z": -16.31
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -12.268,
@@ -14039,7 +14039,7 @@
      "z": -10.58
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -16.269,
@@ -14102,7 +14102,7 @@
   "s04a_nr4_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -9.179,
@@ -14110,7 +14110,7 @@
      "z": 8.041
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -2.742,
@@ -14194,7 +14194,7 @@
      "z": 11.706
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.168,
@@ -14218,7 +14218,7 @@
      "z": 8.818
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 1.167,
@@ -14300,7 +14300,7 @@
      "z": -14.572
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 14.303,
@@ -14316,7 +14316,7 @@
      "z": 5.388
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 9.79,
@@ -14403,7 +14403,7 @@
      "z": -10.07
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.593,
@@ -14419,7 +14419,7 @@
      "z": 13.086
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 4.577,
@@ -14501,7 +14501,7 @@
      "z": 16.262
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.54,
@@ -14517,7 +14517,7 @@
      "z": 12.192
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 6.577,
@@ -14599,7 +14599,7 @@
      "z": 9.937
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.617,
@@ -14623,7 +14623,7 @@
      "z": 12.63
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 6.63,
@@ -14723,7 +14723,7 @@
      "z": -10.671
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 8.87,
@@ -14739,7 +14739,7 @@
      "z": 10.783
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -8.637,
@@ -14755,7 +14755,7 @@
      "z": 0.057
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -8.677,
@@ -14771,7 +14771,7 @@
      "z": 0.071
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 8.88,
@@ -14837,7 +14837,7 @@
      "z": 14.62
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 10.854,
@@ -14853,7 +14853,7 @@
      "z": -10.62
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 10.854,
@@ -14869,7 +14869,7 @@
      "z": 10.777
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 10.81,
@@ -14877,7 +14877,7 @@
      "z": -7.433
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 10.81,
@@ -14964,7 +14964,7 @@
      "z": -4.984
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.05,
@@ -14972,7 +14972,7 @@
      "z": -10.073
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -4.997,
@@ -14996,7 +14996,7 @@
      "z": 11.979
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.05,
@@ -15004,7 +15004,7 @@
      "z": -10.172
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 4.614,
@@ -15020,7 +15020,7 @@
      "z": 0.09
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -0.057,
@@ -15036,7 +15036,7 @@
      "z": 0.09
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 4.592,
@@ -15115,7 +15115,7 @@
      "z": -3.315
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -14.974,
@@ -15123,7 +15123,7 @@
      "z": -0.083
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -19.718,
@@ -15147,7 +15147,7 @@
      "z": -0.047
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -14.98,
@@ -15155,7 +15155,7 @@
      "z": -0.044
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -10.365,
@@ -15234,7 +15234,7 @@
      "z": -12.587
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.46,
@@ -15242,7 +15242,7 @@
      "z": -1.867
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 5.383,
@@ -15250,7 +15250,7 @@
      "z": -5.35
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 1.888,
@@ -15258,7 +15258,7 @@
      "z": 5.343
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 5.421,
@@ -15340,7 +15340,7 @@
      "z": 7.298
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 8.977,
@@ -15356,7 +15356,7 @@
      "z": -10.87
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 5.371,
@@ -15364,7 +15364,7 @@
      "z": -9.105
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 12.579,
@@ -15380,7 +15380,7 @@
      "z": -14.21
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 8.97,
@@ -15454,7 +15454,7 @@
      "z": -10.0
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 5.055,
@@ -15470,7 +15470,7 @@
      "z": -10.618
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.345,
@@ -15494,7 +15494,7 @@
      "z": -10.0
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 5.078,
@@ -15502,7 +15502,7 @@
      "z": 15.018
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 9.81,
@@ -15518,7 +15518,7 @@
      "z": -10.601
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 5.056,
@@ -15534,7 +15534,7 @@
      "z": 15.024
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 7.106,
@@ -15597,7 +15597,7 @@
   "s04b_lc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.193,
@@ -15621,7 +15621,7 @@
      "z": -11.957
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.378,
@@ -15629,7 +15629,7 @@
      "z": 5.396
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 10.114,
@@ -15653,7 +15653,7 @@
      "z": -11.957
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 5.508,
@@ -15716,7 +15716,7 @@
   "s04b_na1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.025,
@@ -15724,7 +15724,7 @@
      "z": -0.538
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -12.55,
@@ -15756,7 +15756,7 @@
      "z": -2.459
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -0.101,
@@ -15772,7 +15772,7 @@
      "z": -2.44
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": -12.55,
@@ -15838,7 +15838,7 @@
      "z": -12.681
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.035,
@@ -15854,7 +15854,7 @@
      "z": -12.679
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 16.286,
@@ -15870,7 +15870,7 @@
      "z": -10.847
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 0.008,
@@ -15886,7 +15886,7 @@
      "z": -10.862
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 4,
      "x": 16.286,
@@ -15952,7 +15952,7 @@
      "z": 1.589
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.232,
@@ -15968,7 +15968,7 @@
      "z": -3.633
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 20.744,
@@ -15984,7 +15984,7 @@
      "z": 1.635
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 12.242,
@@ -16000,7 +16000,7 @@
      "z": -3.655
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": 20.744,
@@ -16063,7 +16063,7 @@
   "s04b_nr4_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -9.179,
@@ -16071,7 +16071,7 @@
      "z": 8.041
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -2.742,
@@ -16163,7 +16163,7 @@
      "z": -12.632
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.056,
@@ -16171,7 +16171,7 @@
      "z": -0.037
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.057,
@@ -16261,7 +16261,7 @@
      "z": 10.04
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -10.073,
@@ -16285,7 +16285,7 @@
      "z": 7.191
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -10.096,
@@ -16364,7 +16364,7 @@
      "z": 14.442
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 3.675,
@@ -16388,7 +16388,7 @@
      "z": 14.533
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 3.675,
@@ -16462,7 +16462,7 @@
      "z": -10.85
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.142,
@@ -16486,7 +16486,7 @@
      "z": -10.85
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.159,
@@ -16560,7 +16560,7 @@
      "z": -7.276
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.063,
@@ -16568,7 +16568,7 @@
      "z": 0.018
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.063,
@@ -16658,7 +16658,7 @@
      "z": -19.822
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.124,
@@ -16674,7 +16674,7 @@
      "z": -0.213
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 3.011,
@@ -16732,7 +16732,7 @@
   "s04e_nr2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.168,
@@ -16806,7 +16806,7 @@
      "z": -0.056
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.098,
@@ -16893,7 +16893,7 @@
   "s05a_ib1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 8.763,
@@ -16917,7 +16917,7 @@
      "z": -1.994
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -8.164,
@@ -16925,7 +16925,7 @@
      "z": -9.31
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.941,
@@ -16949,7 +16949,7 @@
      "z": -2.692
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.941,
@@ -17007,7 +17007,7 @@
   "s05a_ib2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -12.851,
@@ -17031,7 +17031,7 @@
      "z": 15.127
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.902,
@@ -17089,7 +17089,7 @@
   "s05a_ic1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.621,
@@ -17097,7 +17097,7 @@
      "z": -13.872
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -15.163,
@@ -17121,7 +17121,7 @@
      "z": 7.691
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -14.979,
@@ -17145,7 +17145,7 @@
      "z": 4.254
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 2.381,
@@ -17153,7 +17153,7 @@
      "z": -13.628
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -14.273,
@@ -17177,7 +17177,7 @@
      "z": 1.374
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.135,
@@ -17240,7 +17240,7 @@
   "s05a_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.419,
@@ -17264,7 +17264,7 @@
      "z": -15.383
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -15.319,
@@ -17272,7 +17272,7 @@
      "z": 4.147
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 12.419,
@@ -17296,7 +17296,7 @@
      "z": -20.741
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -16.971,
@@ -17320,7 +17320,7 @@
      "z": -20.799
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 9.543,
@@ -17328,7 +17328,7 @@
      "z": -19.462
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -15.927,
@@ -17386,7 +17386,7 @@
   "s05a_lb1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.174,
@@ -17410,7 +17410,7 @@
      "z": -0.664
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 7.87,
@@ -17418,7 +17418,7 @@
      "z": 0.717
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -2.504,
@@ -17442,7 +17442,7 @@
      "z": -3.006
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -2.504,
@@ -17508,7 +17508,7 @@
      "z": -2.6
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.745,
@@ -17524,7 +17524,7 @@
      "z": -3.897
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 5.519,
@@ -17532,7 +17532,7 @@
      "z": -0.458
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.349,
@@ -17556,7 +17556,7 @@
      "z": -4.937
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 13.111,
@@ -17630,7 +17630,7 @@
      "z": -8.926
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 10.655,
@@ -17638,7 +17638,7 @@
      "z": -12.141
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.772,
@@ -17662,7 +17662,7 @@
      "z": -6.146
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 10.545,
@@ -17670,7 +17670,7 @@
      "z": -2.269
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 5.895,
@@ -17728,7 +17728,7 @@
   "s05a_lc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 13.327,
@@ -17752,7 +17752,7 @@
      "z": -0.794
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 7.473,
@@ -17776,7 +17776,7 @@
      "z": -15.248
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -18.213,
@@ -17784,7 +17784,7 @@
      "z": -17.796
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.716,
@@ -17808,7 +17808,7 @@
      "z": -9.87
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -18.249,
@@ -17816,7 +17816,7 @@
      "z": -6.706
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -12.527,
@@ -17874,7 +17874,7 @@
   "s05a_na1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.055,
@@ -17898,7 +17898,7 @@
      "z": 4.33
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -5.118,
@@ -17906,7 +17906,7 @@
      "z": 16.971
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.041,
@@ -17930,7 +17930,7 @@
      "z": -0.377
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -5.118,
@@ -17954,7 +17954,7 @@
      "z": 3.186
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.055,
@@ -17962,7 +17962,7 @@
      "z": 5.178
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -5.118,
@@ -18036,7 +18036,7 @@
      "z": -9.625
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -6.604,
@@ -18044,7 +18044,7 @@
      "z": -17.29
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -5.198,
@@ -18068,7 +18068,7 @@
      "z": -15.274
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.773,
@@ -18076,7 +18076,7 @@
      "z": -21.053
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -5.198,
@@ -18100,7 +18100,7 @@
      "z": -8.992
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 2.564,
@@ -18108,7 +18108,7 @@
      "z": -17.708
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -8.189,
@@ -18166,7 +18166,7 @@
   "s05a_nc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -14.839,
@@ -18190,7 +18190,7 @@
      "z": 16.841
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 14.752,
@@ -18214,7 +18214,7 @@
      "z": -9.16
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -14.839,
@@ -18222,7 +18222,7 @@
      "z": -14.992
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 14.752,
@@ -18246,7 +18246,7 @@
      "z": 20.309
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -13.494,
@@ -18254,7 +18254,7 @@
      "z": 16.54
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 14.752,
@@ -18312,7 +18312,7 @@
   "s05a_nr3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.723,
@@ -18320,7 +18320,7 @@
      "z": -4.124
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 2.439,
@@ -18396,7 +18396,7 @@
   "s05a_tb3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -13.982,
@@ -18436,7 +18436,7 @@
      "z": 3.567
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.545,
@@ -18494,7 +18494,7 @@
   "s05a_tc3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.185,
@@ -18518,7 +18518,7 @@
      "z": 2.976
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -11.222,
@@ -18550,7 +18550,7 @@
      "z": 5.544
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -14.64,
@@ -18624,7 +18624,7 @@
      "z": 1.99
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.863,
@@ -18640,7 +18640,7 @@
      "z": 3.115
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -5.713,
@@ -18714,7 +18714,7 @@
   "s05a_td2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.403,
@@ -18754,7 +18754,7 @@
      "z": 1.99
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -16.867,
@@ -18778,7 +18778,7 @@
      "z": 6.374
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.393,
@@ -18836,7 +18836,7 @@
   "s05a_xb2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.548,
@@ -18860,7 +18860,7 @@
      "z": 9.118
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.138,
@@ -18971,7 +18971,7 @@
      "z": 10.283
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.948,
@@ -18987,7 +18987,7 @@
      "z": -7.359
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 8.692,
@@ -19011,7 +19011,7 @@
      "z": 4.565
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 7.736,
@@ -19019,7 +19019,7 @@
      "z": -8.978
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -6.364,
@@ -19093,7 +19093,7 @@
      "z": -13.362
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -12.614,
@@ -19101,7 +19101,7 @@
      "z": -16.072
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -5.769,
@@ -19159,7 +19159,7 @@
   "s05b_ic1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 13.514,
@@ -19183,7 +19183,7 @@
      "z": -14.215
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 14.478,
@@ -19207,7 +19207,7 @@
      "z": -7.971
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 12.987,
@@ -19215,7 +19215,7 @@
      "z": -8.159
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 13.108,
@@ -19273,7 +19273,7 @@
   "s05b_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -18.617,
@@ -19281,7 +19281,7 @@
      "z": -6.328
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.897,
@@ -19371,7 +19371,7 @@
      "z": -6.475
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.924,
@@ -19379,7 +19379,7 @@
      "z": -4.263
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -5.829,
@@ -19403,7 +19403,7 @@
      "z": 6.986
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 8.463,
@@ -19411,7 +19411,7 @@
      "z": -6.582
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -8.971,
@@ -19419,7 +19419,7 @@
      "z": -7.827
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.602,
@@ -19443,7 +19443,7 @@
      "z": 1.211
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.664,
@@ -19517,7 +19517,7 @@
      "z": -3.533
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.685,
@@ -19525,7 +19525,7 @@
      "z": 3.421
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.685,
@@ -19599,7 +19599,7 @@
      "z": 10.678
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 10.239,
@@ -19607,7 +19607,7 @@
      "z": -15.715
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -8.142,
@@ -19615,7 +19615,7 @@
      "z": -8.846
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -10.033,
@@ -19639,7 +19639,7 @@
      "z": 17.938
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -3.508,
@@ -19647,7 +19647,7 @@
      "z": -9.762
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.669,
@@ -19671,7 +19671,7 @@
      "z": 17.235
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.613,
@@ -19737,7 +19737,7 @@
      "z": 1.727
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.244,
@@ -19753,7 +19753,7 @@
      "z": 4.906
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.244,
@@ -19761,7 +19761,7 @@
      "z": -2.939
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 7.314,
@@ -19785,7 +19785,7 @@
      "z": 8.916
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 10.906,
@@ -19793,7 +19793,7 @@
      "z": -3.481
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -0.409,
@@ -19817,7 +19817,7 @@
      "z": -2.45
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.023,
@@ -19891,7 +19891,7 @@
      "z": -3.051
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 1.812,
@@ -19899,7 +19899,7 @@
      "z": -10.412
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -11.255,
@@ -19973,7 +19973,7 @@
      "z": -12.039
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -18.459,
@@ -19981,7 +19981,7 @@
      "z": -14.696
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -10.555,
@@ -20005,7 +20005,7 @@
      "z": -13.359
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 13.03,
@@ -20013,7 +20013,7 @@
      "z": -19.43
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -10.555,
@@ -20037,7 +20037,7 @@
      "z": -12.349
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -18.459,
@@ -20045,7 +20045,7 @@
      "z": -14.696
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": -10.555,
@@ -20103,7 +20103,7 @@
   "s05b_nc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 11.598,
@@ -20127,7 +20127,7 @@
      "z": -17.869
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 0.544,
@@ -20143,7 +20143,7 @@
      "z": -16.73
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -2.228,
@@ -20159,7 +20159,7 @@
      "z": -16.628
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 0.544,
@@ -20217,7 +20217,7 @@
   "s05b_nr3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -4.723,
@@ -20225,7 +20225,7 @@
      "z": -4.124
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 2.439,
@@ -20301,7 +20301,7 @@
   "s05b_tb3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.66,
@@ -20325,7 +20325,7 @@
      "z": 6.295
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 3.791,
@@ -20415,7 +20415,7 @@
      "z": 0.143
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -13.275,
@@ -20439,7 +20439,7 @@
      "z": 4.309
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 16.656,
@@ -20447,7 +20447,7 @@
      "z": 0.116
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 17.209,
@@ -20521,7 +20521,7 @@
   "s05b_td1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -17.26,
@@ -20561,7 +20561,7 @@
      "z": -9.766
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -17.104,
@@ -20635,7 +20635,7 @@
      "z": -3.705
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 6.981,
@@ -20643,7 +20643,7 @@
      "z": -0.099
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 4.573,
@@ -20733,7 +20733,7 @@
      "z": -2.315
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -3.656,
@@ -20757,7 +20757,7 @@
      "z": -3.922
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 12.245,
@@ -20815,7 +20815,7 @@
   "s05e_ia1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.082,
@@ -20847,7 +20847,7 @@
      "z": -18.865
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": null,
      "x": 11.351,
@@ -20905,7 +20905,7 @@
   "s05e_nr2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 8.211,
@@ -20979,7 +20979,7 @@
      "z": -0.012
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": -9.337,
@@ -21082,7 +21082,7 @@
      "z": 0.861
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.103,
@@ -21098,7 +21098,7 @@
      "z": -0.392
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.784,
@@ -21122,7 +21122,7 @@
      "z": -20.159
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -6.005,
@@ -21130,7 +21130,7 @@
      "z": 4.564
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 6.181,
@@ -21196,7 +21196,7 @@
      "z": 0.265
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -17.899,
@@ -21212,7 +21212,7 @@
      "z": -5.925
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -17.899,
@@ -21220,7 +21220,7 @@
      "z": 5.95
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 16.141,
@@ -21244,7 +21244,7 @@
      "z": 8.94
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 16.141,
@@ -21302,7 +21302,7 @@
   "s06a_ic1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -14.947,
@@ -21326,7 +21326,7 @@
      "z": 5.505
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -10.023,
@@ -21334,7 +21334,7 @@
      "z": -0.194
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.065,
@@ -21358,7 +21358,7 @@
      "z": -1.218
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.065,
@@ -21416,7 +21416,7 @@
   "s06a_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.64,
@@ -21440,7 +21440,7 @@
      "z": 10.154
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -7.681,
@@ -21448,7 +21448,7 @@
      "z": 5.097
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 3.224,
@@ -21472,7 +21472,7 @@
      "z": -14.022
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 7.532,
@@ -21480,7 +21480,7 @@
      "z": -4.957
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 3.224,
@@ -21504,7 +21504,7 @@
      "z": -11.288
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -2.475,
@@ -21575,7 +21575,7 @@
      "z": 14.915
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.384,
@@ -21591,7 +21591,7 @@
      "z": 11.972
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.321,
@@ -21615,7 +21615,7 @@
      "z": -8.152
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -13.35,
@@ -21623,7 +21623,7 @@
      "z": -11.041
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -5.424,
@@ -21681,7 +21681,7 @@
   "s06a_lb3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.995,
@@ -21705,7 +21705,7 @@
      "z": 1.98
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -2.995,
@@ -21729,7 +21729,7 @@
      "z": -12.408
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.011,
@@ -21737,7 +21737,7 @@
      "z": -4.676
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -8.129,
@@ -21795,7 +21795,7 @@
   "s06a_lc1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.451,
@@ -21819,7 +21819,7 @@
      "z": 7.807
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.451,
@@ -21827,7 +21827,7 @@
      "z": 8.739
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -6.538,
@@ -21851,7 +21851,7 @@
      "z": -12.664
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -6.538,
@@ -21917,7 +21917,7 @@
      "z": 7.496
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 7.394,
@@ -21933,7 +21933,7 @@
      "z": 7.433
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 7.394,
@@ -21941,7 +21941,7 @@
      "z": 0.119
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -7.354,
@@ -21965,7 +21965,7 @@
      "z": 12.988
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -12.506,
@@ -22036,7 +22036,7 @@
      "z": -15.503
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 11.185,
@@ -22052,7 +22052,7 @@
      "z": -15.213
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 2.277,
@@ -22060,7 +22060,7 @@
      "z": -18.243
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.063,
@@ -22068,7 +22068,7 @@
      "z": -13.535
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -0.101,
@@ -22142,7 +22142,7 @@
   "s06a_nb2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.123,
@@ -22166,7 +22166,7 @@
      "z": -9.943
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 4.458,
@@ -22190,7 +22190,7 @@
      "z": -18.843
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -4.971,
@@ -22198,7 +22198,7 @@
      "z": -3.777
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 0.084,
@@ -22264,7 +22264,7 @@
      "z": -13.46
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.047,
@@ -22280,7 +22280,7 @@
      "z": -13.252
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 5.358,
@@ -22288,7 +22288,7 @@
      "z": 17.526
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -6.002,
@@ -22296,7 +22296,7 @@
      "z": 17.408
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -9.988,
@@ -22378,7 +22378,7 @@
      "z": -1.96
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -6.24,
@@ -22404,7 +22404,7 @@
   "s06a_tb3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.006,
@@ -22428,7 +22428,7 @@
      "z": -14.003
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.006,
@@ -22510,7 +22510,7 @@
      "z": -9.898
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.346,
@@ -22542,7 +22542,7 @@
      "z": -14.701
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 10.025,
@@ -22621,7 +22621,7 @@
      "z": -14.719
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.999,
@@ -22637,7 +22637,7 @@
      "z": -14.795
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.105,
@@ -22724,7 +22724,7 @@
      "z": -11.234
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.036,
@@ -22732,7 +22732,7 @@
      "z": -17.942
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 4.008,
@@ -22756,7 +22756,7 @@
      "z": -17.836
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -4.397,
@@ -22843,7 +22843,7 @@
      "z": -4.067
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.08,
@@ -22946,7 +22946,7 @@
      "z": -1.007
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -18.229,
@@ -22962,7 +22962,7 @@
      "z": 0.548
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -18.477,
@@ -23028,7 +23028,7 @@
      "z": -2.602
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.083,
@@ -23044,7 +23044,7 @@
      "z": 2.443
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.04,
@@ -23102,7 +23102,7 @@
   "s06b_ic1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -14.967,
@@ -23126,7 +23126,7 @@
      "z": 12.522
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -15.054,
@@ -23174,7 +23174,7 @@
      "z": -0.004
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 14.956,
@@ -23182,7 +23182,7 @@
      "z": -8.719
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": 15.044,
@@ -23272,7 +23272,7 @@
      "z": -17.86
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.113,
@@ -23280,7 +23280,7 @@
      "z": 0.013
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.103,
@@ -23359,7 +23359,7 @@
      "z": -0.11
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -14.18,
@@ -23367,7 +23367,7 @@
      "z": 9.322
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -8.947,
@@ -23446,7 +23446,7 @@
      "z": 13.246
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -6.213,
@@ -23454,7 +23454,7 @@
      "z": 6.592
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.402,
@@ -23515,7 +23515,7 @@
      "z": 16.013
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -17.38,
@@ -23531,7 +23531,7 @@
      "z": 15.862
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -17.38,
@@ -23602,7 +23602,7 @@
   "s06b_lc2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -16.703,
@@ -23626,7 +23626,7 @@
      "z": 20.629
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.763,
@@ -23697,7 +23697,7 @@
      "z": -0.127
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.028,
@@ -23713,7 +23713,7 @@
      "z": -0.033
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -4.455,
@@ -23721,7 +23721,7 @@
      "z": 9.56
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.028,
@@ -23745,7 +23745,7 @@
      "z": -0.127
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -4.455,
@@ -23811,7 +23811,7 @@
      "z": -4.757
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.015,
@@ -23827,7 +23827,7 @@
      "z": -3.642
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -0.003,
@@ -23843,7 +23843,7 @@
      "z": -5.419
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 3,
      "x": -0.015,
@@ -23859,7 +23859,7 @@
      "z": -4.168
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 3,
      "x": -0.003,
@@ -23930,7 +23930,7 @@
      "z": -7.518
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 12.458,
@@ -23954,7 +23954,7 @@
      "z": -9.142
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 0.016,
@@ -24020,7 +24020,7 @@
      "z": -1.96
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -6.24,
@@ -24062,7 +24062,7 @@
      "z": 4.272
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.11,
@@ -24136,7 +24136,7 @@
      "z": -10.1
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.05,
@@ -24210,7 +24210,7 @@
      "z": -14.474
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.198,
@@ -24289,7 +24289,7 @@
      "z": 12.752
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.023,
@@ -24368,7 +24368,7 @@
      "z": 19.276
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.228,
@@ -24434,7 +24434,7 @@
      "z": -10.684
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.217,
@@ -24458,7 +24458,7 @@
      "z": 28.463
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 13.752,
@@ -24524,7 +24524,7 @@
      "z": -17.121
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.351,
@@ -24590,7 +24590,7 @@
      "z": -10.0
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.0,
@@ -24693,7 +24693,7 @@
      "z": 0.639
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.004,
@@ -24701,7 +24701,7 @@
      "z": 0.262
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.1,
@@ -24764,7 +24764,7 @@
   "s07a_ib2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.052,
@@ -24788,7 +24788,7 @@
      "z": -0.105
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.041,
@@ -24854,7 +24854,7 @@
      "z": -1.537
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.241,
@@ -24870,7 +24870,7 @@
      "z": 1.336
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.241,
@@ -24928,7 +24928,7 @@
   "s07a_ic3_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -3.808,
@@ -24952,7 +24952,7 @@
      "z": -0.427
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.65,
@@ -25015,7 +25015,7 @@
   "s07a_lb1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.001,
@@ -25039,7 +25039,7 @@
      "z": 0.575
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.036,
@@ -25110,7 +25110,7 @@
      "z": 0.199
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.504,
@@ -25126,7 +25126,7 @@
      "z": -5.5
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.255,
@@ -25192,7 +25192,7 @@
      "z": 3.071
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.34,
@@ -25208,7 +25208,7 @@
      "z": 9.386
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.853,
@@ -25274,7 +25274,7 @@
      "z": 7.343
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 4.45,
@@ -25290,7 +25290,7 @@
      "z": 6.085
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 8.517,
@@ -25361,7 +25361,7 @@
      "z": 0.271
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.015,
@@ -25427,7 +25427,7 @@
   "s07a_nb2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.031,
@@ -25514,7 +25514,7 @@
      "z": 5.809
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.148,
@@ -25593,7 +25593,7 @@
      "z": -1.96
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -6.24,
@@ -25635,7 +25635,7 @@
      "z": 0.012
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.025,
@@ -25706,7 +25706,7 @@
      "z": -5.38
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 1.883,
@@ -25785,7 +25785,7 @@
      "z": -12.2
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.055,
@@ -25867,7 +25867,7 @@
      "z": -13.239
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.011,
@@ -25933,7 +25933,7 @@
      "z": -0.068
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.021,
@@ -26041,7 +26041,7 @@
      "z": 0.263
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.014,
@@ -26057,7 +26057,7 @@
      "z": 0.263
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.03,
@@ -26128,7 +26128,7 @@
      "z": 0.191
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.053,
@@ -26144,7 +26144,7 @@
      "z": 0.311
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.053,
@@ -26168,7 +26168,7 @@
      "z": 1.222
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -0.053,
@@ -26176,7 +26176,7 @@
      "z": 2.057
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": -0.053,
@@ -26234,7 +26234,7 @@
   "s07b_ic1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.415,
@@ -26258,7 +26258,7 @@
      "z": 3.466
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.415,
@@ -26332,7 +26332,7 @@
      "z": -5.43
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.206,
@@ -26340,7 +26340,7 @@
      "z": 8.257
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.206,
@@ -26411,7 +26411,7 @@
      "z": 0.355
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.156,
@@ -26427,7 +26427,7 @@
      "z": 17.18
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.039,
@@ -26501,7 +26501,7 @@
      "z": -6.298
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -12.022,
@@ -26509,7 +26509,7 @@
      "z": -0.08
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.053,
@@ -26572,7 +26572,7 @@
   "s07b_lc1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 2.43,
@@ -26596,7 +26596,7 @@
      "z": 2.527
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 4.85,
@@ -26662,7 +26662,7 @@
      "z": 13.099
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -9.139,
@@ -26678,7 +26678,7 @@
      "z": 0.347
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -5.549,
@@ -26741,7 +26741,7 @@
   "s07b_na1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.012,
@@ -26765,7 +26765,7 @@
      "z": -1.856
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -5.153,
@@ -26885,7 +26885,7 @@
      "z": -13.21
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 0.016,
@@ -26901,7 +26901,7 @@
      "z": -13.311
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -0.077,
@@ -26964,7 +26964,7 @@
   "s07b_nc2_d": {
    "objects": [
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -4.079,
@@ -26972,7 +26972,7 @@
      "z": 14.145
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.12,
@@ -26996,7 +26996,7 @@
      "z": -4.354
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 4,
      "x": 0.136,
@@ -27083,7 +27083,7 @@
      "z": -1.96
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": -6.24,
@@ -27125,7 +27125,7 @@
      "z": 4.817
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.042,
@@ -27191,7 +27191,7 @@
      "z": -7.914
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 3.79,
@@ -27262,7 +27262,7 @@
   "s07b_td1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -1.56,
@@ -27352,7 +27352,7 @@
      "z": -8.007
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.087,
@@ -27423,7 +27423,7 @@
      "z": 5.776
     },
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": 6.171,
@@ -27494,7 +27494,7 @@
   "s07e_ia1_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -6.672,
@@ -27526,7 +27526,7 @@
      "z": -13.248
     },
     {
-     "k": "meseta",
+     "k": "message pack",
      "m": "o0c_mspack",
      "g": 0,
      "x": 4.823,
@@ -27589,7 +27589,7 @@
   "s07e_nr2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": null,
      "x": 0.0,
@@ -27704,7 +27704,7 @@
   "s07z_na2_d": {
    "objects": [
     {
-     "k": "trebox (unidentified)",
+     "k": "treasure box",
      "m": "o0c_trebox",
      "g": 0,
      "x": -0.028,

--- a/scripts/tools/refield/check_portal_floor_cover.py
+++ b/scripts/tools/refield/check_portal_floor_cover.py
@@ -35,6 +35,17 @@ OUTWARD = {"north": -1, "south": 1, "east": 1, "west": -1}
 # what has to be reachable.
 TRIGGER_HALF = 3.0
 
+# THE POINT BEING ON FLOOR IS NOT ENOUGH. player.gd refuses to move unless it
+# finds floor FLOOR_CHECK_DISTANCE ahead of itself and FLOOR_CHECK_SIDE either
+# side of that -- the same three probes a stuck-walk logs. So reaching a point
+# needs floor about a metre BEYOND it, laterally too.
+#
+# s01b_tb3 is what taught this: floor to z=26.5, trigger face at 26.0, so a
+# plain point test passed it -- and search_and_rescue stalled at 25.5 with 0/3
+# probes, because standing at 26.0 wants floor at 27.0.
+FLOOR_CHECK_DISTANCE = 1.0
+FLOOR_CHECK_SIDE = 0.5
+
 
 def floor_triangles(glb: pathlib.Path):
     """XZ triangles of the collision floor, or None if the file has no mesh."""
@@ -141,7 +152,16 @@ def main() -> int:
                         z -= out * TRIGGER_HALF
                     else:
                         x -= out * TRIGGER_HALF
-                if not inside(tris, x, z):
+                # Probe as the player would: ahead along the approach, plus
+                # both shoulders. All three must land, matching can_move_to.
+                ax_is_z = (ax == 2)
+                fx = out * FLOOR_CHECK_DISTANCE if not ax_is_z else 0.0
+                fz = out * FLOOR_CHECK_DISTANCE if ax_is_z else 0.0
+                sx, sz = (FLOOR_CHECK_SIDE, 0.0) if ax_is_z else (0.0, FLOOR_CHECK_SIDE)
+                probes = [(x + fx, z + fz),
+                          (x + fx + sx, z + fz + sz),
+                          (x + fx - sx, z + fz - sz)]
+                if not inside(tris, x, z) or not all(inside(tris, px, pz) for px, pz in probes):
                     coord = z if ax == 2 else x
                     bad.append((stage_id, p["direction"],
                                 "spawn" if kind == "spawnPosition" else "trigger face",

--- a/scripts/tools/refield/import_re_reference.py
+++ b/scripts/tools/refield/import_re_reference.py
@@ -10,9 +10,13 @@ original puts in a room and what we build is visible instead of theoretical.
     python3 scripts/tools/refield/import_re_reference.py           # write
     python3 scripts/tools/refield/import_re_reference.py --check   # drift guard
 
-NOTHING HERE REACHES THE GAME. It is deliberately a separate file from
+THE OBJECTS HERE DO NOT REACH THE GAME. It is deliberately a separate file from
 room_objects.json so that adding a kind to this list can never accidentally
 start spawning it — the two have different consumers and different risks.
+
+The ENEMY SLOTS are the exception and ARE consumed: FieldPopulation stands each
+wave on them instead of a ring (spec /mechanics/enemy-placement). They are
+positions rather than objects, so they cost nothing against the room cap.
 
 What it carries, per room:
 
@@ -25,9 +29,9 @@ What it carries, per room:
               how we find out.
 
   enemies     Spawn slots from enemy_deploy_positions.json: 257 rooms in set d,
-              8 or 9 slots each. psz-godot still rings enemies at radius 5.0
-              (psz-godot#604), which is why they stand on rocks and why a wave
-              straddles a void.
+              8 or 9 slots each. CONSUMED by FieldPopulation since #616 — before
+              that psz-godot ringed enemies at radius 5.0 (#604), which is why
+              they stood on rocks and why a wave straddled a void.
 
               SLOT ORDER IS (x, z, elevation), NOT (x, y, z) — psz-re's
               THE_COLUMNS_ARE_X_THEN_Z: col0/col1 are the ground plane and col2
@@ -40,9 +44,11 @@ What it carries, per room:
               splits 159/95. With ~8.4 slots per block against 4-enemy wave
               templates, a room's slots plausibly cover more than one wave.
 
-  other       Kinds the original authors that we neither place nor understand:
-              o0c_trebox (653 records over 251 rooms — psz-re's largest single
-              unknown), warps, healing pads, meseta packs.
+  other       Kinds the original authors that psz-godot does not place:
+              o0c_trebox, the TREASURE BOX that appears once a room is cleared
+              (653 records over 251 rooms — long carried as psz-re's largest
+              unknown until it was identified in play, #613); o0c_mspack, the
+              MESSAGE PACK that spawns beside it; warps and healing pads.
 """
 from __future__ import annotations
 
@@ -69,8 +75,21 @@ PLACED_KINDS = {
 # name, which is the honest default for a thing nobody has identified.
 REFERENCE_LABELS = {
     "o0c_key": "key",
-    "o0c_trebox": "trebox (unidentified)",
-    "o0c_mspack": "meseta",
+    # IDENTIFIED IN PLAY, not guessed. Both were wrong in ways that cost time:
+    # "trebox (unidentified)" read as an open question and was re-investigated
+    # every session, and "meseta" was simply the wrong object.
+    #
+    # o0c_trebox is the TREASURE BOX -- it spawns in a room after every enemy in
+    # that room is defeated, and it is the treasure box model in the storybook.
+    # Confirmed across four rooms of a Rioh run, counts matching the reference
+    # each time (kion-dgl/psz-godot#613).
+    #
+    # o0c_mspack is the MESSAGE PACK, which psz-godot already models --
+    # web/src/elements/MessagePack.tsx and scripts/3d/elements/message_pack.gd,
+    # the latter reading its own o0c_1_mspack scroll texture. It spawns
+    # post-clear alongside the treasure box. Nothing about it is meseta.
+    "o0c_trebox": "treasure box",
+    "o0c_mspack": "message pack",
     "o0c_healhp": "heal pad",
     "o0s_warpm": "warp",
     "o0s_warps": "warp",


### PR DESCRIPTION
Closes #613.

Two labels in `room_reference.json` were wrong. Both cost time rather than merely being untidy.

## `trebox (unidentified)` → **treasure box**

The label read as an open question, so it got re-investigated every time anyone looked at the file — including in the session that produced this PR, where it was "discovered" again and reported back to kion, who has been saying what it is for a while.

It is the **treasure box**: it spawns in a room once every enemy there is defeated, and it is the treasure box model in the [storybook](https://kion-dgl.github.io/psz-godot/#/storybook). Confirmed across four rooms of a Rioh run, its count matching the reference each time, and observed appearing post-clear exactly as described.

## `meseta` → **message pack**

Simply the wrong object. The model is `o0c_mspack` — the **Message Pack**, which psz-godot already models:

- `web/src/elements/MessagePack.tsx`
- `scripts/3d/elements/message_pack.gd`, which reads its own `o0c_1_mspack` scroll texture

It spawns beside the treasure box on clear. Nothing about it is meseta — and the wrong label led to it being reported to kion as a "meseta pack" until he corrected it.

## The change

**755 records**: 653 treasure box, 102 message pack.

The relabel **asserts each record's model name agrees** before touching its label, so a mislabelled kind cannot be silently renamed into the wrong thing.

**Nothing consumes the label strings.** `objectCatalog.ts` keys off the model name `o0c_trebox`, and `shopData.ts`'s `meseta` is a currency. The stage editor's Authored tab renders `k`, so it simply reads correctly now.

The data is rewritten with the importer's exact serialisation (`indent=1, ensure_ascii=False`) so a real regeneration against psz-re is a **no-op diff** — verified by the diff being 755 label lines plus one em dash a previous hand-patch had escaped.

The module docstring is updated alongside: it still called trebox *"psz-re's largest single unknown"*, and still said nothing in the file reaches the game, which stopped being true when #616 started consuming the enemy slots.

## Testing

web **616 passed**, godot **2657 passed, 0 failed**, spec builds.

No autopilot run: this changes two display labels in a reference file the game does not read. The enemy slots in the same file are consumed, but they are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)