### PR TITLE
Area map: revealed cells draw their room's SVG footprint

### DIFF
--- a/scripts/3d/field/area_map_overlay.gd
+++ b/scripts/3d/field/area_map_overlay.gd
@@ -11,6 +11,12 @@ extends Control
 ## marker (cyan — the warp back to the city), and the section's exit edge
 ## the area-warp marker (blue) to the next grid.
 ##
+## Room footprints (player request): a revealed cell draws its stage's real
+## floor shape — the same minimap SVG the room minimap parses (MinimapSvg) —
+## rotated by the cell's rotation and fitted into the cell window, so the
+## grid reads as actual rooms instead of uniform squares. Stages without an
+## SVG (≈10 rooms, or a packless CI run) keep the plain-square fallback.
+##
 ## Drawn over assets/ui/hud/map_grid.png when present — kion's 5×5 grid
 ## sheet (1024 px wide, cell windows 107 px at 139 + col·120 / 219 + row·120).
 ## Until the sprite lands in the pack, a procedural plate with identical
@@ -40,6 +46,8 @@ const DOOR_LOCKED_COLOR := Color(1.0, 0.3, 0.3)
 const RETURN_WARP_COLOR := Color(0.3, 0.95, 1.0)
 const AREA_WARP_COLOR := Color(0.29, 0.62, 1.0)
 const HEADER_TEXT := Color(0.16, 0.22, 0.34)
+# Room-footprint strokes — subdued so shapes read as outlines, not noise.
+const SHAPE_BOUNDARY_COLOR := Color(1.0, 1.0, 1.0, 0.45)
 
 const DIR_OFFSETS := {
 	"north": Vector2i(-1, 0),
@@ -53,6 +61,8 @@ var _current_pos: String = ""
 var _visited_cells: Dictionary = {}
 var _gate_states: Dictionary = {}  # "pos>dir" → "open"|"locked"|"exit"
 var _section_label: String = ""
+var _area_folder: String = ""
+var _room_shapes: Dictionary = {}  # pos → MinimapSvg.load_stage() result
 var _cell_lookup: Dictionary = {}
 var _min_row: int = 0
 var _min_col: int = 0
@@ -71,13 +81,24 @@ func _ready() -> void:
 
 
 ## Same wiring contract the grid_minimap had — the field controller calls
-## setup on every cell load and set_gate_state on gate changes.
+## setup on every cell load and set_gate_state on gate changes. area_folder
+## (e.g. "valley") resolves each cell's stage SVG path; without it the stage
+## prefix is reverse-looked up from GridGenerator.AREA_CONFIG.
 func setup(cells: Array, current_pos: String, visited_cells: Dictionary,
-		section_label: String) -> void:
+		section_label: String, area_folder: String = "") -> void:
 	_cells = cells
 	_current_pos = current_pos
 	_visited_cells = visited_cells
 	_section_label = section_label
+	_area_folder = area_folder
+
+	_room_shapes.clear()
+	for cell in _cells:
+		var stage_id := str(cell.get("stage_id", ""))
+		if stage_id.is_empty():
+			continue
+		_room_shapes[str(cell.get("pos", "0,0"))] = \
+			MinimapSvg.load_stage(stage_id, _area_folder)
 
 	_cell_lookup.clear()
 	_min_row = 999
@@ -185,9 +206,10 @@ func _draw() -> void:
 		if not _is_revealed(pos):
 			continue
 		var win := _window_rect(pos, sc)
-		var inset: float = 6.0 * sc
-		var fill := win.grow(-inset)
-		draw_rect(fill, CURRENT_COLOR if pos == _current_pos else VISITED_COLOR)
+		var fill_color := CURRENT_COLOR if pos == _current_pos else VISITED_COLOR
+		if not _draw_room_shape(cell, pos, win, fill_color, sc):
+			var inset: float = 6.0 * sc
+			draw_rect(win.grow(-inset), fill_color)
 
 		# Doors on each connected edge: green open / red locked
 		var connections: Dictionary = cell.get("connections", {})
@@ -207,6 +229,31 @@ func _draw() -> void:
 		if cell.get("is_start", false):
 			var c := win.get_center()
 			draw_arc(c, 16.0 * sc, 0.0, TAU, 20, RETURN_WARP_COLOR, 4.0 * sc)
