### PR TITLE
Three-triangle reticle, centered on the target

### DIFF
--- a/scripts/3d/elements/box.gd
+++ b/scripts/3d/elements/box.gd
@@ -17,7 +17,6 @@ signal destroyed_box
 @export var drop_value: String = ""
 
 
-var _reticle: Node3D
 var is_alive: bool = true
 
 
@@ -42,7 +41,7 @@ func _ready() -> void:
 	collision_body = _build_static_collision("BoxCollision")
 	_setup_hurtbox("BoxHurtbox")
 	_setup_mirror_textures(Vector2(0, 1) if is_rare else Vector2.ZERO)
-	_setup_reticle()
+	_setup_reticle(collision_size.y + 0.5)
 
 
 ## Size the collision box from the container the area actually loaded.
@@ -86,21 +85,6 @@ func destroy() -> void:
 		_spawn_drop()
 
 	print("[Box] Destroyed")
-
-
-func _setup_reticle() -> void:
-	_reticle = TargetReticle.build(collision_size.y + 0.5)
-	add_child(_reticle)
-
-
-func show_reticle() -> void:
-	if _reticle:
-		_reticle.visible = true
-
-
-func hide_reticle() -> void:
-	if _reticle:
-		_reticle.visible = false
 
 
 func _spawn_drop() -> void:

--- a/scripts/3d/elements/destructible_element.gd
+++ b/scripts/3d/elements/destructible_element.gd
@@ -16,6 +16,27 @@ var collision_body: StaticBody3D
 ## attack never registers and the element can never be destroyed.
 var hurtbox: Hurtbox
 
+## Lock-on reticle (three triangles around a centre point — see
+## TargetReticle). The player's targeting drives visibility via
+## show/hide_reticle; only the attach height differs per leaf, so the plumbing
+## lives here.
+var _reticle: Node3D
+
+
+func _setup_reticle(y_offset: float) -> void:
+	_reticle = TargetReticle.build(y_offset)
+	add_child(_reticle)
+
+
+func show_reticle() -> void:
+	if _reticle:
+		_reticle.visible = true
+
+
+func hide_reticle() -> void:
+	if _reticle:
+		_reticle.visible = false
+
 
 func _setup_hurtbox(hurtbox_name: String) -> void:
 	hurtbox = Hurtbox.new()

--- a/scripts/3d/elements/enemy_spawn.gd
+++ b/scripts/3d/elements/enemy_spawn.gd
@@ -322,7 +322,8 @@ func _find_animation(short_name: String) -> String:
 
 
 func _setup_reticle() -> void:
-	_reticle = TargetReticle.build(collision_size.y + 0.5)
+	# Body centre, matching EnemyBase — see the note there.
+	_reticle = TargetReticle.build(collision_size.y * 0.5)
 	add_child(_reticle)
 
 

--- a/scripts/3d/elements/target_reticle.gd
+++ b/scripts/3d/elements/target_reticle.gd
@@ -1,85 +1,88 @@
 extends RefCounted
 class_name TargetReticle
-## Shared builder for the lock-on reticle shown above a target. The Sprite3D +
-## triangle texture were duplicated verbatim in enemy_base / enemy_spawn / box
-## (#517); only the vertical offset differed, so callers pass that in.
+## Shared builder for the lock-on reticle. The Sprite3D + single triangle
+## texture were duplicated verbatim in enemy_base / enemy_spawn / box (#517);
+## only the vertical offset differed, so callers pass that in.
 ##
-## The triangle used to be drawn procedurally into an ImageTexture. It is now
-## the game's own model (#577): `ef_com_rockon` plus `ef_com_rockon_s`.
-##
-## Those two are an OUTLINE PAIR, not variants — the geometry says so rather
-## than the naming. `_s` is smaller (x +/-0.073 against +/-0.104), concentric
-## with the larger one, and sits IN FRONT of it (z 0.024 against 0.008). The
-## larger model carries all-black vertex colours; the smaller carries no
-## COLOR_0 at all and so renders white. Black border behind, white fill in
-## front — which is also why loading either one alone looks wrong.
+## The reticle is THREE TRIANGLES AROUND A CENTER POINT — the original's
+## lock-on shape, read off the real game in play: three small triangles spaced
+## 120° apart, each pointing inward at the target's centre. #577 briefly used
+## the pack's ef_com_rockon outline/fill pair, but that pair is a SINGLE
+## triangle and the models are absent from the asset manifests anyway, so the
+## shape is drawn procedurally here. When the effect models land in the pack,
+## compare against ef_com_rockon before replacing this.
 
