### PR TITLE
Generated fields: restore backward section warps (backtracking regression)

### DIFF
--- a/scripts/3d/field/grid_generator.gd
+++ b/scripts/3d/field/grid_generator.gd
@@ -371,9 +371,12 @@ func generate_field(difficulty: String, area_id: String = "gurhacia") -> Diction
 
 	# Section 1: Area A grid
 	var a_result: Dictionary = generate("a", params["a"], prefix)
+	var a_dirs: Dictionary = _section_warp_dirs(a_result["cells"])
 	sections.append({
 		"type": "grid", "area": "a", "cells": a_result["cells"],
 		"start_pos": a_result["start_pos"], "end_pos": a_result.get("end_pos", ""),
+		"entry_direction": a_dirs["entry_direction"],
+		"exit_direction": a_dirs["exit_direction"],
 	})
 
 	# Section 2: Area E transition (single room)
@@ -388,17 +391,26 @@ func generate_field(difficulty: String, area_id: String = "gurhacia") -> Diction
 	# "south" here meant arriving at the north door and walking back out south,
 	# i.e. through the corridor backwards — which is what kion hit in play.
 	e_cell["warp_edge"] = "north"
+	# The arrival door is the way back to area A — same shape as a b-section
+	# start's entry_warp_edge, which is what _section_warp_dirs reads to emit the
+	# section's entry_direction. Without it the south portal is geometry only:
+	# the runtime builds no backward warp for it (the backtracking regression).
+	e_cell["entry_warp_edge"] = "south"
 	e_cell["objects"] = FieldPopulation.objects_for_single_room(e_stage, _rng)
 	sections.append({
 		"type": "transition", "area": "e", "cells": [e_cell],
 		"start_pos": "0,0", "end_pos": "0,0",
+		"entry_direction": "south", "exit_direction": "north",
 	})
 
 	# Section 3: Area B grid
 	var b_result: Dictionary = generate("b", params["b"], prefix)
+	var b_dirs: Dictionary = _section_warp_dirs(b_result["cells"])
 	sections.append({
 		"type": "grid", "area": "b", "cells": b_result["cells"],
 		"start_pos": b_result["start_pos"], "end_pos": b_result.get("end_pos", ""),
+		"entry_direction": b_dirs["entry_direction"],
+		"exit_direction": b_dirs["exit_direction"],
 	})
 
 	# Section 4: Area Z boss arena (single room)
@@ -418,6 +430,29 @@ func generate_field(difficulty: String, area_id: String = "gurhacia") -> Diction
 	})
 
 	return {"sections": sections}
+
+
+## Section-level warp metadata for the runtime's area-warp classification
+## (valley_field_controller._spawn_field_elements reads entry_direction /
+## exit_direction off the section dict). `entry_direction` is the start room's
+## way-back door — the portal the player materialises at when warping in — and
+## `exit_direction` is the end room's forward warp edge. Static field files
+## (data/field_quests/*.json) have carried these since backtracking shipped
+## (#202's section selector); generated fields dropped them when free fields
+## switched from static JSON to this generator's output, which left every
+## backward door — the b-start's way back, the transition room's south door —
+## as geometry with no warp node and no trigger behind it. The boss section
+## gets neither (its way out is the final exit / boss-clear telepipe), matching
+## the static files.
+func _section_warp_dirs(cells: Array) -> Dictionary:
+	var entry := ""
+	var exit := ""
+	for c in cells:
+		if c.get("is_start", false):
+			entry = str(c.get("entry_warp_edge", ""))
+		if c.get("is_end", false):
+			exit = str(c.get("warp_edge", ""))
+	return {"entry_direction": entry, "exit_direction": exit}
 
 
 ## Generate a linear tower field: entrance → floor rooms → transition → floor rooms → boss.

--- a/scripts/3d/field/valley_field_controller.gd
+++ b/scripts/3d/field/valley_field_controller.gd
@@ -1107,12 +1107,6 @@ func _spawn_field_elements() -> void:
 	var entry_dir: String = str(current_section_data.get("entry_direction", ""))
 	var exit_dir: String = str(current_section_data.get("exit_direction", ""))
 	var room_has_enemies: bool = _cell_has_enemies(_current_cell)
-
-	# entry_direction is only meaningful at the section's start cell — that's
-	# where the player materialises. At any other cell (including the end cell
-	# where warp_edge lives), the same direction might collide with a
-	# warp_edge or exit_dir and mis-classify the portal as a backward entry.
-	# Restricting is_entry to the start cell prevents that collision.
 	var is_start_cell: bool = bool(_current_cell.get("is_start", false))
 
 	for portal_dir in _portal_data:
