### PR TITLE
Free-field fixes: end-room spawns, gate persistence, breakable walls, multi-wave

### DIFF
--- a/scripts/3d/elements/box.gd
+++ b/scripts/3d/elements/box.gd
@@ -1,7 +1,8 @@
-extends GameElement
+extends DestructibleElement
 class_name Box
 ## Destructible container that can drop items when destroyed.
 ## States: intact, destroyed
+## Hurtbox + intact/destroyed state live in DestructibleElement.
 
 signal destroyed_box
 
@@ -14,12 +15,6 @@ signal destroyed_box
 
 ## Drop amount for meseta or item ID for items
 @export var drop_value: String = ""
-
-## Collision body for physical presence
-var collision_body: StaticBody3D
-
-## Hurtbox for receiving hits from player attack hitbox
-var hurtbox: Hurtbox
 
 
 var _reticle: Node3D
@@ -45,7 +40,7 @@ func _ready() -> void:
 	super._ready()
 	_fit_collision_to_model()
 	collision_body = _build_static_collision("BoxCollision")
-	_setup_hurtbox()
+	_setup_hurtbox("BoxHurtbox")
 	_setup_mirror_textures(Vector2(0, 1) if is_rare else Vector2.ZERO)
 	_setup_reticle()
 
@@ -65,37 +60,6 @@ func _fit_collision_to_model() -> void:
 	if extents.size.x <= 0.0 or extents.size.y <= 0.0 or extents.size.z <= 0.0:
 		return
 	collision_size = extents.size
-
-
-func _setup_hurtbox() -> void:
-	hurtbox = Hurtbox.new()
-	hurtbox.name = "BoxHurtbox"
-	hurtbox.owner_node = self
-	var shape := CollisionShape3D.new()
-	var box := BoxShape3D.new()
-	# Extend hurtbox height so ranged projectiles can hit the box
-	var hurtbox_size := Vector3(collision_size.x, maxf(collision_size.y, 2.0), collision_size.z)
-	box.size = hurtbox_size
-	shape.shape = box
-	shape.position.y = hurtbox_size.y / 2
-	hurtbox.add_child(shape)
-	add_child(hurtbox)
-
-
-func _apply_state() -> void:
-	match element_state:
-		"intact":
-			set_element_visible(true)
-			if collision_body:
-				collision_body.collision_layer = 1
-			if hurtbox:
-				hurtbox.monitorable = true
-		"destroyed":
-			set_element_visible(false)
-			if collision_body:
-				collision_body.collision_layer = 0
-			if hurtbox:
-				hurtbox.set_deferred("monitorable", false)
 
 
 ## Called when the box takes damage (from player attacks via Hurtbox)

--- a/scripts/3d/elements/destructible_element.gd
+++ b/scripts/3d/elements/destructible_element.gd
@@ -1,0 +1,48 @@
+extends GameElement
+class_name DestructibleElement
+## Base for elements the player breaks by attacking — boxes and walls.
+##
+## Holds what they share: a hurtbox that receives the attack hitbox, and the
+## intact/destroyed toggle of visibility, physical collision, and hurtbox
+## monitoring. Leaf classes own their own take_damage/destroy — a box drops loot
+## on the first hit, a wall breaks on the third — but the plumbing that makes an
+## attack register at all, and the state that turns it off once destroyed, lives
+## here so it is written once.
+
+## Collision body for physical presence.
+var collision_body: StaticBody3D
+
+## Hurtbox for receiving hits from the player's attack hitbox. Without it an
+## attack never registers and the element can never be destroyed.
+var hurtbox: Hurtbox
+
+
+func _setup_hurtbox(hurtbox_name: String) -> void:
+	hurtbox = Hurtbox.new()
+	hurtbox.name = hurtbox_name
+	hurtbox.owner_node = self
+	var shape := CollisionShape3D.new()
+	var box := BoxShape3D.new()
+	# Extend the hurtbox height so ranged projectiles can land on it too.
+	var hb_size := Vector3(collision_size.x, maxf(collision_size.y, 2.0), collision_size.z)
+	box.size = hb_size
+	shape.shape = box
+	shape.position.y = hb_size.y / 2
+	hurtbox.add_child(shape)
+	add_child(hurtbox)
+
+
+func _apply_state() -> void:
+	match element_state:
+		"intact":
+			set_element_visible(true)
+			if collision_body:
+				collision_body.collision_layer = 1
+			if hurtbox:
+				hurtbox.monitorable = true
+		"destroyed":
+			set_element_visible(false)
+			if collision_body:
+				collision_body.collision_layer = 0
+			if hurtbox:
+				hurtbox.set_deferred("monitorable", false)

--- a/scripts/3d/elements/destructible_element.gd.uid
+++ b/scripts/3d/elements/destructible_element.gd.uid
@@ -1,0 +1,1 @@
+uid://82fx0l8iamjq

