### PR TITLE
Stand keys on the room's authored key slots instead of the portal centroid

### DIFF
--- a/data/re_reference/room_reference.json
+++ b/data/re_reference/room_reference.json
@@ -1,5 +1,5 @@
 {
- "_": "What the ORIGINAL has in a room. OBJECTS are reference only and never reach the game — an unhandled kind would still eat a slot against the 20-object room cap, so the gameplay table stays room_objects.json. ENEMIES are DIFFERENT and ARE consumed: FieldPopulation stands each wave on these authored slots instead of a ring, because they are positions rather than objects and cost nothing against that cap (spec /mechanics/enemy-placement). Regenerate with scripts/tools/refield/import_re_reference.py.",
+ "_": "What the ORIGINAL has in a room. OBJECTS are reference only and never reach the game — an unhandled kind would still eat a slot against the 20-object room cap, so the gameplay table stays room_objects.json. ENEMIES and KEY POSITIONS are DIFFERENT and ARE consumed: FieldPopulation stands each wave on these authored slots instead of a ring, and stands each cell's keys on these authored key slots instead of the portal centroid, because both are positions rather than objects and cost nothing against that cap (specs /mechanics/enemy-placement, /mechanics/key-placement). Regenerate with scripts/tools/refield/import_re_reference.py.",
  "source": "psz-re data/object_placement_per_room.json + enemy_deploy_positions.json",
  "sets": [
   "d"

--- a/scripts/3d/field/field_population.gd
+++ b/scripts/3d/field/field_population.gd
@@ -41,8 +41,11 @@ class_name FieldPopulation
 ##            time, not generation time, so the field data is the same
 ##            either way.
 ##
-## Enemy positions are still ours: the game's enemy deploy table is a separate
-## file that has not been decoded to positions, so enemies stay on a ring.
+## Enemy and key POSITIONS are authored and consumed (#604, #627): waves stand
+## on the room's enemy slots, a cell's keys on its authored key slots. Which
+## subset of either a given room instance uses is OUR seeded choice, not a
+## measurement — the original's per-room placement weights are still undecoded
+## (psz-re default_parameters bytes 4..8).
 
 const RE_DIR := "res://data/re_reference/"
 ## Deploy set to roll from. The RE notes record that d/f1..f4/s draw from the
@@ -112,6 +115,14 @@ static var _rooms: Dictionary = {}
 ## against the 20-object room cap, but spawn slots are positions, not objects,
 ## and cost nothing against that cap.
 static var _enemy_slots: Dictionary = {}
+
+## Authored key slots, room code -> Array of {x, y, z, g: [groups]}. Same file,
+## same argument (spec /mechanics/key-placement): the POSITIONS are consumed,
+## the key object still never spawns through the room-object table -- which
+## rooms hold keys and how many is the gate economy's own rule. The file
+## repeats a position under each group that builds it, so slots are stored
+## DISTINCT, each carrying every group it appears in for the mask filter.
+static var _key_slots: Dictionary = {}
 static var _layout_masks: Array = []
 static var _layout_weights: Dictionary = {}
 static var _group5_weights: Array = []
@@ -141,6 +152,9 @@ static func _load() -> void:
 		var slots: Array = ref_doc["rooms"][code].get("enemies", [])
 		if not slots.is_empty():
 			_enemy_slots[code] = slots
+		var keys: Array = _distinct_key_slots(ref_doc["rooms"][code].get("objects", []))
+		if not keys.is_empty():
+			_key_slots[code] = keys
 
 	var caps: Dictionary = obj_doc.get("caps", {})
 	_cap_per_group = int(caps.get("per_group", 20))
@@ -280,7 +294,13 @@ static func _resolve(re_name: String) -> Array:
 ## `depth` is the room's distance along the generated path; -1 means unknown
 ## and takes the middle weight row. Every draw goes through `rng`, so a seeded
 ## generator reproduces a field exactly.
-static func authored_objects(room_code: String, depth: int, rng: RandomNumberGenerator) -> Array:
+##
+## `layout_mask` shares ONE draw with the caller: pass `drawn_mask()`'s result
+## and this uses it instead of drawing again, so a room's objects and its key
+## slots are selected under the same mask. -1 (the default) draws here, as
+## before -- the key-slot consumer must never let the room draw twice.
+static func authored_objects(room_code: String, depth: int, rng: RandomNumberGenerator,
+		layout_mask: int = -1) -> Array:
 	_load()
 	var entry: Dictionary = _rooms.get("%s_%s" % [room_code, DEPLOY_SET], {})
 	var records: Array = entry.get("objects", [])
@@ -294,8 +314,10 @@ static func authored_objects(room_code: String, depth: int, rng: RandomNumberGen
 		# and builds the file flat. Do the same rather than dropping the room.
 		picked = _cap(records, _cap_per_group)
 	else:
-		var layout: int = _pick_layout(groups, depth, rng)
-		var mask: int = int(_layout_masks[layout]) if layout < _layout_masks.size() else 0
+		var mask := layout_mask
+		if mask < 0:
+			var layout: int = _pick_layout(groups, depth, rng)
+			mask = int(_layout_masks[layout]) if layout < _layout_masks.size() else 0
 		for g in range(5):
 			if (mask >> g) & 1:
 				picked.append_array(_cap(_in_group(records, g), _cap_per_group))
@@ -553,6 +575,118 @@ static func enemy_slot_positions_away(room_code: String, count: int,
 	return out
 
 
+## The room's authored key positions as the data holds them: DISTINCT slots
+## (the file repeats a position under each group that builds it), each
+## carrying the groups it appears in. Mask-agnostic -- key_slot_positions
+## applies the filter. Exposed so a test can assert placement picks FROM this
+## list rather than near it.
+static func authored_key_slots(room_code: String) -> Array:
+	_load()
+	return _key_slots.get("%s_%s" % [room_code, DEPLOY_SET], [])
+
+
+## The reference table's key records collapsed to distinct positions.
+static func _distinct_key_slots(objects: Array) -> Array:
+	var out: Array = []
+	var by_pos := {}
+	for rec in objects:
+		if str(rec.get("k", "")) != "key":
+			continue
+		# The importer rounds to 3 decimals, so a %.3f key is exact identity.
+		var pos_key := "%.3f,%.3f,%.3f" % [
+			float(rec.get("x", 0.0)), float(rec.get("y", 0.0)), float(rec.get("z", 0.0))]
+		var slot: Dictionary = by_pos.get(pos_key, {})
+		if slot.is_empty():
+			slot = {
+				"x": float(rec.get("x", 0.0)),
+				"y": float(rec.get("y", 0.0)),
+				"z": float(rec.get("z", 0.0)),
+				"g": [],
+			}
+			by_pos[pos_key] = slot
+			out.append(slot)
+		var g = rec.get("g", null)
+		if g != null and not slot["g"].has(int(g)):
+			slot["g"].append(int(g))
+	return out
+
+
+## The layout mask this room instance draws: the ONE draw shared by the room's
+## objects and its key slots, so a key only stands in a group the room built
+## (spec /mechanics/key-placement). Draw this FIRST, pass it to
+## authored_objects/objects_for_cell, and hand it to key_slot_positions.
+## -1 when the room builds flat (no recoverable group table) or has no object
+## row -- every key slot is then eligible, exactly as the flat object build
+## takes those rooms' records regardless of mask.
+static func drawn_mask(room_code: String, depth: int, rng: RandomNumberGenerator) -> int:
+	_load()
+	var entry: Dictionary = _rooms.get("%s_%s" % [room_code, DEPLOY_SET], {})
+	var groups = entry.get("groups", null)
+	if groups == null:
+		return -1
+	var layout: int = _pick_layout(groups, depth, rng)
+	return int(_layout_masks[layout]) if layout < _layout_masks.size() else -1
+
+
+## Seeded slot picks for one cell's `count` keys (#627, spec
+## /mechanics/key-placement). Filters the room's authored key slots by the
+## drawn layout mask, shuffles, and takes `count` with modulo wrap -- a slot
+## may be reused, never a key dropped, because the gate demands exactly
+## `count`. Returns [] when the room authors no key slot at all, so the caller
+## keeps its centroid fallback.
+static func key_slot_positions(room_code: String, count: int,
+		rng: RandomNumberGenerator, mask: int) -> Array:
+	_load()
+	var slots: Array = _key_slots.get("%s_%s" % [room_code, DEPLOY_SET], [])
+	var pool: Array = []
+	for slot in slots:
+		if _slot_in_mask(slot.get("g", []), mask):
+			pool.append(slot)
+	if pool.is_empty() and not slots.is_empty() and mask >= 0:
+		# The drawn mask leaves this room no slot -- under it the original
+		# would place no key here at all. But WHICH rooms hold keys is the gate
+		# economy's committed decision, not the reference table's, so the key
+		# exists regardless: stand it on the room's authored spots from its
+		# other layouts rather than on a doorway centroid over a void. (88 of
+		# the 224 key rooms are group-0-only; layout 3 does not build group 0.)
+		pool = slots
+	if pool.is_empty() or count <= 0:
+		return []
+
+	# Same seeded-subset contract as enemy_slot_positions: the POSITIONS are
+	# authored and exact, the selection among them is ours.
+	var order: Array = []
+	for i in range(pool.size()):
+		order.append(i)
+	for i in range(order.size() - 1, 0, -1):
+		var j: int = rng.randi_range(0, i)
+		var t = order[i]
+		order[i] = order[j]
+		order[j] = t
+
+	var out: Array = []
+	for i in range(count):
+		var slot: Dictionary = pool[order[i % order.size()]]
+		out.append([
+			snappedf(float(slot.get("x", 0.0)), 0.01),
+			snappedf(float(slot.get("y", 0.0)), 0.01),
+			snappedf(float(slot.get("z", 0.0)), 0.01),
+		])
+	return out
+
+
+## A slot stands in one of the mask's groups. An ungrouped slot -- the
+## flat-build rooms, whose group table did not survive -- is always eligible,
+## exactly as the flat object build takes those rooms' records.
+static func _slot_in_mask(groups: Array, mask: int) -> bool:
+	if groups.is_empty() or mask < 0:
+		return true
+	for g in groups:
+		if (mask >> int(g)) & 1:
+			return true
+	return false
+
+
 static func ring_positions(count: int, radius: float) -> Array:
 	var out: Array = []
 	for i in range(count):
@@ -608,8 +742,11 @@ static func _wave_count(room_code: String, rng: RandomNumberGenerator) -> int:
 	return rng.randi_range(lo, hi)
 
 
+## `layout_mask` is drawn_mask()'s result for this same room instance, so the
+## objects and the caller's key slots share ONE draw; -1 (the default) draws
+## here as before.
 static func objects_for_cell(room_code: String, is_start: bool, _is_end: bool,
-		rng: RandomNumberGenerator, depth: int = -1) -> Array:
+		rng: RandomNumberGenerator, depth: int = -1, layout_mask: int = -1) -> Array:
 	# Only the START room is unconditionally empty. is_end is NOT: the goal is
 	# "not necessarily last" (free-field spec), so the last cell of a path is
 	# often an ordinary combat room, and suppressing its wave left whole rooms
@@ -636,7 +773,7 @@ static func objects_for_cell(room_code: String, is_start: bool, _is_end: bool,
 				"wave": w,
 			})
 
-	var authored: Array = authored_objects(room_code, depth, rng)
+	var authored: Array = authored_objects(room_code, depth, rng, layout_mask)
 	if authored.is_empty():
 		# No authored table for this room code. Fall back to the ring rather
 		# than leaving the room bare — see BOXES_PER_ROOM.

--- a/scripts/3d/field/grid_generator.gd
+++ b/scripts/3d/field/grid_generator.gd
@@ -1435,6 +1435,8 @@ func _to_output(grid: Dictionary, _path: Array[Vector2i],
 		if cell.get("is_end", false):
 			warp_edge = str(cell.get("key_gate_direction", ""))
 
+		var populated: Dictionary = _populate_cell(cell)
+
 		cells.append({
 			"pos": key,
 			"stage_id": str(cell["stage_id"]),
@@ -1460,25 +1462,58 @@ func _to_output(grid: Dictionary, _path: Array[Vector2i],
 			# a TWO-key gate is a real two-key gate today rather than waiting for
 			# step 3 of /states/field-gates.
 			"required_keys": int(cell.get("required_keys", 0)),
+			# Where this cell's keys STAND: the room's authored key slots,
+			# mask-filtered by the same draw that built `objects` and wrapped to
+			# key_count (#627). Consumed by _create_key_pickup between the
+			# editor-authored key_position and the centroid fallback.
+			"key_slots": populated["key_slots"],
 			"warp_edge": warp_edge,
 			# The start room's way back to wherever the player warped in from.
 			# "" for an `a` section, which is entered through a defaultSpawn.
 			"entry_warp_edge": _entry_warp_dir(grid, key, cell),
 			"path_order": int(cell.get("path_order", -1)),
 			"portals": _baked_portals(str(cell["stage_id"]), int(cell.get("rotation", 0))),
-			"objects": FieldPopulation.objects_for_cell(
-				str(cell["stage_id"]),
-				cell.get("is_start", false),
-				cell.get("is_end", false),
-				_rng,
-				int(cell.get("path_order", -1)),
-			),
+			"objects": populated["objects"],
 		})
 
 	return {
 		"cells": cells,
 		"start_pos": _pos_key(start_pos),
 		"end_pos": _pos_key(end_pos),
+	}
+
+
+## A cell's generated contents: its objects and, for a key cell, the slots its
+## keys stand on.
+##
+## ONE layout draw per room instance, shared by the objects and the key slots,
+## so a key never stands in a group the room did not build (spec
+## /mechanics/key-placement); the mask comes back as -1 for a flat build or a
+## room with no object row, which leaves every key slot eligible. Start rooms
+## stay undrawn — objects_for_cell empties them before any draw, and they never
+## hold a key anyway. Key slots are selected HERE, at generation, so a field
+## populates identically on every revisit; [] leaves _create_key_pickup on its
+## centroid fallback (a room code the reference never covered).
+func _populate_cell(cell: Dictionary) -> Dictionary:
+	var stage_id := str(cell["stage_id"])
+	var depth := int(cell.get("path_order", -1))
+	var layout_mask: int = -1
+	if not cell.get("is_start", false):
+		layout_mask = FieldPopulation.drawn_mask(stage_id, depth, _rng)
+	var key_slots: Array = []
+	if cell.get("has_key", false):
+		key_slots = FieldPopulation.key_slot_positions(
+			stage_id, maxi(1, int(cell.get("key_count", 1))), _rng, layout_mask)
+	return {
+		"objects": FieldPopulation.objects_for_cell(
+			stage_id,
+			cell.get("is_start", false),
+			cell.get("is_end", false),
+			_rng,
+			depth,
+			layout_mask,
+		),
+		"key_slots": key_slots,
 	}
 
 

--- a/scripts/3d/field/portal_gate_manager.gd
+++ b/scripts/3d/field/portal_gate_manager.gd
@@ -359,22 +359,78 @@ func _add_gate_label(direction: String, pos: Vector3, target_cell: String, porta
 ## `count` is the cell's authored `key_count`. A gate with required_keys=N
 ## consumes N copies of the SAME key id (key_gate.gd counts them via
 ## Inventory.get_key_count), so a multi-key cell must spawn N pickups sharing
-## one key_id — spawning a single pickup leaves the gate permanently
-## unopenable. Extra keys are ringed around the base position so they don't
-## overlap into one un-clickable pile.
+## one key id — spawning a single pickup leaves the gate permanently
+## unopenable. WHERE they stand is _resolve_key_positions' tier list below.
 func _create_key_pickup(key_for_cell: String, count: int = 1) -> void:
 	var key_item_id := "key_%s" % key_for_cell.replace(",", "_")
 	var total: int = maxi(1, count)
+	var positions: Array[Vector3] = _resolve_key_positions(total)
 
-	# Place key at authored position from quest editor, or fall back to heuristic
+	# Remaining-count guard: the cell is only marked collected once EVERY key
+	# in it is taken. Marking on the first pickup would suppress the respawn of
+	# the others on re-entry (_keys_collected is the respawn guard), stranding
+	# the player below the gate's requirement with no way to top up.
+	var remaining := [total]
+
+	for i in total:
+		var key := KeyPickupScript.new()
+		key.key_id = key_item_id
+		key.name = ("KeyPickup_%s_%d" % [key_for_cell, i]) if total > 1 else ("KeyPickup_%s" % key_for_cell)
+
+		_c._map_root.add_child(key)
+		key.position = positions[i]
+
+		# Track collection for grid state and update HUD
+		key.interacted.connect(func(_player: Node3D) -> void:
+			remaining[0] -= 1
+			if remaining[0] <= 0:
+				_c._keys_collected[key_for_cell] = true
+			_c._update_key_hud()
+		)
+		print("[ValleyField] Key pickup spawned for cell %s at %s (id=%s, %d/%d)" % [
+			key_for_cell, positions[i], key_item_id, i + 1, total])
+
+
+## One spawn position per key, in tier order (#627, spec /mechanics/key-placement):
+##   1. the quest editor's authored `key_position`;
+##   2. the room's authored key slots, mask-filtered at generation and carried
+##      on the cell as `key_slots` — generated fields always have these;
+##   3. the portal-spawn centroid with ringed extras — a room code the
+##      reference never covered, or a cell saved before #627.
+func _resolve_key_positions(total: int) -> Array[Vector3]:
+	var out: Array[Vector3] = []
 	var key_pos := Vector3.ZERO
 	var authored_pos: Array = _c._current_cell.get("key_position", [])
+	var slots: Array = _c._current_cell.get("key_slots", [])
 	if authored_pos.size() == 3:
-		# Use authored position from quest editor (stage-local coordinates)
+		# Tier 1: authored position from quest editor (stage-local coordinates)
 		key_pos = Vector3(float(authored_pos[0]), float(authored_pos[1]), float(authored_pos[2]))
 		print("[ValleyField] Key using authored position: %s (rotation handled by _map_root)" % key_pos)
+	elif not slots.is_empty():
+		print("[ValleyField] Key using authored reference slots: %d slot(s) for %d key(s)" % [
+			slots.size(), total])
+		for i in total:
+			# Every record carries y=0.0 — the original authors no height — so
+			# floor-snap at the slot's (x,z) and hover, the same contract boxes
+			# follow. A key under a raised floor is an unopenable gate, i.e. a
+			# soft lock, not a cosmetic bug.
+			var sa: Array = slots[i % slots.size()]
+			var spot := Vector3(float(sa[0]), float(sa[1]), float(sa[2]))
+			if i >= slots.size():
+				# More keys than the room authors distinct slots: wrap, and ring
+				# the copy so two pickups don't sit inside one interaction
+				# volume (collision_size 2.5 — see KEY_SPREAD_RADIUS).
+				var angle := TAU * float(i) / float(total)
+				spot += Vector3(cos(angle), 0.0, sin(angle)) * KEY_SPREAD_RADIUS
+			if _c._cell_spawner:
+				var floored: Vector3 = _c._cell_spawner._place_on_floor(spot)
+				floored.y += KEY_HOVER_HEIGHT
+				out.append(floored)
+			else:
+				out.append(spot + Vector3(0.0, KEY_HOVER_HEIGHT, 0.0))
+		return out
 	else:
-		# Fallback: midpoint between portal spawns
+		# Tier 3 fallback: midpoint between portal spawns
 		var portal_positions: Array[Vector3] = []
 		for dir in _c._portal_data:
 			if dir != "default":
@@ -389,25 +445,16 @@ func _create_key_pickup(key_for_cell: String, count: int = 1) -> void:
 		key_pos.y = 0.5
 		print("[ValleyField] Key using fallback midpoint: %s" % key_pos)
 
-	# Remaining-count guard: the cell is only marked collected once EVERY key
-	# in it is taken. Marking on the first pickup would suppress the respawn of
-	# the others on re-entry (_keys_collected is the respawn guard), stranding
-	# the player below the gate's requirement with no way to top up.
-	var remaining := [total]
-
+	# Tiers 1 and 3 share a base position: single-key cells sit on it verbatim,
+	# multi-key cells ring their copies so each is separately walkable and
+	# interactable, then floor-validate — a blind offset pushes keys past the
+	# floor edge in narrow rooms (s02b_lb1), leaving one unreachable and the
+	# gate unopenable, the very failure the ring exists to avoid.
+	# _place_on_floor snaps to the floor, or relocates to the nearest floor
+	# point when a ringed spot has none.
 	for i in total:
-		var key := KeyPickupScript.new()
-		key.key_id = key_item_id
-		key.name = ("KeyPickup_%s_%d" % [key_for_cell, i]) if total > 1 else ("KeyPickup_%s" % key_for_cell)
-
 		var pos := key_pos
 		if total > 1:
-			# Ring the copies so each is separately walkable/interactable, then
-			# floor-validate: a blind offset pushes keys past the floor edge in
-			# narrow rooms (s02b_lb1), leaving one unreachable and the gate
-			# unopenable — the very failure this multi-key path exists to fix.
-			# _place_on_floor snaps to the floor, or relocates to the nearest
-			# floor point when the ringed spot has none.
 			var angle := TAU * float(i) / float(total)
 			var ringed := key_pos + Vector3(cos(angle), 0.0, sin(angle)) * KEY_SPREAD_RADIUS
 			if _c._cell_spawner:
@@ -417,19 +464,8 @@ func _create_key_pickup(key_for_cell: String, count: int = 1) -> void:
 				pos.y += KEY_HOVER_HEIGHT
 			else:
 				pos = ringed
-
-		_c._map_root.add_child(key)
-		key.position = pos
-
-		# Track collection for grid state and update HUD
-		key.interacted.connect(func(_player: Node3D) -> void:
-			remaining[0] -= 1
-			if remaining[0] <= 0:
-				_c._keys_collected[key_for_cell] = true
-			_c._update_key_hud()
-		)
-		print("[ValleyField] Key pickup spawned for cell %s at %s (id=%s, %d/%d)" % [
-			key_for_cell, pos, key_item_id, i + 1, total])
+		out.append(pos)
+	return out
 
 
 func _drop_key_on_clear(target_cell: String, tracking_key: String) -> void:

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -475,15 +475,6 @@ func _ready() -> void:
 
 	# (warp_edge exit is handled by area warp auto-generation in _spawn_field_elements)
 
-	# Place key pickup if this cell has one
-	if _current_cell.get("has_key", false):
-		var key_for: String = str(_current_cell.get("key_for_cell", ""))
-		if not key_for.is_empty() and not _keys_collected.has(key_for):
-			# key_count is how many copies this cell holds; the gate it feeds
-			# consumes required_keys of them (key_gate.gd). Defaults to 1 for
-			# cells authored before multi-key gates existed.
-			_gate_mgr._create_key_pickup(key_for, int(_current_cell.get("key_count", 1)))
-
 	_spawn_field_elements()
 	_spawn_companion()
 	# Wait one PHYSICS frame so the floor collision built above is live in the
@@ -493,6 +484,19 @@ func _ready() -> void:
 	# floated at y=0. This makes the snap deterministic on hardware.
 	await get_tree().physics_frame
 	_cell_spawner._spawn_cell_objects()
+
+	# Place key pickup if this cell has one — AFTER the physics frame, because
+	# authored key slots (#627) floor-snap exactly like boxes and the ray needs
+	# that tick to see the floor. Earlier, a slot over raised floor snapped to
+	# nothing and buried the key: an unopenable gate, a soft lock.
+	if _current_cell.get("has_key", false):
+		var key_for: String = str(_current_cell.get("key_for_cell", ""))
+		if not key_for.is_empty() and not _keys_collected.has(key_for):
+			# key_count is how many copies this cell holds; the gate it feeds
+			# consumes required_keys of them (key_gate.gd). Defaults to 1 for
+			# cells authored before multi-key gates existed.
+			_gate_mgr._create_key_pickup(key_for, int(_current_cell.get("key_count", 1)))
+
 	_setup_debug_panel()
 
 	# Re-spawn the player-dropped telepipe if one is active in this exact

--- a/scripts/tools/refield/import_re_reference.py
+++ b/scripts/tools/refield/import_re_reference.py
@@ -14,19 +14,25 @@ THE OBJECTS HERE DO NOT REACH THE GAME. It is deliberately a separate file from
 room_objects.json so that adding a kind to this list can never accidentally
 start spawning it — the two have different consumers and different risks.
 
-The ENEMY SLOTS are the exception and ARE consumed: FieldPopulation stands each
-wave on them instead of a ring (spec /mechanics/enemy-placement). They are
-positions rather than objects, so they cost nothing against the room cap.
+The ENEMY SLOTS and the KEY POSITIONS are the exceptions and ARE consumed:
+FieldPopulation stands each wave on the enemy slots instead of a ring (spec
+/mechanics/enemy-placement), and stands a generated cell's keys on the authored
+key slots instead of the portal centroid (spec /mechanics/key-placement). Both
+are positions rather than objects, so they cost nothing against the room cap.
+The key OBJECT still does not spawn from here — which rooms hold keys and how
+many stays the gate economy's own rule (spec /states/field-gates) — only the
+positions are read.
 
 What it carries, per room:
 
-  keys        o0c_key, 836 records over 224 rooms in set d. The original
-              AUTHORS where a key sits. psz-godot instead scatters keys by the
-              measured rule (BFS depth < 2 from the gated room, max 2 per room),
-              because which ROOMS hold keys is a per-field decision. Both can be
-              true — the room table saying where a key may sit, the generator
-              choosing which rooms use it — and seeing the authored positions is
-              how we find out.
+  keys        o0c_key, 836 records over 224 rooms in set d, 2-6 distinct
+              positions each. The original AUTHORS where a key sits, and the
+              records are group-tagged like every other object: a key exists
+              only in the layout masks that build its group, so the consumer
+              filters by the room's drawn mask. psz-godot still decides which
+              rooms hold keys and how many (the gate economy's BFS scatter);
+              since #627 the keys a generated cell does hold STAND on these
+              positions rather than on the portal centroid.
 
   enemies     Spawn slots from enemy_deploy_positions.json: 257 rooms in set d,
               8 or 9 slots each. CONSUMED by FieldPopulation since #616 — before
@@ -161,10 +167,12 @@ def build(re_root: pathlib.Path, sets: tuple[str, ...]) -> dict:
         "_": ("What the ORIGINAL has in a room. OBJECTS are reference only and "
               "never reach the game — an unhandled kind would still eat a slot "
               "against the 20-object room cap, so the gameplay table stays "
-              "room_objects.json. ENEMIES are DIFFERENT and ARE consumed: "
-              "FieldPopulation stands each wave on these authored slots instead "
-              "of a ring, because they are positions rather than objects and "
-              "cost nothing against that cap (spec /mechanics/enemy-placement). "
+              "room_objects.json. ENEMIES and KEY POSITIONS are DIFFERENT and "
+              "ARE consumed: FieldPopulation stands each wave on these authored "
+              "slots instead of a ring, and stands each cell's keys on these "
+              "authored key slots instead of the portal centroid, because both "
+              "are positions rather than objects and cost nothing against that "
+              "cap (specs /mechanics/enemy-placement, /mechanics/key-placement). "
               "Regenerate with scripts/tools/refield/import_re_reference.py."),
         "source": "psz-re data/object_placement_per_room.json + enemy_deploy_positions.json",
         "sets": list(sets),

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -117,6 +117,7 @@ func _run_tests_core() -> void:
 	test_gate_kind_per_door()
 	test_group_five_trap_roll()
 	test_enemies_stand_on_authored_slots()
+	test_keys_stand_on_authored_slots()
 	test_field_trap_behaviour()
 	test_trap_vision_reveal()
 	test_palette_picker_grid()
@@ -1224,6 +1225,122 @@ func test_enemies_stand_on_authored_slots() -> void:
 	# An unknown room code falls back to the ring rather than spawning nothing.
 	var none: Array = Pop.enemy_slot_positions("s99z_zz9", 3, _seeded_rng(3))
 	assert_true(none.is_empty(), "unknown room code yields no slots, so the caller rings")
+
+
+func test_keys_stand_on_authored_slots() -> void:
+	print("── Keys stand on the room's AUTHORED KEY SLOTS, not the portal centroid ──")
+	const Pop := preload("res://scripts/3d/field/field_population.gd")
+
+	# Every position MUST be one the room actually authors — placement picks
+	# from the slot list, it does not interpolate or jitter. s01a_ib2 splits
+	# its four slots by group (two in group 0, two in group 3, disjoint), so
+	# the same fixture exercises the mask filter below. Keys are compared in
+	# key_slot_positions' own snappedf form: GDScript's %.2f and snappedf
+	# disagree on half-boundary values (-0.405 → -0.41 vs -0.4), so mixing the
+	# two roundings fails a slot that IS authored.
+	var authored := {}
+	for s in Pop.authored_key_slots("s01a_ib2"):
+		authored[_key_slot_key(s)] = true
+	assert_eq(authored.size(), 4, "s01a_ib2 authors 4 distinct key positions")
+
+	var picks: Array = Pop.key_slot_positions("s01a_ib2", 2, _seeded_rng(1), 33)
+	assert_eq(picks.size(), 2, "two keys get two positions")
+	for p in picks:
+		assert_true(authored.has("%.2f,%.2f" % [float(p[0]), float(p[2])]),
+			"position %s is an authored key slot" % [p])
+
+	# THE MASK FILTER — the same draw that builds the room's objects decides
+	# which slots exist. Mask 33 builds group 0 (+5); mask 40 builds group 3.
+	# count=2 empties each pool, so each pick set IS its mask's slot set.
+	var set33 := {}
+	for p in Pop.key_slot_positions("s01a_ib2", 2, _seeded_rng(2), 33):
+		set33["%.2f,%.2f" % [float(p[0]), float(p[2])]] = true
+	var set40 := {}
+	for p in Pop.key_slot_positions("s01a_ib2", 2, _seeded_rng(3), 40):
+		set40["%.2f,%.2f" % [float(p[0]), float(p[2])]] = true
+	for s in Pop.authored_key_slots("s01a_ib2"):
+		var slot_key := _key_slot_key(s)
+		assert_eq(set33.has(slot_key), s.get("g", []).has(0),
+			"mask 33 admits exactly the group-0 slot %s" % slot_key)
+		assert_eq(set40.has(slot_key), s.get("g", []).has(3),
+			"mask 40 admits exactly the group-3 slot %s" % slot_key)
+
+	# A mask that leaves the room NO slot must not unplace the key: s03a_ib1's
+	# slots are all group 0, which mask 40 does not build, so the mask is set
+	# aside and the authored slots are used anyway (spec /mechanics/key-placement
+	# — which rooms hold keys is the gate economy's committed decision).
+	var mask_empty: Array = Pop.key_slot_positions("s03a_ib1", 2, _seeded_rng(4), 40)
+	assert_eq(mask_empty.size(), 2, "the key exists regardless of the mask — no slot dropped")
+
+	# Flat-build rooms (no recoverable group table, all of s02/s05): records
+	# carry no group, so every slot is eligible whatever the mask.
+	var flat_a: Array = Pop.key_slot_positions("s02a_ib1", 2, _seeded_rng(5), 33)
+	var flat_b: Array = Pop.key_slot_positions("s02a_ib1", 2, _seeded_rng(5), 40)
+	assert_eq(flat_a.size(), 2, "a flat room still yields its authored slots")
+	assert_true(str(flat_a) == str(flat_b), "the mask does not filter an ungrouped slot")
+
+	# Seeded: the same field populates the same way on every revisit.
+	var again: Array = Pop.key_slot_positions("s01a_ib2", 2, _seeded_rng(1), 33)
+	assert_true(str(again) == str(picks), "same seed gives the same placement")
+
+	# More keys than distinct slots WRAP — the gate demands them, none dropped.
+	var big: Array = Pop.key_slot_positions("s01a_ib2", 12, _seeded_rng(6), 33)
+	assert_eq(big.size(), 12, "a 12-key cell gets 12 positions, none dropped")
+
+	# Authored records carry no height (y=0.0 corpus-wide) — the pickup
+	# floor-snaps and hovers at spawn instead of trusting y.
+	assert_true(is_zero_approx(float(picks[0][1])),
+		"slot y is authored 0.0; the spawn floor-snaps rather than trusting it")
+
+	# An unknown room code yields no slots, so the caller keeps the centroid.
+	assert_true(Pop.key_slot_positions("s99z_zz9", 3, _seeded_rng(7), 33).is_empty(),
+		"unknown room code yields no slots")
+
+	# END TO END: generated fields stand every key on its room's authored
+	# slots, wrapped to the cell's key_count, under a mask the room drew. The
+	# sweep lives in its own helper so neither function crosses the
+	# code-health size bound.
+	var checked: int = _sweep_generated_key_slots()
+	assert_true(checked > 50, "the sweep exercised real key placements (%d)" % checked)
+
+
+## How many key slots the generator sweep checked; asserts each one against
+## its room's authored list (see test_keys_stand_on_authored_slots).
+func _sweep_generated_key_slots() -> int:
+	const Pop := preload("res://scripts/3d/field/field_population.gd")
+	const GridGen := preload("res://scripts/3d/field/grid_generator.gd")
+	var checked := 0
+	for seed_value in range(30):
+		var gen = GridGen.new()
+		gen.set_seed(seed_value)
+		for section in gen.generate_field("normal", "gurhacia")["sections"]:
+			for cell in section.get("cells", []):
+				if not cell.get("has_key", false):
+					continue
+				var stage_id: String = str(cell.get("stage_id", ""))
+				var room_authors: Array = Pop.authored_key_slots(stage_id)
+				if room_authors.is_empty():
+					continue  # reference never covered this room — centroid path
+				var slots: Array = cell.get("key_slots", [])
+				var want: int = maxi(1, int(cell.get("key_count", 1)))
+				assert_eq(slots.size(), want,
+					"cell %s holds one slot per key (%d wanted)" % [str(cell.get("pos", "")), want])
+				var by_xy := {}
+				for s in room_authors:
+					by_xy[_key_slot_key(s)] = true
+				for sa in slots:
+					checked += 1
+					assert_true(by_xy.has("%.2f,%.2f" % [float(sa[0]), float(sa[2])]),
+						"generated slot %s is authored for %s" % [str(sa), stage_id])
+	return checked
+
+
+## Comparison key for an authored key-slot record, in key_slot_positions' own
+## snappedf form — see the note in test_keys_stand_on_authored_slots.
+func _key_slot_key(s: Dictionary) -> String:
+	return "%.2f,%.2f" % [
+		snappedf(float(s.get("x", 0.0)), 0.01),
+		snappedf(float(s.get("z", 0.0)), 0.01)]
 
 
 func test_group_five_trap_roll() -> void:

--- a/spec/src/pages/mechanics/index.astro
+++ b/spec/src/pages/mechanics/index.astro
@@ -12,6 +12,7 @@ import Concept from '../../layouts/Concept.astro';
     <li><a href="/mechanics/targeting">Targeting &amp; hit detection</a> — the per-weapon hit cone, damaging-frame hit resolution, and the target-info HUD. Reference: the in-repo <code>combat-room</code> tool.</li>
     <li><a href="/mechanics/enemy-attacks">Enemy attacks</a> — per-enemy attack tables: selection bands, windup → damaging-window timelines, and the arc hit shape. Reference: the in-repo <code>enemy-room</code> tool.</li>
     <li><a href="/mechanics/enemy-placement">Enemy placement</a> — where a wave's enemies stand: the room's authored spawn slots, subset selection, and slot reuse across waves.</li>
+    <li><a href="/mechanics/key-placement">Key placement</a> — where a key pickup stands in its room: the authored key slots, the layout-mask filter, and the fallback order.</li>
     <li><a href="/mechanics/enemy-waves">Enemy waves</a> — how many waves a room runs (the per-room <code>w3</code>/<code>w4</code> min/max) and when each arrives (later waves wait for the player).</li>
     <li><a href="/mechanics/techs">Techniques</a> — casting, hold-to-charge, PP costs, elements.</li>
     <li><a href="/mechanics/stats-weapons">Character stats &amp; weapons</a> — class stats and equippable weapon types / requirements.</li>

--- a/spec/src/pages/mechanics/key-placement.astro
+++ b/spec/src/pages/mechanics/key-placement.astro
@@ -1,0 +1,63 @@
+---
+import Concept from '../../layouts/Concept.astro';
+---
+
+<Concept title="Key Placement" section="Mechanics">
+  <p>The key words <strong>MUST</strong>, <strong>MUST NOT</strong>, <strong>SHOULD</strong>, and <strong>MAY</strong> are used as in RFC 2119.</p>
+
+  <p>This page governs <em>where in its room a key pickup stands</em>. It does not govern <em>which rooms hold keys or how many</em> — that is the gate economy's scatter rule (<a href="/states/field-gates">Field Gate Economy</a>): BFS depth &lt; 2 from the gated room, at most 2 per room. The two compose: the economy picks the room and the count, this page picks the spot.</p>
+
+  <h2>The rule</h2>
+
+  <p>The original <strong>authors</strong> where a key sits: 836 <code>o0c_key</code> records over 224 of the 295 reference rooms, 2–6 distinct positions each, decoded by psz-re from <code>object_placement_per_room.json</code> and carried in <code>room_reference.json</code>. A generated field's keys <strong>MUST</strong> stand on those slots.</p>
+
+  <p>psz-godot previously placed the fallback key at the centroid of the cell's portal spawn points and ringed extra copies around it. That is <strong>refuted</strong>: the centroid has no relationship to where the room's floor is wide enough, which is why keys hover over voids (<a href="https://github.com/kion-dgl/psz-godot/issues/627">#627</a>). A centroid is an average of doorways, not a placement.</p>
+
+  <h2>Resolution order</h2>
+
+  <table>
+    <thead><tr><th>Case</th><th>Behaviour</th></tr></thead>
+    <tbody>
+      <tr><td>Cell carries an authored <code>key_position</code></td><td>That position wins — the quest editor spoke, and generated cells never carry the field.</td></tr>
+      <tr><td>Generated cell with authored key slots</td><td>Keys <strong>MUST</strong> stand on the room's mask-filtered key slots, chosen as below.</td></tr>
+      <tr><td>Cell holds more keys than the room has distinct slots</td><td>Slots <strong>MUST</strong> be reused (modulo wrap) rather than keys dropped — the gate demands them — and each reused copy <strong>MUST</strong> be ringed apart so pickups stay separately clickable.</td></tr>
+      <tr><td>Room code has no authored slots</td><td>Fall back to the portal centroid. This is a fallback for a room code the reference never covered, <strong>not</strong> a placement policy.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>The mask filter</h2>
+
+  <p>Authored key records are group-tagged like every other room object: a key exists only in the layout masks that build its group. Faithful placement <strong>MUST</strong> filter slots by the layout mask the room instance actually drew — the same draw that selected the room's objects (<code>_pick_layout</code>) — so a key never stands in a group the room did not build. One draw per room instance, shared by objects and keys; the selection <strong>MUST NOT</strong> draw twice.</p>
+
+  <p>Two consequences fall out of the data and are behaviour, not accidents:</p>
+
+  <ul>
+    <li>Rooms with no recoverable group table (all of s02 and s05) build flat; their key records carry no group and every slot is always eligible.</li>
+    <li>Layout mask 4 (the only one naming group 4) is never drawn in a free field — see <code>authored_objects</code> — so a slot whose only group is 4 is <strong>never</strong> eligible. Group-4 keys stay unplaced, exactly as the original's group-4 objects stay unbuilt.</li>
+  </ul>
+
+  <h3>When the mask leaves nothing</h3>
+
+  <p>88 of the 224 key rooms carry slots in group 0 only, and mask 40 — layout 3 — does not build group 0. Under that draw the original would place <em>no key in that room at all</em>. But which rooms hold keys is not the reference table's decision: it is the gate economy's, already committed before placement runs. So when the drawn mask leaves a room no eligible slot, the mask <strong>MUST</strong> be set aside and all of the room's authored slots used — the key exists regardless, and an authored spot from another layout of the same room beats a doorway centroid over a void. The filter narrows <em>where</em>; it must not unplace <em>whether</em>.</p>
+
+  <h2>Positions, not objects</h2>
+
+  <p><code>room_reference.json</code> says its objects never reach the game, because an unhandled kind would still eat a slot against the 20-object room cap. Keys are the second exception after enemy slots, and the argument is the same with one honest addition: a key is not a passive spawn point — it occupies interactivity, a thing the player picks up. So the split is stated rather than blurred:</p>
+
+  <ul>
+    <li>The <strong>positions</strong> are consumed (mask-filtered, seeded selection), and cost nothing against the room cap.</li>
+    <li>The key <strong>object</strong> still does not spawn through the room-object table — <code>o0c_key</code> stays under <code>not_imported_yet</code>. Which rooms hold keys, and how many, remains the gate economy's own rule (<a href="/states/field-gates">Field Gate Economy</a>), not the reference table's.</li>
+  </ul>
+
+  <h2>Coordinates and height</h2>
+
+  <p>Slots are room-local, same units and orientation as authored objects. Every authored key record carries <code>y = 0</code>, so the pickup <strong>MUST NOT</strong> trust the authored height: it floor-snaps at the slot's <code>(x, z)</code> and hovers a fixed amount above whatever floor it finds — the same contract boxes already follow. A key buried under a raised floor is an unopenable gate, which is a soft lock, not a cosmetic bug.</p>
+
+  <h2>Seeding</h2>
+
+  <p>Which subset of a room's eligible slots a cell uses is a seeded choice made at field generation, so a given field populates identically on every revisit rather than reshuffling under an uncollected key.</p>
+
+  <h2>What this page does not settle</h2>
+
+  <p>Which slot the original picks for a given room instance is <strong>not known</strong> — the same undecoded per-room seed and placement weights as <a href="/mechanics/enemy-placement">Enemy Placement</a>'s subset note. The <em>positions</em> are authored data and are exact; the <em>selection among them</em> is ours. Which rooms hold keys is likewise ours-by-measurement (the economy's scatter rule), not the reference table's.</p>
+</Concept>


### PR DESCRIPTION
Closes #627.

## Why

Keys in generated fields dropped at the centroid of the cell's portal spawn points, extras ringed around it. That is an **average of doorways** — it has no relationship to where the room's floor is actually wide enough, which is why keys hovered over voids and landed in weird spots (#627).

The original does not do this. **Every reference room authors where its keys sit** — 836 `o0c_key` records over 224 of the 295 rooms, 2–6 distinct positions each, decoded by psz-re into `object_placement_per_room.json` and **already sitting in `room_reference.json`, where nothing read them.** This reads them, mirroring #616's enemy-slot pattern.

## Why it is safe to read that file (the policy note #627 asks for)

`room_reference.json` says its OBJECTS never reach the game — an unhandled kind would still eat a slot against the 20-object room cap. Keys are the **second exception after enemy slots**, with one honest addition the spec states plainly: a key is not a passive spawn point — it **occupies interactivity**, a thing the player picks up. So the split is explicit rather than blurred:

- The **positions** are consumed (mask-filtered, seeded) and cost nothing against the cap.
- The key **object** still never spawns through the room-object table — `o0c_key` stays under `room_objects.json`'s `not_imported_yet`. Which rooms hold keys and how many remains the gate economy's own measured rule (spec /states/field-gates), not the reference table's.

The reference file's self-description is updated in the importer AND the generated file, as #616 did — otherwise the file would be asserting something about itself that had become false.

## What is measured, and what is ours

- **Measured:** the positions (authored, exact), the group tags, and the layout-mask rule (a key exists only in masks that build its group — the same `_pick_layout` draw the room's objects already use; `drawn_mask` draws once and both consume it, so a key never stands in a group the room did not build).
- **Ours, not claimed to match:** which subset of a room's slots a cell uses (same undecoded per-room placement weights as enemy slots), seeded at generation so a field populates identically on every revisit rather than reshuffling under an uncollected key.

## One measured design call worth review

88 of the 224 key rooms are group-0-only, and layout 3 (mask 40) does not build group 0 — under that draw the original would place **no key in that room at all**. But which rooms hold keys is the gate economy's committed decision, so the key exists regardless: when the drawn mask empties a room's pool, the mask is **set aside** and all authored slots are used — an authored spot from another layout of the same room beats a doorway centroid over a void. The filter narrows *where*; it must not unplace *whether*. Stated in the spec's "When the mask leaves nothing" section.

## Also in the diff

- `_create_key_pickup` now resolves positions through a three-tier list (editor `key_position` → cell `key_slots` → centroid fallback) and **runs after the `physics_frame` await**: authored records carry y=0 corpus-wide, so pickups floor-snap exactly like boxes, and the ray needs that tick — a key buried under a raised floor is an unopenable gate, i.e. a soft lock.
- Flat-build rooms (no recoverable group table, all of s02/s05) keep every slot eligible, matching the flat object build.
- `_to_output`/`_create_key_pickup` were split (`_populate_cell`, `_resolve_key_positions`) to stay under the code-health size bound — no accepted debt.

## Spec

`/mechanics/key-placement`, written before the implementation per the spec-first rule, and reconciled with /states/field-gates (room-level scatter vs in-room placement compose; neither contradicts).

## Testing

- `test_keys_stand_on_authored_slots` — placement picks FROM the authored list; the mask filter admits exactly each mask's groups (s01a_ib2's slots split 2×group-0 / 2×group-3); mask-empty degrades to all slots (s03a_ib1); flat rooms ignore the mask; seeded reproduction; 12-key wrap drops nobody; unknown room code yields []. Plus an end-to-end sweep: 30 generator seeds, every `has_key` cell's stored `key_slots` are that room's authored positions.
- Full suite: **2818 passed, 0 failed**.
- `code_graph --check`: 0 new. Baseline debt: 0 increases. Spec builds.

## Not done

**No autopilot probe**, so the two-layer rule is only half met — the autoplay scripts are Linux-only (xvfb) and this was written on the Mac, same as #616. This is a spawn-position change in the field generator, so it wants a matrix run through key-gate fields before it lands — flagging rather than quietly skipping.

🤖 Generated with ZCode