@@ -1121,26 +1115,26 @@ func _spawn_field_elements() -> void:
 		if connections.has(portal_dir):
 			continue  # Has a connection — handled by gate logic above
 
-		# Determine warp target based on direction
+		# Determine warp target based on direction (area_warp_kind owns the
+		# classification rules — see its doc comment).
+		var warp_kind: int = area_warp_kind(portal_dir, entry_dir, exit_dir,
+			warp_edge, is_start_cell, section_idx_for_warp, sections_for_warp.size())
+		if warp_kind == WARP_NONE:
+			continue  # No valid target — skip
+
 		var target_section := 0
 		var target_cell := ""
-		var is_entry: bool = is_start_cell and (portal_dir == entry_dir)
-		var is_exit: bool = (portal_dir == warp_edge or portal_dir == exit_dir) and not is_entry
-
-		var is_final_exit: bool = false
-		if is_exit and section_idx_for_warp + 1 < sections_for_warp.size():
+		var is_entry: bool = warp_kind == WARP_ENTRY
+		var is_exit: bool = warp_kind == WARP_EXIT or warp_kind == WARP_FINAL_EXIT
+		var is_final_exit: bool = warp_kind == WARP_FINAL_EXIT
+		if is_exit and not is_final_exit:
 			var next_sec: Dictionary = sections_for_warp[section_idx_for_warp + 1]
 			target_section = section_idx_for_warp + 1
 			target_cell = str(next_sec.get("start_pos", ""))
-		elif is_exit:
-			# Last section — exit returns to city
-			is_final_exit = true
-		elif is_entry and section_idx_for_warp > 0:
+		elif is_entry:
 			var prev_sec: Dictionary = sections_for_warp[section_idx_for_warp - 1]
 			target_section = section_idx_for_warp - 1
 			target_cell = str(prev_sec.get("end_pos", ""))
-		else:
-			continue  # No valid target — skip
 
 		var pd: Dictionary = _portal_data[portal_dir]
 		var aw_gate_pos: Vector3 = pd.get("gate_pos", pd["trigger_pos"])
@@ -1732,6 +1726,30 @@ func _wire_fence_links() -> void:
 ## behaviour they had: a gate on every connection, key gates where the legacy
 ## `is_key_gate` / `key_gate_direction` fields say so.
 enum { GATE_NONE, GATE_KEY, GATE_ENEMY_DEFEAT }
+
+## Which section transition (if any) an UNCONNECTED portal represents — the
+## classifier behind the area-warp loop in _spawn_field_elements. Sections
+## carry entry_direction (the start cell's way-back door, where the player
+## materialises on warp-in) and exit_direction (the end cell's forward warp
+## edge); static field files have always had them, and generated fields emit
+## the same keys via grid_generator._section_warp_dirs. Before the generated
+## fields did, every backward door classified as WARP_NONE: portal geometry
+## with no warp and no trigger, which is how backtracking regressed.
+enum { WARP_NONE, WARP_ENTRY, WARP_EXIT, WARP_FINAL_EXIT }
+
+## entry_direction only classifies at the section's START cell — that is where
+## the player materialises. At any other cell (including the end cell where
+## warp_edge lives), the same direction might collide with a warp_edge or
+## exit_direction and mis-classify the portal as a backward entry. The first
+## section has nothing to warp back to, so its start's off-grid door is inert.
+static func area_warp_kind(portal_dir: String, entry_dir: String, exit_dir: String,
+		warp_edge: String, is_start_cell: bool, section_idx: int,
+		section_count: int) -> int:
+	if is_start_cell and portal_dir == entry_dir:
+		return WARP_ENTRY if section_idx > 0 else WARP_NONE
+	if portal_dir == warp_edge or portal_dir == exit_dir:
+		return WARP_EXIT if section_idx + 1 < section_count else WARP_FINAL_EXIT
+	return WARP_NONE
 
 static func gate_kind_for_door(attrs: Dictionary, dir: String, spawn_edge: String,
 		legacy_is_key_gate: bool, legacy_key_dirs: Array) -> int:

--- a/scripts/tools/test_runner.gd
+++ b/scripts/tools/test_runner.gd
@@ -130,6 +130,7 @@ func _run_tests_core() -> void:
 	test_authored_walls_clear_doorways()
 	test_authored_fences_are_openable()
 	test_gate_kind_per_door()
+	test_area_warp_classification()
 	test_group_five_trap_roll()
 	test_enemies_stand_on_authored_slots()
 	test_keys_stand_on_authored_slots()