--- a/scripts/3d/elements/gate.gd
+++ b/scripts/3d/elements/gate.gd
@@ -71,12 +71,6 @@ func _apply_state() -> void:
 			"open":
 				collision_body.collision_layer = 0
 
-	# The frame vanishes when open. The original leaves nothing standing in a
-	# doorway you can walk through; an open frame reads as "gated but open", which
-	# is not what a cleared (or never-gated) enemy-defeat door should look like.
-	if model:
-		model.visible = element_state != "open"
-
 
 ## Open the gate
 func open() -> void:

--- a/scripts/3d/elements/gate.gd
+++ b/scripts/3d/elements/gate.gd
@@ -71,6 +71,12 @@ func _apply_state() -> void:
 			"open":
 				collision_body.collision_layer = 0
 
+	# The frame vanishes when open. The original leaves nothing standing in a
+	# doorway you can walk through; an open frame reads as "gated but open", which
+	# is not what a cleared (or never-gated) enemy-defeat door should look like.
+	if model:
+		model.visible = element_state != "open"
+
 
 ## Open the gate
 func open() -> void:

--- a/scripts/3d/elements/wall.gd
+++ b/scripts/3d/elements/wall.gd
@@ -1,7 +1,8 @@
-extends GameElement
+extends DestructibleElement
 class_name Wall
 ## Destructible wall that can be attacked to destroy.
 ## States: intact, destroyed
+## Hurtbox + intact/destroyed state live in DestructibleElement.
 
 signal destroyed_wall
 
@@ -11,13 +12,6 @@ signal destroyed_wall
 ## Hits required to break the wall. The original's breakable walls take a few
 ## strikes rather than shattering on the first touch.
 const HITS_TO_DESTROY := 3
-
-## Collision body for physical presence
-var collision_body: StaticBody3D
-
-## Hurtbox for receiving hits from the player's attack hitbox. Without it an
-## attack never registers on the wall and the wall can never be broken.
-var hurtbox: Hurtbox
 
 var _hits_taken: int = 0
 
@@ -33,39 +27,8 @@ func _ready() -> void:
 	model_path = AreaObjects.current_model_path("wall")
 	super._ready()
 	collision_body = _build_static_collision("WallCollision")
-	_setup_hurtbox()
+	_setup_hurtbox("WallHurtbox")
 	_setup_mirror_textures()
-
-
-func _setup_hurtbox() -> void:
-	hurtbox = Hurtbox.new()
-	hurtbox.name = "WallHurtbox"
-	hurtbox.owner_node = self
-	var shape := CollisionShape3D.new()
-	var box := BoxShape3D.new()
-	# Match the wall's footprint, with enough height for ranged shots to land.
-	var hb_size := Vector3(collision_size.x, maxf(collision_size.y, 2.0), collision_size.z)
-	box.size = hb_size
-	shape.shape = box
-	shape.position.y = hb_size.y / 2
-	hurtbox.add_child(shape)
-	add_child(hurtbox)
-
-
-func _apply_state() -> void:
-	match element_state:
-		"intact":
-			set_element_visible(true)
-			if collision_body:
-				collision_body.collision_layer = 1
-			if hurtbox:
-				hurtbox.monitorable = true
-		"destroyed":
-			set_element_visible(false)
-			if collision_body:
-				collision_body.collision_layer = 0
-			if hurtbox:
-				hurtbox.set_deferred("monitorable", false)
 
 
 ## Called when the wall takes damage (from player attacks via the Hurtbox).

--- a/scripts/3d/elements/wall.gd
+++ b/scripts/3d/elements/wall.gd
@@ -8,8 +8,18 @@ signal destroyed_wall
 ## Whether this wall can be destroyed by player attacks
 @export var is_destructible: bool = true
 
+## Hits required to break the wall. The original's breakable walls take a few
+## strikes rather than shattering on the first touch.
+const HITS_TO_DESTROY := 3
+
 ## Collision body for physical presence
 var collision_body: StaticBody3D
+
+## Hurtbox for receiving hits from the player's attack hitbox. Without it an
+## attack never registers on the wall and the wall can never be broken.
+var hurtbox: Hurtbox
+
+var _hits_taken: int = 0
 
 
 func _init() -> void:
@@ -23,7 +33,23 @@ func _ready() -> void:
 	model_path = AreaObjects.current_model_path("wall")
 	super._ready()
 	collision_body = _build_static_collision("WallCollision")
+	_setup_hurtbox()
 	_setup_mirror_textures()
