### PR TITLE
Cleanup: debug quests out of the guild list, gate id labels behind a Debug toggle

### DIFF
--- a/scripts/2d/guild_counter.gd
+++ b/scripts/2d/guild_counter.gd
@@ -114,6 +114,11 @@ func _load_entries() -> void:
 	for qid in quest_ids:
 		if qid == "hello_quest" or qid == "manifest":
 			continue
+		# Debug boss/arena quests are the Coliseum Master's job (launched via
+		# SessionManager.enter_quest from coliseum_pick) — keep the quest files
+		# out of the player-facing guild list.
+		if qid.begins_with("debug_"):
+			continue
 		var quest := QuestLoader.load_quest(qid)
 		if quest.is_empty():
 			continue

--- a/scripts/3d/field/portal_gate_manager.gd
+++ b/scripts/3d/field/portal_gate_manager.gd
@@ -320,6 +320,7 @@ func _create_fallback_trigger(trigger_name: String, pos: Vector3, callback: Call
 
 
 ## DEBUG: Add a floating 3D text label at gate position showing compass label + target cell.
+## Hidden unless DebugConfig.show_gate_labels is on (start menu → Debug).
 ## Also adds colored sphere markers for gate (yellow), spawn (green), and trigger (red).
 func _add_gate_label(direction: String, pos: Vector3, target_cell: String, portal_id: String = "") -> void:
 	var label := Label3D.new()
@@ -342,8 +343,12 @@ func _add_gate_label(direction: String, pos: Vector3, target_cell: String, porta
 	label.modulate = Color(1, 1, 0, 1)  # Bright yellow
 	label.outline_modulate = Color(0, 0, 0, 1)
 	label.outline_size = 8
+	label.visible = DebugConfig.show_gate_labels
 	_c.add_child(label)
 	label.global_position = Vector3(pos.x, 3.5, pos.z)
+	# Tracked so _sync_debug_config can flip labels when the start-menu
+	# toggle changes mid-session (same pattern as the gate-dot spheres).
+	_c._debug_gate_labels.append(label)
 
 	# DEBUG: Sphere markers — gate=yellow, spawn=green, trigger=red
 	var clean_dir: String = direction.split(" ")[0]  # Strip "(EXIT)" suffix

--- a/scripts/3d/field/pso_start_menu.gd
+++ b/scripts/3d/field/pso_start_menu.gd
@@ -604,6 +604,7 @@ func _get_debug_list() -> Array:
 		"Unlock All Missions",
 		"Floor Collision: %s" % (on if DebugConfig.show_floor_collision else off),
 		"Gate Dots: %s" % (on if DebugConfig.show_gate_dots else off),
+		"Gate Labels: %s" % (on if DebugConfig.show_gate_labels else off),
 		"Hitboxes: %s" % (on if DebugConfig.show_hitboxes else off),
 		"Combo Timing: %s" % (on if DebugConfig.show_combo_timing else off),
 		"Time + Room: %s" % (on if DebugConfig.show_time_room else off),
@@ -662,20 +663,21 @@ func _toggle_debug(idx: int) -> void:
 			_debug_msg = "Unlocked all missions (%d newly cleared)." % n
 		1: DebugConfig.show_floor_collision = not DebugConfig.show_floor_collision
 		2: DebugConfig.show_gate_dots = not DebugConfig.show_gate_dots
-		3: DebugConfig.show_hitboxes = not DebugConfig.show_hitboxes
-		4: DebugConfig.show_combo_timing = not DebugConfig.show_combo_timing
-		5:
+		3: DebugConfig.show_gate_labels = not DebugConfig.show_gate_labels
+		4: DebugConfig.show_hitboxes = not DebugConfig.show_hitboxes
+		5: DebugConfig.show_combo_timing = not DebugConfig.show_combo_timing
+		6:
 			DebugConfig.show_time_room = not DebugConfig.show_time_room
 			TimeManager.show_hud(DebugConfig.show_time_room)
-		6:
-			DebugConfig.profile_frames = not DebugConfig.profile_frames
 		7:
-			DebugConfig.show_player_position = not DebugConfig.show_player_position
+			DebugConfig.profile_frames = not DebugConfig.profile_frames
 		8:
-			DebugConfig.equip_all = not DebugConfig.equip_all
+			DebugConfig.show_player_position = not DebugConfig.show_player_position
 		9:
-			DebugConfig.reveal_map = not DebugConfig.reveal_map
+			DebugConfig.equip_all = not DebugConfig.equip_all
 		10:
+			DebugConfig.reveal_map = not DebugConfig.reveal_map
+		11:
 			DebugConfig.unlock_all_areas = not DebugConfig.unlock_all_areas
 			_debug_msg = (
 				"Every field listed in the city warp."

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -123,6 +123,7 @@ var _debug_spawn_meshes: Array = []
 var _debug_all_collision_meshes: Array = []
 var _debug_floor_viz: MeshInstance3D       # DebugFloorViz green overlay
 var _debug_gate_spheres: Array = []        # GateMark/SpawnMark/TriggerMark spheres
+var _debug_gate_labels: Array = []         # GateLabel_* floating id/target labels
 var _debug_panel: PanelContainer
 
 ## Cell-object spawning + save/restore, extracted into its own module.
@@ -2304,6 +2305,10 @@ func _sync_debug_config() -> void:
 	for m in _debug_gate_spheres:
 		if is_instance_valid(m) and m.visible != DebugConfig.show_gate_dots:
 			m.visible = DebugConfig.show_gate_dots
+	# Floating gate id/target labels (GateLabel_*)
+	for l in _debug_gate_labels:
+		if is_instance_valid(l) and l.visible != DebugConfig.show_gate_labels:
+			l.visible = DebugConfig.show_gate_labels
 
 
 func _build_all_collision_debug() -> void:

--- a/scripts/config/debug_config.gd
+++ b/scripts/config/debug_config.gd
@@ -3,6 +3,9 @@ class_name DebugConfig
 
 static var show_floor_collision := false
 static var show_gate_dots := false
+# Floating label above each gate showing its portal id + target cell. Off by
+# default; toggle in the start menu's Debug submenu (pairs with show_gate_dots).
+static var show_gate_labels := false
 static var show_time_room := false
 static var show_hitboxes := false
 static var show_combo_timing := false  # Show rhythm combo window indicator


### PR DESCRIPTION
Two pieces of tester-facing cleanup. Nothing here changes gameplay balance or quest data — it's about who owns boss-testing and what's on screen by default.

## Why

**Boss-testing moved to the Coliseum (#629), but the guild counter kept listing the plumbing.** The ten `DEBUG: *` arena quests and the coliseum shell quest still showed in the player-facing quest list because `_load_entries()` only skipped two sentinel ids. The Coliseum Master launches those same `debug_*` files directly via `SessionManager.enter_quest` (and `coliseum_roster` scans them for its boss→arena mapping), so the quest JSONs and their manifest entries stay — only the guild list filters them out (`debug_` prefix skip). The autopilot is unaffected: it scrolls to real-quest positions, and the debug entries sit at the manifest's end.

**Every gate rendered an always-on floating label** (compass letter + portal-id suffix + target cell). That's authoring diagnostics, not player UI — it now defaults OFF behind `DebugConfig.show_gate_labels`, exposed as a "Gate Labels" row in the start menu's System → Debug submenu (under Gate Dots). Labels are tracked in `_debug_gate_labels` and flipped by the existing per-frame `_sync_debug_config()`, so toggling applies to already-loaded cells immediately — same pattern as the gate-dot spheres.

## Verification

- Full headless test runner: **3047 passed, 0 failed** (includes the 187-script parse smoke test; `test_coliseum_debug_quest` / `test_debug_unlock_all_missions` still green).
- Manual round in a live session: guild counter list ends at the real quests, gate labels off by default and toggleable mid-field.