+
+
+## Real room footprint: the stage minimap SVG's floor triangles, rotated by
+## the cell's rotation and fitted into the cell window (the full 0..400 SVG
+## viewBox maps onto the window, so room sizes stay comparable and gates land
+## on the edges their door notches mark). Returns false when the stage has no
+## parsed SVG so the caller keeps the plain-square fallback.
+func _draw_room_shape(cell: Dictionary, pos: String, win: Rect2,
+		fill_color: Color, sc: float) -> bool:
+	var shape: Dictionary = _room_shapes.get(pos, {})
+	var triangles: Array = shape.get("triangles", [])
+	if triangles.is_empty():
+		return false
+	var rotation_deg := int(cell.get("rotation", 0))
+	for tri in triangles:
+		var pts := PackedVector2Array()
+		for v in tri:
+			pts.append(MinimapSvg.svg_to_view(v, rotation_deg, win))
+		draw_polygon(pts, [fill_color])
+	for seg in shape.get("boundaries", []):
+		draw_line(
+			MinimapSvg.svg_to_view(seg[0], rotation_deg, win),
+			MinimapSvg.svg_to_view(seg[1], rotation_deg, win),
+			SHAPE_BOUNDARY_COLOR, 1.5 * sc)
+	return true
 
 
 ## Door / warp notch centered on one edge of a cell window. Warp markers are