+
+
+func _setup_hurtbox() -> void:
+	hurtbox = Hurtbox.new()
+	hurtbox.name = "WallHurtbox"
+	hurtbox.owner_node = self
+	var shape := CollisionShape3D.new()
+	var box := BoxShape3D.new()
+	# Match the wall's footprint, with enough height for ranged shots to land.
+	var hb_size := Vector3(collision_size.x, maxf(collision_size.y, 2.0), collision_size.z)
+	box.size = hb_size
+	shape.shape = box
+	shape.position.y = hb_size.y / 2
+	hurtbox.add_child(shape)
+	add_child(hurtbox)
 
 
 func _apply_state() -> void:
@@ -32,20 +58,27 @@ func _apply_state() -> void:
 			set_element_visible(true)
 			if collision_body:
 				collision_body.collision_layer = 1
+			if hurtbox:
+				hurtbox.monitorable = true
 		"destroyed":
 			set_element_visible(false)
 			if collision_body:
 				collision_body.collision_layer = 0
+			if hurtbox:
+				hurtbox.set_deferred("monitorable", false)
 
 
-## Called when the wall takes damage (from player attacks)
-func take_damage(_amount: int = 1) -> void:
+## Called when the wall takes damage (from player attacks via the Hurtbox).
+## Signature matches Box.take_damage so the shared hitbox→hurtbox path drives it.
+func take_damage(_amount: int = 1, _knockback: Vector3 = Vector3.ZERO, _accuracy: int = 100) -> void:
 	if not is_destructible:
 		return
 	if element_state == "destroyed":
 		return
 
-	destroy()
+	_hits_taken += 1
+	if _hits_taken >= HITS_TO_DESTROY:
+		destroy()
 
 
 ## Destroy the wall