-const OUTLINE_MODEL := "ef_com_rockon"
-const FILL_MODEL := "ef_com_rockon_s"
+## Texture pixel size for the fallback sprite.
+const FALLBACK_PX := 96
 
-## Fallback triangle size, used only when the models cannot be loaded.
-const FALLBACK_PX := 48
+## Distance from texture centre to a triangle's apex (pointing inward) and to
+## its base, in fractions of the half-size.
+const APEX_RADIUS := 0.16
+const BASE_RADIUS := 0.42
+## Half-width of each triangle's base, as a fraction of the half-size.
+const BASE_HALF_WIDTH := 0.14
 
 
 ## Build the reticle. `y_offset` is the local height above the target's origin
-## (typically collision height + 0.5). Caller add_child()s the result and drives
-## `visible`. Returns a Node3D — it used to be a Sprite3D, and callers that
-## still type it that way will not compile.
+## where the reticle centre sits — over the body centre for a wall, above the
+## head for an enemy. Caller add_child()s the result and drives `visible`.
+## Returns a Node3D — it used to be a Sprite3D, and callers that still type it
+## that way will not compile.
 static func build(y_offset: float) -> Node3D:
 	var root := Node3D.new()
 	root.name = "TargetReticle"
 	root.visible = false
 	root.position = Vector3(0, y_offset, 0)
 
-	# ORIENTATION IS UNRESOLVED. The models are authored pointing UP, while the
-	# sprite they replace pointed DOWN at the target it hangs above.
-	#
-	# Both ways of flipping it fail: BILLBOARD_ENABLED replaces the node basis
-	# with the camera's, so rotating the node moves the offset without turning
-	# the quad, and a negative Y scale reverses the winding so the quad vanishes.
-	# Flipping it properly means flipping the geometry or hand-billboarding.
-	#
-	# Left as authored rather than guessed at — it may well be that the original
-	# pins this BELOW the target, in which case pointing up is already right and
-	# only the attach point is wrong. Worth one look at the real game.
-	# Draw order matters: both quads disable depth testing so they read through
-	# the target, which means the painter's order is all that separates them.
-	var outline := EffectBillboard.load_model(OUTLINE_MODEL, 0)
-	var fill := EffectBillboard.load_model(FILL_MODEL, 1)
-	if outline and fill:
-		root.add_child(outline)
-		root.add_child(fill)
-		return root
-
-	# The models live in the asset pack; if it is missing we still want a
-	# visible reticle rather than an invisible node the player cannot aim with.
-	if outline:
-		outline.queue_free()
-	if fill:
-		fill.queue_free()
-	root.add_child(_fallback_sprite())
-	return root
-
-
-## The pre-#577 procedural triangle, kept as a pack-free fallback.
-static func _fallback_sprite() -> Sprite3D:
 	var reticle := Sprite3D.new()
-	reticle.name = "FallbackTriangle"
+	reticle.name = "ThreeTriangleReticle"
 	reticle.pixel_size = 0.008
 	reticle.billboard = BaseMaterial3D.BILLBOARD_ENABLED
 	reticle.no_depth_test = true
 	reticle.modulate = Color(1.0, 0.15, 0.15, 0.9)
+	reticle.texture = _three_triangle_texture()
+	root.add_child(reticle)
+	return root
 
-	# Filled downward-pointing triangle: top row full width, narrowing to a point.
+
+## Three inward-pointing triangles, 120° apart, around a transparent centre.
+static func _three_triangle_texture() -> ImageTexture:
 	var size := FALLBACK_PX
+	var half := size / 2.0
+	var center := Vector2(half, half)
 	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
 	img.fill(Color(0, 0, 0, 0))