@@ -142,6 +143,7 @@ func _run_tests_core() -> void:
 	test_city_scroll_fixes()
 	test_area_objects()
 	test_generated_field_doors()
+	test_generated_section_warp_directions()
 	test_equipment_slot_names()
 	test_material_system()
 	test_set_bonuses()
@@ -644,6 +646,67 @@ func _portal_backed(configs: Dictionary, stage_id: String, rotation: int, game_d
 	return false
 
 
+## Generated sections carry the warp metadata the runtime's area-warp loop
+## classifies by (spec /states/field-lifecycle "Area gates are two-way").
+## Static field files have had entry_direction/exit_direction since #202;
+## generated fields dropped them when free fields switched from static JSON,
+## which left every backward door as geometry with no warp behind it.
+func test_generated_section_warp_directions() -> void:
+	print("── Generated free fields (section warp metadata) ──")
+	const GridGen := preload("res://scripts/3d/field/grid_generator.gd")
+	var areas := ["gurhacia", "ozette", "rioh", "makara", "paru", "arca", "dark"]
+	var b_without_wayback := 0
+	for area in areas:
+		for roll in range(3):
+			var gen = GridGen.new()
+			gen.set_seed(roll)
+			var sections: Array = gen.generate_field("normal", area)["sections"]
+			assert_eq(sections.size(), 4, "%s roll %d: field has 4 sections" % [area, roll])
+			# Grid sections a and b: entry names the start room's way back,
+			# exit names the end room's warp edge.
+			for letter in ["a", "b"]:
+				var sec: Dictionary = {}
+				for s in sections:
+					if str(s.get("area", "")) == letter:
+						sec = s
+						break
+				var start: Dictionary = {}
+				var endc: Dictionary = {}
+				for c in sec.get("cells", []):
+					if c.get("is_start", false):
+						start = c
+					if c.get("is_end", false):
+						endc = c
+				assert_eq(str(sec.get("entry_direction", "")), str(start.get("entry_warp_edge", "")),
+					"%s roll %d %s: entry_direction is the start room's way back" % [area, roll, letter])
+				assert_eq(str(sec.get("exit_direction", "")), str(endc.get("warp_edge", "")),
+					"%s roll %d %s: exit_direction is the end room's warp edge" % [area, roll, letter])
+				if letter == "b":
+					var way_back := str(sec.get("entry_direction", ""))
+					if way_back.is_empty():
+						b_without_wayback += 1
+					else:
+						assert_true(not start.get("connections", {}).has(way_back),
+							"%s roll %d b: the way back is a warp door, not a connection" % [area, roll])
+			# Transition room: entered at the south door, exits north.
+			var e_sec: Dictionary = sections[1]
+			var e_cells: Array = e_sec.get("cells", [])
+			var e_cell: Dictionary = e_cells[0] if not e_cells.is_empty() else {}
+			assert_eq(str(e_sec.get("entry_direction", "")), "south",
+				"%s roll %d: transition is entered at its south door" % [area, roll])
+			assert_eq(str(e_sec.get("exit_direction", "")), str(e_cell.get("warp_edge", "")),
+				"%s roll %d: transition exit_direction matches its warp edge" % [area, roll])
+			# Boss section carries neither, matching the static field files —
+			# its way out is the final exit / boss-clear telepipe.
+			assert_true(not sections[3].has("entry_direction"),
+				"%s roll %d: boss section carries no entry_direction" % [area, roll])
+			assert_true(not sections[3].has("exit_direction"),
+				"%s roll %d: boss section carries no exit_direction" % [area, roll])
+	assert_eq(b_without_wayback, 0, "every generated b section names its way back")
+	print("  INFO: %d areas x 3 rolls, all sections classified" % areas.size())
+	print("")
+
+
 ## BFS over `connections`.
 func _connected(by_pos: Dictionary, from_pos: String, to_pos: String) -> bool:
 	var seen := {from_pos: true}
@@ -1085,6 +1148,77 @@ func test_gate_kind_per_door() -> void:
 		VF.GATE_KEY, "legacy field still key-gates what its old fields name")
 	assert_eq(VF.gate_kind_for_door({}, "south", "south", false, []),
 		VF.GATE_ENEMY_DEFEAT, "legacy field gates the entry edge as it always did")
