### PR TITLE
Drop the stale Copilot-review guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,15 @@ like authorization to fast-forward straight onto `main`. Don't.
 `main` is protected by the **"Merge to Main"** ruleset — it requires:
 
 - A pull request (so the diff shows up for review)
-- A Copilot code review (auto-runs on PR open / push to PR)
 - Plus the standard CI: `verify-assets`, `check-asset-refs`,
   `version-check`, the Godot test runner
 
 Admin-tier accounts have `bypass_mode: pull_request` — meaning they
-can self-merge once the rule's met, but **the PR + Copilot review step
-is not skippable**. Do not look for a way around it; it is load-bearing.
+can self-merge once the rule's met, but **the PR step is not
+skippable**. Do not look for a way around it; it is load-bearing.
+Review is human (kion reads the PR). Copilot code reviews were
+cancelled on purpose — there is no automated reviewer, so don't wait
+for one, request one, or try to re-enable one.
 
 Merging the PR also kicks off **release CD** (APK signing, Arweave
 publish if assets changed, etc.). Pushing to `main` directly skips
@@ -52,9 +54,9 @@ Workflow when the user asks to land changes:
 2. Commit and push the branch.
 3. `gh pr create` — write a real summary that explains *why*, not just
    *what*. The summary is the thing the human reviewer reads first.
-4. Wait for Copilot's automatic review and address its comments.
+4. Let CI finish and address anything it flags.
 5. Either the user merges (typical), or — if they explicitly authorize
-   "merge it for me" *after* Copilot has signed off — `gh pr merge`.
+   "merge it for me" — `gh pr merge`.
    Even then, default to merge-commit (or rebase if the user prefers
    linear history); never force-push to merge.
 

--- a/docs/valley-field-split.md
+++ b/docs/valley-field-split.md
@@ -11,8 +11,8 @@ pre-beta refactor milestone (issue #215).
    `test_runner.tscn` (unit suite) + `run_regression_matrix.sh` (full spine).
    Red → fix before proceeding.
 3. **PR** — bump version (3 sources), push, `gh pr create`.
-4. **Review** — wait for Copilot + CI green; address comments.
-5. **Merge** — after Copilot signs off (user-authorized for this effort).
+4. **Review** — wait for CI green; kion reviews; address comments.
+5. **Merge** — after kion signs off (user-authorized for this effort).
 6. **Next** — branch the next increment off the freshly-merged `main`.
 
 ## Increments
@@ -71,4 +71,4 @@ Harness/infra that landed alongside: #257 (dbus-run-session wrapper),
   being merged — addressing review comments means re-running `npm run sanity-check`.
 - Version bump is **three sources** (VERSION, project.godot `config/version`,
   export_presets.cfg `version/name`) and only at PR-open.
-- `main` is protected — PR + Copilot review required; merging triggers release CD.
+- `main` is protected — PR required; merging triggers release CD.


### PR DESCRIPTION
## Why

Copilot code reviews were cancelled a while back, but the repo's agent guidance never caught up. CLAUDE.md still describes Copilot as an active, load-bearing part of the merge gate:

- listed as a requirement of the "Merge to Main" ruleset ("auto-runs on PR open / push to PR")
- "the PR + Copilot review step is not skippable … do not look for a way around it"
- workflow step 4: "Wait for Copilot's automatic review and address its comments"
- merge authorization only "*after* Copilot has signed off"

Since CLAUDE.md is the first (and usually only) conventions file an LLM reads here, every agent dutifully waits on a reviewer that never arrives — most recently ~12 minutes of polling for a review on #637 before handing the PR back.

## What

- CLAUDE.md: the merge gate is now stated as **PR + CI, review is human (kion)**, with an explicit note that the Copilot pass was cancelled on purpose — so nothing waits for, requests, or re-enables an automated reviewer.
- docs/valley-field-split.md: the three restatements ("wait for Copilot + CI green", "after Copilot signs off", "PR + Copilot review required") updated to match.

Docs-only change — no Godot autopilot needed per CLAUDE.md's own rule for spec/docs PRs.