--- a/scripts/3d/field/minimap_svg.gd
+++ b/scripts/3d/field/minimap_svg.gd
@@ -1,0 +1,213 @@
+class_name MinimapSvg
+extends RefCounted
+## Shared parser for the stage minimap SVGs baked by the web stage editor
+## (assets/stages/<area>_<variant>/<stage_id>/lndmd/<stage_id>_minimap.svg).
+##
+## Extracted from room_minimap.gd (which kept its own copy) so the area-map
+## overlay can draw each cell's real room footprint — the player-facing ask
+## that the map read as actual rooms instead of uniform squares. Same
+## string-matching approach as always: floor triangles from the
+## `fill="#2a2a4e"` path, boundary edges from the `stroke="white"` path, gate
+## rects from data-gate attributes, transform metadata from the root data-*.
+##
+## load_stage() caches per stage — a section's cells reuse a handful of stage
+## variants, so each SVG is read and parsed once per run. Stages without an
+## SVG (≈10 rooms ship none; CI runs without pack assets) cache an empty
+## result and callers fall back to their plain rendering.
+
+const STAGES_ROOT := "res://assets/stages"
+const VIEW_SIZE := 400.0  # every minimap SVG uses viewBox="0 0 400 400"
+
+const GridGenerator := preload("res://scripts/3d/field/grid_generator.gd")
+
+static var _cache: Dictionary = {}  # "stage_id|area_folder" → {triangles, boundaries}
+
+
+## Floor + boundary geometry for a stage, in SVG space (0..400, y down =
+## south). Empty arrays when the stage has no readable SVG.
+static func load_stage(stage_id: String, area_folder: String = "") -> Dictionary:
+	var key := "%s|%s" % [stage_id, area_folder]
+	if _cache.has(key):
+		return _cache[key]
+	var result := {"triangles": [], "boundaries": []}
+	var path := svg_path(stage_id, area_folder)
+	if not path.is_empty():
+		var file := FileAccess.open(path, FileAccess.READ)
+		if file:
+			var svg_text := file.get_as_text()
+			file.close()
+			result["triangles"] = parse_floor(svg_text)
+			result["boundaries"] = parse_boundaries(svg_text)
+	_cache[key] = result
+	return result
+
+
+## res:// path of a stage's minimap SVG. Subfolder derivation mirrors
+## valley_field_controller._get_stage_subfolder ("s01a_ga1" + "valley" →
+## "valley_a"); without an explicit folder the area is reverse-looked up from
+## the stage_id prefix. Empty string when the prefix is unknown.
+static func svg_path(stage_id: String, area_folder: String = "") -> String:
+	var folder := area_folder
+	if folder.is_empty():
+		folder = folder_for_prefix(stage_id.substr(0, 3))
+	if folder.is_empty():
+		return ""
+	var subfolder := folder
+	if stage_id.length() >= 4:
+		subfolder = "%s_%s" % [folder, stage_id[3]]
+	return "%s/%s/%s/lndmd/%s_minimap.svg" % [STAGES_ROOT, subfolder, stage_id, stage_id]
+
+
+static func folder_for_prefix(prefix: String) -> String:
+	for area_id in GridGenerator.AREA_CONFIG:
+		var cfg: Dictionary = GridGenerator.AREA_CONFIG[area_id]
+		if str(cfg.get("prefix", "")) == prefix:
+			return str(cfg.get("folder", ""))
+	return ""
+
+
+## Map SVG-space coordinates (0..400, y down) into a destination view rect,
+## rotating about the viewBox center by the cell's rotation first — the same
+## convention the room minimap's display transform always used, so a room's
+## gates stay glued to the edges its (relabeled) grid directions claim.
+static func svg_to_view(svg_pos: Vector2, rotation_deg: int, view: Rect2) -> Vector2:
+	var p := svg_pos
+	if rotation_deg != 0:
+		var center := Vector2(VIEW_SIZE * 0.5, VIEW_SIZE * 0.5)
+		p = (p - center).rotated(deg_to_rad(float(rotation_deg))) + center
+	return view.position + p * (view.size / VIEW_SIZE)
+
+
+# ── Parsing (all pure: SVG text in, geometry out) ────────────────────────────
+
+static func parse_metadata(svg_text: String) -> Dictionary:
+	## data-scale / data-offset-x / data-offset-y from the root <svg> line —
+	## the transform metadata the stage editor bakes for live markers.
+	var meta := {"scale": 0.0, "offset_x": 0.0, "offset_y": 0.0}
+	var first_line := ""
+	for line in svg_text.split("\n"):
+		if "<svg" in line:
+			first_line = line
+			break
+	if first_line.is_empty():
+		return meta
+	var scale_str := attr(first_line, "data-scale")
+	var off_x_str := attr(first_line, "data-offset-x")
+	var off_y_str := attr(first_line, "data-offset-y")
+	if not scale_str.is_empty():
+		meta["scale"] = float(scale_str)
+	if not off_x_str.is_empty():
+		meta["offset_x"] = float(off_x_str)
+	if not off_y_str.is_empty():
+		meta["offset_y"] = float(off_y_str)
+	return meta
+
+
+static func parse_floor(svg_text: String) -> Array:
+	var triangles: Array = []
+	for line in svg_text.split("\n"):
+		if 'fill="#2a2a4e"' not in line:
+			continue
+		var d := attr(line, "d")
+		if d.is_empty():
+			continue
+		for chunk in d.split(" Z "):
+			chunk = chunk.strip_edges()
+			if chunk.ends_with(" Z"):
+				chunk = chunk.substr(0, chunk.length() - 2)
+			if chunk.is_empty():
+				continue
+			var tri := parse_triangle(chunk)
+			if tri.size() == 3:
+				triangles.append(tri)
+	return triangles
+
+
+static func parse_boundaries(svg_text: String) -> Array:
+	var segments: Array = []
+	for line in svg_text.split("\n"):
+		if 'stroke="white"' not in line or 'fill="none"' not in line:
+			continue
+		var d := attr(line, "d")
+		if d.is_empty():
+			continue
+		for seg in d.split(" M "):
+			seg = seg.strip_edges()
+			if seg.begins_with("M "):
+				seg = seg.substr(2)
+			if seg.is_empty():
+				continue
+			var parts := seg.split(" L ")
+			if parts.size() == 2:
+				segments.append([
+					pt(parts[0].strip_edges()),
+					pt(parts[1].strip_edges()),
+				])
+	return segments
+
+
+static func parse_gates(svg_text: String) -> Array:
+	## Gate markers + their baked direction. Returns [{center: Vector2, dir: String}].
+	var gates: Array = []
+	for line in svg_text.split("\n"):
+		line = line.strip_edges()
+		# New format: <rect ... data-gate="true" data-gate-dir="south" .../>
+		if line.begins_with("<rect") and 'data-gate="true"' in line:
+			var x := float(attr(line, "x"))
+			var y := float(attr(line, "y"))
+			var w := float(attr(line, "width"))
+			var h := float(attr(line, "height"))
+			gates.append({
+				"center": Vector2(x + w * 0.5, y + h * 0.5),
+				"dir": attr(line, "data-gate-dir"),
+			})
+		# Legacy format: <polygon fill="#4a9eff" .../>
+		elif line.begins_with("<polygon") and 'fill="#4a9eff"' in line:
+			var ps := attr(line, "points")
+			if ps.is_empty():
+				continue
+			var sum := Vector2.ZERO
+			var n := 0
+			for p in ps.strip_edges().split(" "):
+				p = p.strip_edges()
+				if p.is_empty():
+					continue
+				var xy := p.split(",")
+				if xy.size() == 2:
+					sum += Vector2(float(xy[0]), float(xy[1]))
+					n += 1
+			if n > 0:
+				gates.append({"center": sum / float(n), "dir": ""})
+	return gates
+
+
+# ── Token helpers ────────────────────────────────────────────────────────────
+
+static func attr(line: String, attr_name: String) -> String:
+	var key := attr_name + '="'
+	var idx := line.find(key)
+	if idx < 0:
+		return ""
+	var start := idx + key.length()
+	var end_idx := line.find('"', start)
+	if end_idx < 0:
+		return ""
+	return line.substr(start, end_idx - start)
+
+
+static func pt(s: String) -> Vector2:
+	var parts := s.split(",")
+	if parts.size() >= 2:
+		return Vector2(float(parts[0].strip_edges()), float(parts[1].strip_edges()))
+	return Vector2.ZERO
+
+
+static func parse_triangle(chunk: String) -> PackedVector2Array:
+	var verts := PackedVector2Array()
+	for tok in chunk.split(" "):
+		tok = tok.strip_edges()
+		if "," in tok:
+			verts.append(pt(tok))
+	if verts.size() >= 3:
+		return PackedVector2Array([verts[0], verts[1], verts[2]])
+	return PackedVector2Array()