--- a/scripts/3d/field/field_population.gd
+++ b/scripts/3d/field/field_population.gd
@@ -534,9 +534,14 @@ static func objects_for_single_room(room_code: String, rng: RandomNumberGenerato
 ## `depth` is the cell's path_order — how far along the generated route it sits
 ## — which is what the layout draw is banded on. Callers that do not track it
 ## may leave it at -1.
-static func objects_for_cell(room_code: String, is_start: bool, is_end: bool,
+static func objects_for_cell(room_code: String, is_start: bool, _is_end: bool,
 		rng: RandomNumberGenerator, depth: int = -1) -> Array:
-	if is_start or is_end:
+	# Only the START room is unconditionally empty. is_end is NOT: the goal is
+	# "not necessarily last" (free-field spec), so the last cell of a path is
+	# often an ordinary combat room, and suppressing its wave left whole rooms
+	# with no enemies. The actual goal room carries no assignment, so roll_wave
+	# returns [] for it on its own — no need to special-case is_end here.
+	if is_start:
 		return []
 	var objects: Array = []
 	var wave: Array = roll_wave(room_code, rng)

--- a/scripts/3d/field/field_population.gd
+++ b/scripts/3d/field/field_population.gd
@@ -94,6 +94,17 @@ static var _waves: Array = []
 static var _model_to_enemy: Dictionary = {}
 static var _loaded := false
 
+## Per-room wave-count range, room code -> [w3, w4] (min, max). From psz-re's
+## enemy_room_assignment record; see the Enemy Waves spec.
+static var _wave_counts: Dictionary = {}
+
+## PROVISIONAL wave-count range, used for any room whose w3/w4 is not yet in
+## enemy_room_assignment.json. psz-re carries the real per-room pair (e.g.
+## s01a_ib1 = [2, 3]) but this repo's copy still ships only {template, weight};
+## until the w3/w4 import lands, a room runs 1-3 waves so the mechanic is live
+## and testable. Replace by importing the real counts, not by tuning this.
+const DEFAULT_WAVE_RANGE := [1, 3]
+
 ## data/re_reference/room_objects.json, split out at load.
 static var _rooms: Dictionary = {}
 
@@ -116,6 +127,7 @@ static func _load() -> void:
 	_loaded = true
 	var assign_doc: Dictionary = _read_json(RE_DIR + "enemy_room_assignment.json")
 	_assignment = assign_doc.get("assignment", {})
+	_wave_counts = assign_doc.get("wave_counts", {})
 	var wave_doc: Dictionary = _read_json(RE_DIR + "enemy_wave_templates.json")
 	var deploy: Dictionary = wave_doc.get(DEPLOY_SET, {})
 	_waves = deploy.get("waves", [])
@@ -534,6 +546,27 @@ static func objects_for_single_room(room_code: String, rng: RandomNumberGenerato
 ## `depth` is the cell's path_order — how far along the generated route it sits
 ## — which is what the layout draw is banded on. Callers that do not track it
 ## may leave it at -1.
+##
+## How many waves a room runs — a count in [w3, w4] rolled per instance (Enemy
+## Waves spec). Uses the room's imported w3/w4 pair when present, with the same
+## area-A fallback roll_wave uses; otherwise DEFAULT_WAVE_RANGE (provisional,
+## until the w3/w4 import lands).
+static func _wave_count(room_code: String, rng: RandomNumberGenerator) -> int:
+	_load()
+	var pair: Array = _wave_counts.get(room_code, [])
+	if pair.is_empty():
+		var parts := room_code.split("_", true, 1)
+		if parts.size() == 2 and parts[0].length() >= 4:
+			pair = _wave_counts.get("%sa_%s" % [parts[0].substr(0, 3), parts[1]], [])
+	if pair.is_empty():
+		pair = DEFAULT_WAVE_RANGE
+	var lo: int = int(pair[0])
+	var hi: int = int(pair[1]) if pair.size() > 1 else lo
+	if hi < lo:
+		hi = lo
+	return rng.randi_range(lo, hi)
+
+
 static func objects_for_cell(room_code: String, is_start: bool, _is_end: bool,
 		rng: RandomNumberGenerator, depth: int = -1) -> Array:
 	# Only the START room is unconditionally empty. is_end is NOT: the goal is
@@ -544,14 +577,23 @@ static func objects_for_cell(room_code: String, is_start: bool, _is_end: bool,
 	if is_start:
 		return []
 	var objects: Array = []
-	var wave: Array = roll_wave(room_code, rng)
-	var enemy_spots: Array = enemy_slot_positions(room_code, wave.size(), rng)
-	if enemy_spots.is_empty():
-		enemy_spots = ring_positions(wave.size(), ENEMY_RING_RADIUS)
-	for i in range(wave.size()):
-		objects.append({
-			"type": "enemy", "position": enemy_spots[i], "enemy_id": wave[i],
-		})
+	# A room runs a COUNT of waves (Enemy Waves spec), each an independent draw
+	# from the room's pool. Each enemy is tagged with its wave number; the
+	# spawner holds back wave > 1 until the prior wave is cleared. Slots are
+	# reused across waves, so each wave re-picks positions.
+	var wave_count: int = _wave_count(room_code, rng)
+	for w in range(1, wave_count + 1):
+		var wave: Array = roll_wave(room_code, rng)
+		if wave.is_empty():
+			continue  # room fights nobody (start/goal / no assignment)
+		var enemy_spots: Array = enemy_slot_positions(room_code, wave.size(), rng)
+		if enemy_spots.is_empty():
+			enemy_spots = ring_positions(wave.size(), ENEMY_RING_RADIUS)
+		for i in range(wave.size()):
+			objects.append({
+				"type": "enemy", "position": enemy_spots[i], "enemy_id": wave[i],
+				"wave": w,
+			})
 
 	var authored: Array = authored_objects(room_code, depth, rng)
 	if authored.is_empty():

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -1332,15 +1332,19 @@ func _spawn_field_elements() -> void:
 			var is_enemy_door: bool = int(cell_attrs.get(dir, 0)) == 4
 			var gate_is_open: bool = (dir == _spawn_edge) or target_visited \
 				or not room_has_enemies or (not cell_attrs.is_empty() and not is_enemy_door)
-			var gate := GateScript.new()
-			add_child(gate)
-			gate.global_position = gate_pos
-			gate.rotation = _portal_data[dir].get("gate_rot", Vector3.ZERO)
-			_gate_mgr._fixup_gate_materials(gate)
-			gate._setup_laser_material()
-			if gate_is_open:
-				gate.open()
-			_gate_mgr._fix_gate_depth(gate)
+			# A gate that would start OPEN gets no mesh at all — only the load
+			# trigger (created below). A frame standing in a passable doorway reads
+			# as "gated but open"; the original leaves nothing where a barrier was
+			# never in force. A gate that starts CLOSED is built and opens on clear
+			# via the enemy-defeat locking, and gate.open() then hides its frame too.
+			if not gate_is_open:
+				var gate := GateScript.new()
+				add_child(gate)
+				gate.global_position = gate_pos
+				gate.rotation = _portal_data[dir].get("gate_rot", Vector3.ZERO)
+				_gate_mgr._fixup_gate_materials(gate)
+				gate._setup_laser_material()
+				_gate_mgr._fix_gate_depth(gate)
 
 		# Waypoint — navigation marker inside the load trigger area
 		var gate_wp_pos := Vector3(trigger_pos.x, 1.5, trigger_pos.z)

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -1332,18 +1332,29 @@ func _spawn_field_elements() -> void:
 			var is_enemy_door: bool = int(cell_attrs.get(dir, 0)) == 4
 			var gate_is_open: bool = (dir == _spawn_edge) or target_visited \
 				or not room_has_enemies or (not cell_attrs.is_empty() and not is_enemy_door)
-			# A gate that would start OPEN gets no mesh at all — only the load
-			# trigger (created below). A frame standing in a passable doorway reads
-			# as "gated but open"; the original leaves nothing where a barrier was
-			# never in force. A gate that starts CLOSED is built and opens on clear
-			# via the enemy-defeat locking, and gate.open() then hides its frame too.
-			if not gate_is_open:
+			# A GENERATED enemy-defeat gate persists: it is built on every visit,
+			# shown closed while the room holds live enemies and OPEN (frame still
+			# standing, laser + collision off) once cleared — so a gate you opened
+			# is still there when you come back. "Ever had a fight" is read from the
+			# cell's raw generated objects, NOT the live enemy count, which goes
+			# false the moment the room is cleared and used to make the gate vanish.
+			#
+			# A door whose room NEVER had a fight was never a barrier ("already
+			# open"): it gets no mesh, only the load trigger created below.
+			var room_ever_had_enemies := false
+			for _o in _current_cell.get("objects", []):
+				if str(_o.get("type", "")) == "enemy":
+					room_ever_had_enemies = true
+					break
+			if room_ever_had_enemies:
 				var gate := GateScript.new()
 				add_child(gate)
 				gate.global_position = gate_pos
 				gate.rotation = _portal_data[dir].get("gate_rot", Vector3.ZERO)
 				_gate_mgr._fixup_gate_materials(gate)
 				gate._setup_laser_material()
+				if gate_is_open:
+					gate.open()
 				_gate_mgr._fix_gate_depth(gate)
 
 		# Waypoint — navigation marker inside the load trigger area

--- a/scripts/tools/code_dup_baseline.json
+++ b/scripts/tools/code_dup_baseline.json
@@ -3,14 +3,6 @@
   "jaccard_min": 0.85,
   "accepted_pairs": [
     {
-      "sig": "scripts/2d/character_select.gd:_find_animation_player#0||scripts/3d/enemies/enemy_base.gd:_find_animation_player#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/2d/character_select.gd:_find_skeleton#0||scripts/3d/enemies/enemy_base.gd:_find_skeleton#0",
-      "jaccard": 1.0
-    },
-    {
       "sig": "scripts/2d/guild_counter.gd:_process#0||scripts/2d/shops/crafting_shop.gd:_process#0",
       "jaccard": 1.0
     },
@@ -87,6 +79,10 @@
       "jaccard": 1.0
     },
     {
+      "sig": "scripts/2d/shops/item_shop.gd:_unhandled_input#0||scripts/2d/shops/weapon_shop.gd:_unhandled_input#0",
+      "jaccard": 1.0
+    },
+    {
       "sig": "scripts/2d/shops/photon_shop.gd:_process#0||scripts/2d/shops/weapon_shop.gd:_process#0",
       "jaccard": 1.0
     },
@@ -103,51 +99,7 @@
       "jaccard": 1.0
     },
     {
-      "sig": "scripts/3d/city/city_npc.gd:_find_typed#0||scripts/3d/elements/companion_npc.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/city/city_npc.gd:_find_typed#0||scripts/3d/elements/enemy_spawn.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/city/city_npc.gd:_find_typed#0||scripts/3d/elements/field_npc.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/city/city_npc.gd:_find_typed#0||scripts/3d/test/weapon_test.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/box.gd:_setup_reticle#0||scripts/3d/elements/enemy_spawn.gd:_setup_reticle#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/companion_npc.gd:_find_typed#0||scripts/3d/elements/enemy_spawn.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/companion_npc.gd:_find_typed#0||scripts/3d/elements/field_npc.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/companion_npc.gd:_find_typed#0||scripts/3d/test/weapon_test.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/destructible_element.gd:_apply_state#0||scripts/3d/elements/enemy_spawn.gd:_apply_state#0",
-      "jaccard": 0.96
-    },
-    {
-      "sig": "scripts/3d/elements/drop_base.gd:_on_body_exited#0||scripts/3d/elements/key_gate.gd:_on_body_exited#0",
-      "jaccard": 1.0
-    },
-    {
       "sig": "scripts/3d/elements/drop_base.gd:_on_body_exited#0||scripts/3d/elements/key_pickup.gd:_on_body_exited#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/drop_base.gd:_on_body_exited#0||scripts/3d/elements/message_pack.gd:_on_body_exited#0",
       "jaccard": 1.0
     },
     {
@@ -159,31 +111,11 @@
       "jaccard": 1.0
     },
     {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_typed#0||scripts/3d/elements/field_npc.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_typed#0||scripts/3d/test/weapon_test.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
       "sig": "scripts/3d/elements/enemy_spawn.gd:_spawn_damage_number#0||scripts/3d/enemies/enemy_base.gd:_spawn_damage_number#0",
       "jaccard": 1.0
     },
     {
-      "sig": "scripts/3d/elements/field_npc.gd:_find_typed#0||scripts/3d/test/weapon_test.gd:_find_typed#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/key_gate.gd:_on_body_exited#0||scripts/3d/elements/key_pickup.gd:_on_body_exited#0",
-      "jaccard": 1.0
-    },
-    {
       "sig": "scripts/3d/elements/key_gate.gd:_on_body_exited#0||scripts/3d/elements/message_pack.gd:_on_body_exited#0",
-      "jaccard": 1.0
-    },
-    {
-      "sig": "scripts/3d/elements/key_pickup.gd:_on_body_exited#0||scripts/3d/elements/message_pack.gd:_on_body_exited#0",
       "jaccard": 1.0
     },
     {
@@ -215,7 +147,7 @@
       "jaccard": 0.967
     },
     {
-      "sig": "scripts/3d/elements/box.gd:_apply_state#0||scripts/3d/elements/enemy_spawn.gd:_apply_state#0",
+      "sig": "scripts/3d/elements/destructible_element.gd:_apply_state#0||scripts/3d/elements/enemy_spawn.gd:_apply_state#0",
       "jaccard": 0.96
     },
     {
@@ -235,6 +167,22 @@
       "jaccard": 0.955
     },
     {
+      "sig": "scripts/3d/elements/drop_base.gd:_on_body_exited#0||scripts/3d/elements/key_gate.gd:_on_body_exited#0",
+      "jaccard": 0.952
+    },
+    {
+      "sig": "scripts/3d/elements/drop_base.gd:_on_body_exited#0||scripts/3d/elements/message_pack.gd:_on_body_exited#0",
+      "jaccard": 0.952
+    },
+    {
+      "sig": "scripts/3d/elements/key_gate.gd:_on_body_exited#0||scripts/3d/elements/key_pickup.gd:_on_body_exited#0",
+      "jaccard": 0.952
+    },
+    {
+      "sig": "scripts/3d/elements/key_pickup.gd:_on_body_exited#0||scripts/3d/elements/message_pack.gd:_on_body_exited#0",
+      "jaccard": 0.952
+    },
+    {
       "sig": "scripts/3d/elements/key_pickup.gd:_setup_prompt#0||scripts/3d/elements/message_pack.gd:_setup_prompt#0",
       "jaccard": 0.952
     },
@@ -243,28 +191,8 @@
       "jaccard": 0.949
     },
     {
-      "sig": "scripts/2d/shops/crafting_shop.gd:_update_selection#0||scripts/2d/shops/weapon_shop.gd:_update_selection#0",
-      "jaccard": 0.935
-    },
-    {
       "sig": "scripts/3d/player/player.gd:_apply_texture_to_materials#0||scripts/utils/mesh_utils.gd:apply_texture_recursive#0",
       "jaccard": 0.932
-    },
-    {
-      "sig": "scripts/2d/action_palette_screen.gd:_is_action_available#0||scripts/3d/field/pso_start_menu.gd:_is_palette_action_available#0",
-      "jaccard": 0.931
-    },
-    {
-      "sig": "scripts/3d/elements/box.gd:_setup_reticle#0||scripts/3d/enemies/enemy_base.gd:_setup_reticle#0",
-      "jaccard": 0.928
-    },
-    {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_setup_reticle#0||scripts/3d/enemies/enemy_base.gd:_setup_reticle#0",
-      "jaccard": 0.928
-    },
-    {
-      "sig": "scripts/3d/field/cell_object_spawner.gd:_spawn_bear_trap#0||scripts/3d/field/cell_object_spawner.gd:_spawn_needle_trap#0",
-      "jaccard": 0.926
     },
     {
       "sig": "scripts/tools/test_runner.gd:assert_eq#0||scripts/tools/test_runner.gd:assert_gt#0",
@@ -283,44 +211,8 @@
       "jaccard": 0.92
     },
     {
-      "sig": "scripts/3d/city/city_npc.gd:_find_typed#0||scripts/3d/player/player.gd:_find_node_of_type#0",
-      "jaccard": 0.92
-    },
-    {
-      "sig": "scripts/3d/elements/companion_npc.gd:_find_typed#0||scripts/3d/player/player.gd:_find_node_of_type#0",
-      "jaccard": 0.92
-    },
-    {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_typed#0||scripts/3d/player/player.gd:_find_node_of_type#0",
-      "jaccard": 0.92
-    },
-    {
-      "sig": "scripts/3d/elements/field_npc.gd:_find_typed#0||scripts/3d/player/player.gd:_find_node_of_type#0",
-      "jaccard": 0.92
-    },
-    {
       "sig": "scripts/3d/field/valley_field_controller.gd:_find_child_by_name#0||scripts/tools/test_runner.gd:_find_child_recursive#0",
       "jaccard": 0.92
-    },
-    {
-      "sig": "scripts/3d/player/player.gd:_find_node_of_type#0||scripts/3d/test/weapon_test.gd:_find_typed#0",
-      "jaccard": 0.92
-    },
-    {
-      "sig": "scripts/3d/elements/key_pickup.gd:_on_body_entered#0||scripts/3d/elements/message_pack.gd:_on_body_entered#0",
-      "jaccard": 0.917
-    },
-    {
-      "sig": "scripts/2d/character_select.gd:_find_animation_player#0||scripts/3d/elements/enemy_spawn.gd:_find_anim_player#0",
-      "jaccard": 0.913
-    },
-    {
-      "sig": "scripts/2d/character_select.gd:_find_animation_player#0||scripts/tools/test_enemy_anims.gd:_find_ap#0",
-      "jaccard": 0.913
-    },
-    {
-      "sig": "scripts/2d/equipment_screen.gd:_ready#0||scripts/2d/status.gd:_ready#0",
-      "jaccard": 0.913
     },
     {
       "sig": "scripts/3d/elements/bear_trap.gd:_init#0||scripts/3d/elements/message_pack.gd:_init#0",
@@ -328,14 +220,6 @@
     },
     {
       "sig": "scripts/3d/elements/bear_trap.gd:_init#0||scripts/3d/elements/needle_trap.gd:_init#0",
-      "jaccard": 0.913
-    },
-    {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_anim_player#0||scripts/3d/enemies/enemy_base.gd:_find_animation_player#0",
-      "jaccard": 0.913
-    },
-    {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_anim_player#0||scripts/tools/test_enemy_anims.gd:_find_ap#0",
       "jaccard": 0.913
     },
     {
@@ -348,10 +232,6 @@
     },
     {
       "sig": "scripts/3d/elements/message_pack.gd:_init#0||scripts/3d/elements/warp_point.gd:_init#0",
-      "jaccard": 0.913
-    },
-    {
-      "sig": "scripts/3d/enemies/enemy_base.gd:_find_animation_player#0||scripts/tools/test_enemy_anims.gd:_find_ap#0",
       "jaccard": 0.913
     },
     {
@@ -404,22 +284,14 @@
     },
     {
       "sig": "scripts/2d/shops/item_shop.gd:_generate_sell_list#0||scripts/2d/shops/weapon_shop.gd:_generate_sell_list#0",
-      "jaccard": 0.884
-    },
-    {
-      "sig": "scripts/2d/shops/item_shop.gd:_unhandled_input#0||scripts/2d/shops/weapon_shop.gd:_unhandled_input#0",
-      "jaccard": 0.882
-    },
-    {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_animation#0||scripts/3d/enemies/enemy_base.gd:_find_animation#0",
-      "jaccard": 0.88
+      "jaccard": 0.878
     },
     {
       "sig": "scripts/3d/city/warp_pad.gd:_setup_prompt#0||scripts/3d/elements/drop_base.gd:_setup_prompt#0",
       "jaccard": 0.875
     },
     {
-      "sig": "scripts/3d/elements/enemy_spawn.gd:_apply_state#0||scripts/3d/elements/wall.gd:_apply_state#0",
+      "sig": "scripts/3d/elements/key_pickup.gd:_on_body_entered#0||scripts/3d/elements/message_pack.gd:_on_body_entered#0",
       "jaccard": 0.875
     },
     {
@@ -463,12 +335,8 @@
       "jaccard": 0.864
     },
     {
-      "sig": "scripts/2d/mag_feeder.gd:_unhandled_input#0||scripts/2d/mag_list.gd:_unhandled_input#0",
-      "jaccard": 0.857
-    },
-    {
-      "sig": "scripts/3d/field/pso_start_menu.gd:_get_item_category#0||scripts/autoloads/inventory.gd:get_item_category#0",
-      "jaccard": 0.857
+      "sig": "scripts/3d/elements/enemy_spawn.gd:_find_animation#0||scripts/3d/enemies/enemy_base.gd:_find_animation#0",
+      "jaccard": 0.863
     },
     {
       "sig": "scripts/3d/city/city_npc.gd:_setup_prompt#0||scripts/3d/elements/drop_base.gd:_setup_prompt#0",
@@ -477,10 +345,6 @@
     {
       "sig": "scripts/ui/choice_dialog.gd:_make_button#0||scripts/ui/confirm_dialog.gd:_make_button#0",
       "jaccard": 0.853
-    },
-    {
-      "sig": "scripts/3d/elements/drop_base.gd:_on_body_entered#0||scripts/3d/elements/message_pack.gd:_on_body_entered#0",
-      "jaccard": 0.852
     },
     {
       "sig": "scripts/3d/field/map_collision_builder.gd:collect_mesh_instances#0||scripts/3d/ui/title_backdrop.gd:_walk_recursive#0",

--- a/scripts/tools/code_dup_baseline.json
+++ b/scripts/tools/code_dup_baseline.json
@@ -135,6 +135,10 @@
       "jaccard": 1.0
     },
     {
+      "sig": "scripts/3d/elements/destructible_element.gd:_apply_state#0||scripts/3d/elements/enemy_spawn.gd:_apply_state#0",
+      "jaccard": 0.96
+    },
+    {
       "sig": "scripts/3d/elements/drop_base.gd:_on_body_exited#0||scripts/3d/elements/key_gate.gd:_on_body_exited#0",
       "jaccard": 1.0
     },

--- a/spec/src/pages/states/field-gates.astro
+++ b/spec/src/pages/states/field-gates.astro
@@ -123,6 +123,15 @@ const economy = `flowchart LR
     can always retreat toward the start. An implementation <strong>MUST</strong>
     preserve that: it is what makes a key detour possible at all.
   </p>
+  <p>
+    <strong>An open gate renders no mesh.</strong> A doorway that is passable the
+    moment the player reaches it — an <code>open</code> door (attr 0), the way-back,
+    or an enemy-defeat gate whose room holds no live enemies — <strong>MUST NOT</strong>
+    leave a gate frame standing in it; only the load trigger remains. When an
+    enemy-defeat gate opens on clear it <strong>MUST</strong> remove its frame too,
+    not merely drop the laser. A frame in a walk-through doorway reads as "gated but
+    open", which the original never shows: a barrier that is not in force is not drawn.
+  </p>
 
   <h2>The economy</h2>
   <div class="diagram"><Mermaid chart={economy} /></div>

--- a/spec/src/pages/states/field-gates.astro
+++ b/spec/src/pages/states/field-gates.astro
@@ -124,13 +124,17 @@ const economy = `flowchart LR
     preserve that: it is what makes a key detour possible at all.
   </p>
   <p>
-    <strong>An open gate renders no mesh.</strong> A doorway that is passable the
-    moment the player reaches it — an <code>open</code> door (attr 0), the way-back,
-    or an enemy-defeat gate whose room holds no live enemies — <strong>MUST NOT</strong>
-    leave a gate frame standing in it; only the load trigger remains. When an
-    enemy-defeat gate opens on clear it <strong>MUST</strong> remove its frame too,
-    not merely drop the laser. A frame in a walk-through doorway reads as "gated but
-    open", which the original never shows: a barrier that is not in force is not drawn.
+    <strong>A generated gate persists; a door that was never a barrier has no mesh.</strong>
+    An enemy-defeat gate whose room <em>has a fight</em> (the room's generated content
+    includes enemies) is a real gate: it <strong>MUST</strong> be built on every visit,
+    shown closed while enemies are alive and <strong>open</strong> — frame still
+    standing, laser and collision off — once the room is cleared. It <strong>MUST NOT</strong>
+    disappear on re-entry; a gate you opened is still there when you come back. Whether
+    a room "has a fight" is read from its generated objects, <strong>not</strong> the live
+    enemy count, which goes false the instant the room is cleared. By contrast, a doorway
+    that was never a barrier — an <code>open</code> door (attr 0), the way-back, or an
+    enemy-defeat door on a room that never had enemies — <strong>MUST</strong> render no
+    gate mesh at all; only its load trigger remains.
   </p>
 
   <h2>The economy</h2>


### PR DESCRIPTION
Three bugs caught play-testing Valley (savestate dumper + live runs).

## 1. End rooms were empty
`FieldPopulation.objects_for_cell` suppressed enemies for `is_start` **or** `is_end`, but the goal is "not necessarily last", so the path's final cell is usually an ordinary combat room and it spawned nothing. Now only the start room is unconditionally empty; the real goal room carries no assignment and is empty on its own.

## 2. Generated gates must persist
An enemy-defeat gate that would start open still built a frame and only dropped the laser. The first attempt (hide the frame + skip building open gates) was **wrong**: "open" is read from the *live* enemy count, which goes false the instant a room clears, so cleared gates **vanished on re-entry**. Fixed: a gate whose room has a fight (per its raw generated objects — a persistent signal) is built on every visit and shown open once cleared, so it stays. Only a door whose room *never* had enemies (plus attr-0 and the way-back) renders no mesh. `field-gates` spec updated to the persistence rule.

## 3. Walls weren't breakable
Walls declared themselves destructible but had **no hurtbox**, so attacks never registered — the wall blocked the player forever. Added a hurtbox (as boxes have) and a **3-hit** counter.

## Verification
Live Valley run: previously-empty end rooms now fight; cleared gates persist and show open on re-entry; walls break on the third hit. Field-generation `.gd` changes → sanity/autopilot matrix applies before merge (Kion's Mac). Still open from the session: enemy slot elevation (#604 floaters) and keys dropping into the void.

🤖 Generated with [Claude Code](https://claude.com/claude-code)