-	var half: int = size / 2
-	for y in range(size):
-		var progress: float = float(y) / float(size - 1)
-		var half_width: int = int(float(half) * (1.0 - progress))
-		for x in range(half - half_width, half + half_width + 1):
-			if x >= 0 and x < size:
+
+	for k in range(3):
+		var angle := TAU * float(k) / 3.0 - PI / 2.0
+		var dir := Vector2(cos(angle), sin(angle))
+		var perp := Vector2(-dir.y, dir.x)
+		# Apex points at the centre; the base sits further out.
+		var apex := center + dir * (half * APEX_RADIUS)
+		var b1 := center + dir * (half * BASE_RADIUS) + perp * (half * BASE_HALF_WIDTH)
+		var b2 := center + dir * (half * BASE_RADIUS) - perp * (half * BASE_HALF_WIDTH)
+		_fill_triangle(img, apex, b1, b2)
+
+	return ImageTexture.create_from_image(img)
+
+
+## Rasterize one white triangle (the Sprite3D's modulate carries the colour).
+static func _fill_triangle(img: Image, a: Vector2, b: Vector2, c: Vector2) -> void:
+	var min_x := int(floor(minf(a.x, minf(b.x, c.x))))
+	var max_x := int(ceil(maxf(a.x, maxf(b.x, c.x))))
+	var min_y := int(floor(minf(a.y, minf(b.y, c.y))))
+	var max_y := int(ceil(maxf(a.y, maxf(b.y, c.y))))
+	var area := _edge(a, b, c)
+	if absf(area) < 0.0001:
+		return
+	for y in range(maxi(min_y, 0), mini(max_y, img.get_height() - 1) + 1):
+		for x in range(maxi(min_x, 0), mini(max_x, img.get_width() - 1) + 1):
+			var p := Vector2(x + 0.5, y + 0.5)
+			# Same-side test against all three edges, robust to winding.
+			if _edge(a, b, p) * area >= 0.0 and _edge(b, c, p) * area >= 0.0 \
+					and _edge(c, a, p) * area >= 0.0:
 				img.set_pixel(x, y, Color.WHITE)
-	reticle.texture = ImageTexture.create_from_image(img)
-	return reticle
+
+
+static func _edge(a: Vector2, b: Vector2, p: Vector2) -> float:
+	return (p.x - a.x) * (b.y - a.y) - (p.y - a.y) * (b.x - a.x)

--- a/scripts/3d/elements/wall.gd
+++ b/scripts/3d/elements/wall.gd
@@ -44,6 +44,10 @@ func _ready() -> void:
 	collision_body = _build_static_collision("WallCollision")
 	_setup_hurtbox("WallHurtbox")
 	_setup_mirror_textures()
+	# Centre of the wall's face, not above it — a wall is targeted like an
+	# enemy standing in the doorway, not like loot on the ground.
+	if is_destructible:
+		_setup_reticle(collision_size.y * 0.5)
 
 
 ## Called when the wall takes damage (from player attacks via the Hurtbox).
@@ -66,6 +70,7 @@ func destroy() -> void:
 
 	is_alive = false
 	remove_from_group("enemies")
+	hide_reticle()
 	set_state("destroyed")
 	destroyed_wall.emit()
 	print("[Wall] Destroyed")

--- a/scripts/3d/enemies/enemy_base.gd
+++ b/scripts/3d/enemies/enemy_base.gd
@@ -1288,10 +1288,13 @@ func _spawn_damage_number(text: String, color: Color = Color.WHITE) -> void:
 
 
 func _setup_reticle() -> void:
+	# Centre of the body, not above the head — the three triangles mark the
+	# thing they lock, and with a crowd the above-head reticles smear into a
+	# band instead of reading one-per-enemy.
 	var height := 1.5
 	if enemy_data:
 		height = enemy_data.collision_height
-	_reticle = TargetReticle.build(height + 0.5)
+	_reticle = TargetReticle.build(height * 0.5)
 	add_child(_reticle)
 
 


### PR DESCRIPTION
Playtest-driven reticle work, two commits:

- **The reticle is now the original's shape**: three triangles around a center point, 120° apart, pointing inward — drawn procedurally, since the ef_com_rockon pair renders a single triangle and the effect models are absent from the asset manifests anyway. Reticle setup/show/hide hoisted into DestructibleElement so boxes and walls share it.
- **Destructible walls are targeted like enemies**: a reticle sits at the CENTER of the wall's face (walls already ride the \"enemies\" group cone from #624), dropped on destroy.
- **Enemy reticles sit at the body's center** (`collision_height * 0.5`) instead of floating above the head — with a crowd, above-head reticles smeared into a band instead of reading one-per-enemy.

Verified: code-health ratchet clean (dup unchanged at 87), headless layout tests 36/36, playtested — walls targeted through the reticle and destroyed, no script errors in the session log.