+	print("")
+
+
+## The runtime half of generated-field backtracking: the classifier the
+## area-warp loop consults for unconnected portals (spec /states/field-lifecycle
+## "Area gates are two-way"). Same layer split as test_gate_kind_per_door — the
+## generator test asserts the metadata exists; this pins what the runtime does
+## with it, because the autopilot's free-roam smoke only walks forward.
+func test_area_warp_classification() -> void:
+	print("── Area-warp classification (spec /states/field-lifecycle) ──")
+	const VF := preload("res://scripts/3d/field/valley_field_controller.gd")
+	const GridGen := preload("res://scripts/3d/field/grid_generator.gd")
+	var gen = GridGen.new()
+	gen.set_seed(0)
+	var sections: Array = gen.generate_field("normal", "gurhacia")["sections"]
+	assert_eq(sections.size(), 4, "seeded gurhacia field has 4 sections")
+
+	# Transition room (section 1): south is the way back to a, north goes to b.
+	var e_sec: Dictionary = sections[1]
+	var e_cells: Array = e_sec.get("cells", [])
+	var e_warp: String = str(e_cells[0].get("warp_edge", ""))
+	var e_entry: String = str(e_sec.get("entry_direction", ""))
+	var e_exit: String = str(e_sec.get("exit_direction", ""))
+	assert_eq(VF.area_warp_kind("south", e_entry, e_exit, e_warp, true, 1, 4),
+		VF.WARP_ENTRY, "transition south door warps back to section a")
+	assert_eq(VF.area_warp_kind("north", e_entry, e_exit, e_warp, true, 1, 4),
+		VF.WARP_EXIT, "transition north door warps forward to section b")
+
+	# B section (section 2): the start room's way-back door is a backward warp,
+	# the end room's warp edge goes forward to the boss.
+	var b_sec: Dictionary = sections[2]
+	var b_start: Dictionary = {}
+	var b_end: Dictionary = {}
+	for c in b_sec.get("cells", []):
+		if c.get("is_start", false):
+			b_start = c
+		if c.get("is_end", false):
+			b_end = c
+	var b_entry: String = str(b_sec.get("entry_direction", ""))
+	var b_exit: String = str(b_sec.get("exit_direction", ""))
+	assert_true(not b_entry.is_empty(), "seeded b section has a way back")
+	assert_eq(VF.area_warp_kind(b_entry, b_entry, b_exit, str(b_start.get("warp_edge", "")), true, 2, 4),
+		VF.WARP_ENTRY, "b start's way back warps to the transition room")
+	assert_eq(VF.area_warp_kind(str(b_end.get("warp_edge", "")), b_entry, b_exit,
+			str(b_end.get("warp_edge", "")), false, 2, 4),
+		VF.WARP_EXIT, "b end's warp edge goes forward to the boss section")
+
+	# Boss section (last): its warp edge is the final exit, not a backward warp.
+	assert_eq(VF.area_warp_kind("south", "", "", "south", false, 3, 4),
+		VF.WARP_FINAL_EXIT, "boss warp edge is the final exit")
+
+	# A section (first): the start's off-grid door has nothing to warp back to.
+	var a_sec: Dictionary = sections[0]
+	var a_start: Dictionary = {}
+	for c in a_sec.get("cells", []):
+		if c.get("is_start", false):
+			a_start = c
+			break
+	var a_entry: String = str(a_start.get("entry_warp_edge", ""))
+	if not a_entry.is_empty():
+		assert_eq(VF.area_warp_kind(a_entry, str(a_sec.get("entry_direction", "")),
+				str(a_sec.get("exit_direction", "")), str(a_start.get("warp_edge", "")), true, 0, 4),
+			VF.WARP_NONE, "a start's off-grid door is inert — nothing before section a")
+
+	# Guards: entry_direction only classifies at the start cell, and without
+	# the metadata (the pre-fix generated shape) the way back classifies as
+	# nothing — the regression this test exists to pin.
+	assert_eq(VF.area_warp_kind("south", "south", "north", "", false, 2, 4),
+		VF.WARP_NONE, "entry_direction does not classify away from the start cell")
+	assert_eq(VF.area_warp_kind(b_entry, "", "", "", true, 2, 4),
+		VF.WARP_NONE, "no entry metadata = no backward warp (the regression)")
 	print("")
 
 