--- a/scripts/3d/field/minimap_svg.gd.uid
+++ b/scripts/3d/field/minimap_svg.gd.uid
@@ -1,0 +1,1 @@
+uid://cvs14lwkovcuu

--- a/scripts/3d/field/room_minimap.gd
+++ b/scripts/3d/field/room_minimap.gd
@@ -4,7 +4,8 @@ extends Control
 ## via _draw().  Added as a child of the MapOverlay CanvasLayer.
 ##
 ## Uses embedded metadata from SVG (data-scale, data-offset-x/y) for player
-## position tracking, matching the web PreviewMinimap approach.
+## position tracking, matching the web PreviewMinimap approach. The SVG
+## parsing itself lives in MinimapSvg, shared with the area-map overlay.
 
 # Frame sprite (map.png) — committed in-repo under assets/ui/, so it ships with
 # the binary rather than the asset pack (no pck republish to iterate on it). The
@@ -89,8 +90,7 @@ func setup(stage_id: String, area_folder: String, portal_data: Dictionary,
 	offset_bottom = 12 + total_h
 
 	# Load SVG text (not as texture — we need to parse geometry)
-	var subfolder: String = "%s_%s" % [area_folder, stage_id[3]] if stage_id.length() >= 4 else area_folder
-	var svg_path := "res://assets/stages/%s/%s/lndmd/%s_minimap.svg" % [subfolder, stage_id, stage_id]
+	var svg_path := MinimapSvg.svg_path(stage_id, area_folder)
 	var file := FileAccess.open(svg_path, FileAccess.READ)
 	if not file:
 		push_warning("[RoomMinimap] Could not open SVG: %s (error=%d)" % [svg_path, FileAccess.get_open_error()])
@@ -98,15 +98,18 @@ func setup(stage_id: String, area_folder: String, portal_data: Dictionary,
 	var svg_text := file.get_as_text()
 	file.close()
 
-	# Parse geometry
-	_parse_floor(svg_text)
-	_parse_boundaries(svg_text)
+	# Parse geometry (shared parser — the area-map overlay reads the same SVGs)
+	_floor_triangles = MinimapSvg.parse_floor(svg_text)
+	_boundary_lines = MinimapSvg.parse_boundaries(svg_text)
 
 	# Parse embedded transform metadata
-	_parse_embedded_metadata(svg_text)
+	var meta := MinimapSvg.parse_metadata(svg_text)
+	_svg_scale = meta["scale"]
+	_svg_offset_x = meta["offset_x"]
+	_svg_offset_y = meta["offset_y"]
 
 	# Parse gates with their baked direction (data-gate-dir attribute)
-	var svg_gates := _parse_gates_with_dirs(svg_text)
+	var svg_gates := MinimapSvg.parse_gates(svg_text)
 
 	print("[RoomMinimap] stage=%s  svg_gates=%d  scale=%.2f  offset=(%.1f, %.1f)  rot=%d" % [
 		stage_id, svg_gates.size(), _svg_scale, _svg_offset_x, _svg_offset_y, _rotation_deg])
@@ -322,112 +325,8 @@ func update_keys(collected: int, _total: int) -> void:
 func _svg_to_display(svg_pos: Vector2) -> Vector2:
 	## Apply cell rotation and scale SVG coordinates to display size.
 	## SVG Y already increases downward (north=top), matching display space.
-	var pos := Vector2(svg_pos.x, svg_pos.y)
-	if _rotation_deg != 0:
-		var center := Vector2(200.0, 200.0)
-		pos = (pos - center).rotated(deg_to_rad(float(_rotation_deg))) + center
-	return pos * (DISPLAY_SIZE / 400.0)
-
-
-# ── SVG parsing ─────────────────────────────────────────────────────────────
-
-func _parse_embedded_metadata(svg_text: String) -> void:
-	## Parse data-scale, data-offset-x, data-offset-y from SVG root element.
-	## These are baked by the stage editor's SVG exporter.
-	var first_line := ""
-	for line in svg_text.split("\n"):
-		if "<svg" in line:
-			first_line = line
-			break
-	if first_line.is_empty():
-		return
-
-	var scale_str := _attr(first_line, "data-scale")
-	var off_x_str := _attr(first_line, "data-offset-x")
-	var off_y_str := _attr(first_line, "data-offset-y")
-
-	if not scale_str.is_empty():
-		_svg_scale = float(scale_str)
-	if not off_x_str.is_empty():
-		_svg_offset_x = float(off_x_str)
-	if not off_y_str.is_empty():
-		_svg_offset_y = float(off_y_str)
-
-
-func _parse_floor(svg_text: String) -> void:
-	for line in svg_text.split("\n"):
-		if 'fill="#2a2a4e"' not in line:
-			continue
-		var d := _attr(line, "d")
-		if d.is_empty():
-			continue
-		for chunk in d.split(" Z "):
-			chunk = chunk.strip_edges()
-			if chunk.ends_with(" Z"):
-				chunk = chunk.substr(0, chunk.length() - 2)
-			if chunk.is_empty():
-				continue
-			var tri := _parse_triangle(chunk)
-			if tri.size() == 3:
-				_floor_triangles.append(tri)
-
-
-func _parse_boundaries(svg_text: String) -> void:
-	for line in svg_text.split("\n"):
-		if 'stroke="white"' not in line or 'fill="none"' not in line:
-			continue
-		var d := _attr(line, "d")
-		if d.is_empty():
-			continue
-		for seg in d.split(" M "):
-			seg = seg.strip_edges()
-			if seg.begins_with("M "):
-				seg = seg.substr(2)
-			if seg.is_empty():
-				continue
-			var parts := seg.split(" L ")
-			if parts.size() == 2:
-				_boundary_lines.append([
-					_pt(parts[0].strip_edges()),
-					_pt(parts[1].strip_edges()),
-				])
-
-
-func _parse_gates_with_dirs(svg_text: String) -> Array:
-	## Parse gate markers and their baked direction from data-gate-dir attribute.
-	## Returns Array of {center: Vector2, dir: String}.
-	var gates: Array = []
-	for line in svg_text.split("\n"):
-		line = line.strip_edges()
-		# New format: <rect ... data-gate="true" data-gate-dir="south" .../>
-		if line.begins_with("<rect") and 'data-gate="true"' in line:
-			var x := float(_attr(line, "x"))
-			var y := float(_attr(line, "y"))
-			var w := float(_attr(line, "width"))
-			var h := float(_attr(line, "height"))
-			var gate_dir := _attr(line, "data-gate-dir")
-			gates.append({
-				"center": Vector2(x + w * 0.5, y + h * 0.5),
-				"dir": gate_dir,
-			})
-		# Legacy format: <polygon fill="#4a9eff" .../>
-		elif line.begins_with("<polygon") and 'fill="#4a9eff"' in line:
-			var ps := _attr(line, "points")
-			if ps.is_empty():
-				continue
-			var sum := Vector2.ZERO
-			var n := 0
-			for pt in ps.strip_edges().split(" "):
-				pt = pt.strip_edges()
-				if pt.is_empty():
-					continue
-				var xy := pt.split(",")
-				if xy.size() == 2:
-					sum += Vector2(float(xy[0]), float(xy[1]))
-					n += 1
-			if n > 0:
-				gates.append({"center": sum / float(n), "dir": ""})
-	return gates
+	return MinimapSvg.svg_to_view(svg_pos, _rotation_deg,
+		Rect2(Vector2.ZERO, Vector2.ONE * DISPLAY_SIZE))
 
 
 # ── Gate entries ─────────────────────────────────────────────────────────────
@@ -467,35 +366,3 @@ func _build_gate_entries(svg_gates: Array, connections: Dictionary,
 		_gate_entries.append({"center": svg_center, "color": color, "label": label, "dir": grid_dir})
 		if not grid_dir.is_empty():
 			_gate_dir_index[grid_dir] = _gate_entries.size() - 1
-
-
-# ── Helpers ──────────────────────────────────────────────────────────────────
-
-func _attr(line: String, attr_name: String) -> String:
-	var key := attr_name + '="'
-	var idx := line.find(key)
-	if idx < 0:
-		return ""
-	var start := idx + key.length()
-	var end_idx := line.find('"', start)
-	if end_idx < 0:
-		return ""
-	return line.substr(start, end_idx - start)
-
-
-func _pt(s: String) -> Vector2:
-	var parts := s.split(",")
-	if parts.size() >= 2:
-		return Vector2(float(parts[0].strip_edges()), float(parts[1].strip_edges()))
-	return Vector2.ZERO
-
-
-func _parse_triangle(chunk: String) -> PackedVector2Array:
-	var verts := PackedVector2Array()
-	for tok in chunk.split(" "):
-		tok = tok.strip_edges()
-		if "," in tok:
-			verts.append(_pt(tok))
-	if verts.size() >= 3:
-		return PackedVector2Array([verts[0], verts[1], verts[2]])
-	return PackedVector2Array()

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -527,7 +527,7 @@ func _ready() -> void:
 	_area_map_panel = AreaMapOverlayScript.new()
 	_map_overlay.add_child(_area_map_panel)
 	_area_map_panel.setup(cells, str(_current_cell.get("pos", "")),
-		_visited_cells, "Section %d" % (section_idx + 1))
+		_visited_cells, "Section %d" % (section_idx + 1), str(area_cfg["folder"]))
 
 	# Per-scene field HUD (minimap host, palette, log, FPS). The HP/PP/Lv stats
 	# panel is NOT rebuilt here — it persists on the HudStats autoload (#444).

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -43,6 +43,7 @@ func _run_tests_combat() -> void:
 	test_damaging_frame()
 	test_target_info_panel()
 	test_area_map_overlay()
+	test_area_map_room_shapes()
 	test_element_status()
 	test_enemy_attack_recovery()
 	test_enemy_attack_clip_resolution()
@@ -8369,6 +8370,55 @@ func test_area_map_overlay() -> void:
 	assert_eq(str(map._gate_states.get("0,0>east", "")), "locked", "set_gate_state locks a door")
 	map.set_gate_state("0,0", "east", "open")
 	assert_eq(str(map._gate_states.get("0,0>east", "")), "open", "set_gate_state reopens it")
+	map.free()
+	print("")
+
+
+# ── Area map room shapes: per-cell SVG footprints (player request) ──
+# The map should read as actual rooms, not uniform squares: revealed cells
+# draw their stage's minimap-SVG floor outline, rotated per cell. The
+# parsing lives in MinimapSvg (extracted from room_minimap so both maps
+# share it — and so the near-dup ratchet keeps it that way). Seeded inline
+# SVG: CI runs without pack assets, so nothing here touches res://assets.
+func test_area_map_room_shapes() -> void:
+	print("── Area map room shapes (SVG footprints, shared parser) ──")
+	var svg := "<svg viewBox=\"0 0 400 400\" data-scale=\"15.5\" data-offset-x=\"1.5\" data-offset-y=\"-2.5\">\n<path fill=\"#2a2a4e\" d=\"M 10,20 L 30,20 L 10,60 Z M 100,100 L 140,100 L 100,160 Z\"/>\n<path fill=\"none\" stroke=\"white\" stroke-width=\"2\" d=\"M 10,20 L 30,20 M 5,5 L 9,9\"/>\n<rect x=\"123.2\" y=\"272.9\" width=\"48\" height=\"8\" fill=\"#ff4444\" data-gate=\"true\" data-gate-dir=\"south\"/>\n</svg>\n"
+	var tris: Array = MinimapSvg.parse_floor(svg)
+	assert_eq(tris.size(), 2, "floor path parses into its two triangles")
+	var first: PackedVector2Array = tris[0]
+	assert_eq(first.size(), 3, "each floor chunk is a 3-vertex triangle")
+	assert_true(Vector2(first[0]).is_equal_approx(Vector2(10, 20)),
+		"triangle verts parse from the path d")
+	var bounds: Array = MinimapSvg.parse_boundaries(svg)
+	assert_eq(bounds.size(), 2, "boundary path parses into its two segments")
+	var meta: Dictionary = MinimapSvg.parse_metadata(svg)
+	assert_true(is_equal_approx(float(meta["scale"]), 15.5), "data-scale parses")
+	assert_true(is_equal_approx(float(meta["offset_y"]), -2.5), "data-offset-y parses")
+	var gates: Array = MinimapSvg.parse_gates(svg)
+	assert_eq(gates.size(), 1, "data-gate rect parses")
+	assert_eq(str(gates[0]["dir"]), "south", "gate direction comes from data-gate-dir")
+	assert_true(Vector2(gates[0]["center"]).is_equal_approx(Vector2(147.2, 276.9)),
+		"gate center is the rect midpoint")
+	# View transform: unrotated SVG fills the window; rotation mirrors the CW
+	# label swap StageRotation applies to directions (north edge → east edge).
+	var win := Rect2(139.0, 219.0, 107.0, 107.0)
+	assert_true(MinimapSvg.svg_to_view(Vector2(0, 0), 0, win).is_equal_approx(win.position),
+		"unrotated SVG origin lands on the window corner")
+	var east_mid := Vector2(win.position.x + win.size.x, win.position.y + win.size.y * 0.5)
+	assert_true(MinimapSvg.svg_to_view(Vector2(200, 0), 90, win).is_equal_approx(east_mid),
+		"90° rotation maps the north edge onto the east edge")
+	# Overlay fallback: a cell whose stage has no SVG (bogus id) caches an
+	# empty shape and keeps the square; a cell without stage_id requests none.
+	const OverlayScript := preload("res://scripts/3d/field/area_map_overlay.gd")
+	var map = OverlayScript.new()
+	var cells: Array = [
+		{"pos": "0,0", "stage_id": "s01z_zz9", "rotation": 90, "connections": {"east": "0,1"}},
+		{"pos": "0,1", "connections": {"west": "0,0"}},
+	]
+	map.setup(cells, "0,0", {"0,0": true}, "Section 1", "valley")
+	assert_true((map._room_shapes["0,0"] as Dictionary).get("triangles", []).is_empty(),
+		"stage without an SVG caches an empty shape → square fallback")
+	assert_true(not map._room_shapes.has("0,1"), "cell without stage_id requests no shape")
 	map.free()
 	print("")
 

--- a/spec/src/pages/states/area-map.astro
+++ b/spec/src/pages/states/area-map.astro
@@ -22,6 +22,7 @@ import Concept from '../../layouts/Concept.astro';
   <h2>Fog of war</h2>
   <ul>
     <li>A cell MUST render only once the player has <strong>visited</strong> it (<code>_visited_cells</code>); unexplored cells stay dark windows — the map fills in as the player explores.</li>
+    <li>A revealed cell draws its <strong>room footprint</strong> — the actual floor shape from the stage's minimap SVG (<code>lndmd/&lt;stage&gt;_minimap.svg</code>, parsed by the shared <code>MinimapSvg</code> reader), rotated by the cell's rotation and fitted into the cell window so the grid reads as real rooms, not uniform squares (player request). Rooms relative sizes stay true to their SVGs, so gates land on the edges their door markers occupy. A stage without an SVG (≈10 rooms, or a packless CI run) SHOULD fall back to the plain square.</li>
     <li>A revealed cell draws its <strong>doors</strong> per state: green = open, red = locked (key gates, enemy locks, pending objectives — the same gate-state feed the room minimap uses).</li>
     <li>The <strong>start cell</strong> carries the return-warp marker (cyan ring — the warp back to the city); the section's <strong>exit edge</strong> (<code>warp_edge</code>) carries the area-warp marker (blue, locked-red while objectives are pending) to the next grid.</li>
     <li>The current cell is highlighted (bright green).</li>
@@ -32,8 +33,9 @@ import Concept from '../../layouts/Concept.astro';
 
   <h2>Implemented by</h2>
   <ul>
-    <li><code>scripts/3d/field/area_map_overlay.gd</code> — the overlay Control (layout, fog of war, doors/warps; sprite or procedural backdrop).</li>
-    <li><code>scripts/3d/field/valley_field_controller.gd</code> — mounts it in the <code>MapOverlay</code> CanvasLayer, feeds <code>setup(cells, current, visited, label)</code> per cell load and <code>set_gate_state</code> on gate changes, handles the <code>area_map</code> action.</li>
+    <li><code>scripts/3d/field/area_map_overlay.gd</code> — the overlay Control (layout, fog of war, room footprints, doors/warps; sprite or procedural backdrop).</li>
+    <li><code>scripts/3d/field/minimap_svg.gd</code> — shared minimap-SVG parser (floor triangles, boundaries, gates, transform metadata) used by both the area map and the room minimap.</li>
+    <li><code>scripts/3d/field/valley_field_controller.gd</code> — mounts it in the <code>MapOverlay</code> CanvasLayer, feeds <code>setup(cells, current, visited, label, area_folder)</code> per cell load and <code>set_gate_state</code> on gate changes, handles the <code>area_map</code> action.</li>
     <li><code>project.godot</code> — the <code>area_map</code> input action; <code>scripts/config/debug_config.gd</code> — <code>reveal_map</code>.</li>
   </ul>
 


### PR DESCRIPTION
## Why

Players asked for the field/mission map to feel more expansive: it only showed uniform squares with door open/locked notches, so every room looked identical. The actual room geometry already exists — each stage ships a `lndmd/<stage>_minimap.svg` floor outline that the room minimap parses — the area map just wasn't using it.

## What

- **Room footprints on the area map**: a revealed cell draws its stage's real floor shape (triangles + faint boundary edges from the minimap SVG), rotated by the cell's rotation and fitted into the 107px cell window. Full 0–400 viewBox → window, so relative room sizes stay true and gates land on the edges their door notches occupy. Visited/current fill colors and all door/warp markers are unchanged.
- **Shared parser**: the SVG parsing moved out of `room_minimap.gd` into a new static `MinimapSvg` reader (cached per stage — a section reuses a handful of stage variants). Both maps now share one parser, which also keeps the code-graph near-dup ratchet honest.
- **Fallback**: stages without an SVG (≈10 rooms, and CI's packless runs) keep the plain-square rendering; missing files cache an empty result so repeat setups don't re-hit the disk.
- **Wiring**: the field controller passes the area folder into the overlay's `setup()`; without it the folder is derived from the stage-id prefix (`s086…` → `tower`).
- **Test**: `test_area_map_room_shapes` (seeded inline SVG — no pack dependency) pins parsing, the rotation/view transform (north edge → east edge under 90°, matching the `StageRotation` label swap), and the square fallback. Spec `/states/area-map` updated.

## Verification

- `test_runner.tscn`: 3047 passed, 0 failed, no warnings-as-errors.
- `test_field_layout.tscn`: 36 passed, 0 failed.
- `check_asset_refs` / `orphan_files --check` / `code_graph --check`: clean, no new debt.
- Live playtest on real hardware (kion): field run through four valley rooms — map shapes render, refactored room minimap parity confirmed (gates/rotations correct in the log), clean exit.