--- a/spec/src/pages/states/field-lifecycle.astro
+++ b/spec/src/pages/states/field-lifecycle.astro
@@ -200,6 +200,26 @@ const lifecycle = `flowchart TD
   <p>Gate <em>direction</em> is resolved through <code>StageRotation</code> so a
   rotated cell still opens the correct physical exit.</p>
 
+  <h3>Area gates are two-way</h3>
+  <p>Every section that is entered by warp — the transition room between the two
+  grids, and the second grid itself — <strong>MUST</strong> carry section-level
+  <code>entry_direction</code> / <code>exit_direction</code> metadata:
+  <code>entry_direction</code> names the portal on the section's start cell that
+  the player arrived at (the way back to the previous section), and
+  <code>exit_direction</code> names the end cell's forward warp edge. The runtime
+  <strong>MUST</strong> build an area gate and trigger for both, so walking back
+  through the arrival door returns the player to the previous section's end cell,
+  and a forward warp <strong>MUST</strong> land the player on the target
+  section's <code>entry_direction</code> portal. The first section (entered from
+  the city, not by warp) and the boss arena (left by its final exit or the
+  boss-clear telepipe) carry neither. Generated fields <strong>MUST</strong> emit
+  this metadata exactly as static field files do — a generated section without it
+  draws its way back as inert geometry: a door with no warp and no trigger
+  behind it. <code>entry_direction</code> classifies a portal as a backward warp
+  only on the section's <strong>start cell</strong>; elsewhere the same compass
+  value can collide with a <code>warp_edge</code> and mis-classify the
+  door.</p>
+
   <h2>Fences &amp; switches</h2>
   <p>Fences are distinct from gates. A fence is toggled by its own dedicated
   <strong>step-switch</strong>: stepping on the switch (<code>flip_switch</code>)


### PR DESCRIPTION
## Why

Backtracking regressed during the "make generation mirror the game" arc and this is the mechanism:

- Static field files have carried section-level `entry_direction` / `exit_direction` since backtracking shipped (#202). The runtime's area-warp loop classifies unconnected portals with them: `is_entry` (start cell only) builds the **backward** warp to the previous section, and the forward exit computes its arrival edge from the *target* section's `entry_direction`.
- When free fields switched from static JSON to generator output (6f6ef060), the generated sections dropped those keys — so `is_entry` could never fire. The transition room's south door and the b-section start's way-back door kept their portal geometry but got **no AreaWarp and no trigger**: doors you can walk into forever. Forward progress still worked via the end-cell `warp_edge`, which is exactly why every smoke test stayed green.
- 88985ce0 later preserved the way-back door through the no-spare-doors retile and exported `entry_warp_edge` — but a repo-wide grep shows nothing in the runtime ever consumed it. The data side was fixed; the wiring wasn't.

## What

- **`grid_generator.gd`** — `generate_field()` now emits `entry_direction` / `exit_direction` per section via a new `_section_warp_dirs()` helper (start cell's `entry_warp_edge`, end cell's `warp_edge`). The transition cell learns its south arrival door (`entry_warp_edge = "south"`). The boss section carries neither, matching the static field files — its way out is the final exit / boss-clear telepipe.
- **`valley_field_controller.gd`** — the inline `is_entry`/`is_exit` classification moves into a static `area_warp_kind()` classifier (same pattern as `gate_kind_for_door`, added for the same reason: the autopilot can't reach this layer). Behavior for static fields is identical; generated sections now classify their backward doors as `WARP_ENTRY`.
- Side effect of the metadata: warp-ins now land on the target section's real arrival portal (`spawn_edge` resolves from `entry_direction`) instead of the "fallback north portal" guess.
- **Spec** — `/states/field-lifecycle` gains **"Area gates are two-way"** as the normative contract (spec-first per CLAUDE.md; reconciles with the existing area-gate definition).

## Verification (both layers)

- `test_generated_section_warp_directions` — data layer: 7 areas × 3 seeded rolls assert every section's directions match its cells, the b way-back is a warp door (not a connection), the transition is entered south, and the boss section carries neither key.
- `test_area_warp_classification` — runtime layer: the classifier's decision for the transition's two doors, the b-start way back, the b-end forward warp, the boss final exit, the inert first-section door, the start-cell-only guard, and the pre-fix shape (no metadata → no backward warp).
- Full suite: **3267 passed, 0 failed** (main: 3047 — the new tests add 220 assertions).
- Autopilot free-roam smoke (gurhacia, fresh save, local pack): cleared A → transition → B (key detour + gates) → boss → **`[sanity] DONE ok`** — the changed warp-in spawn edges are exercised at both section transitions.

One incidental find while verifying: a doc comment in `grid_generator.gd` mentioning `AreaWarp` by class name tripped the autoload pack-only preload guard (the guard's text scan treats any whole-word class_name reference as a load-time dependency, and `grid_generator.gd` is autoload-reachable via `warp_pad.gd`). Reworded to avoid the identifier — worth knowing that guard reacts to comments, not just code.

Out of scope: `generate_tower_field()` sections have no runtime caller today (tests only) and still carry no direction metadata — noted for whenever towers go live.